### PR TITLE
Fix Drag and Drop test

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 invoke==0.15.0
-selenium==3.6.0
+selenium==3.141.0
 pytest==3.5.0
 flake8==2.4.0
 flake8-quotes==0.3.0

--- a/tests/test_project_files.py
+++ b/tests/test_project_files.py
@@ -316,8 +316,8 @@ class TestFilesPage:
 
             # Wait for 5 seconds for Copying message to show
             WebDriverWait(driver, 5).until(EC.visibility_of_element_located((By.CLASS_NAME, 'text-muted')))
-            # Wait a maximum of 20 seconds for Copying message to resolve
-            WebDriverWait(driver, 20).until(EC.invisibility_of_element_located((By.CLASS_NAME, 'text-muted')))
+            # Wait a maximum of 30 seconds for Copying message to resolve
+            WebDriverWait(driver, 30).until(EC.invisibility_of_element_located((By.CLASS_NAME, 'text-muted')))
 
             files_page.goto()
             origin_file = find_row_by_name(driver, provider, new_file)

--- a/tests/test_project_files.py
+++ b/tests/test_project_files.py
@@ -1,5 +1,8 @@
 import pytest
 import time
+
+from selenium.common.exceptions import TimeoutException
+
 import markers
 import settings
 
@@ -316,8 +319,13 @@ class TestFilesPage:
 
             # Wait for 5 seconds for Copying message to show
             WebDriverWait(driver, 5).until(EC.visibility_of_element_located((By.CLASS_NAME, 'text-muted')))
-            # Wait a maximum of 30 seconds for Copying message to resolve
-            WebDriverWait(driver, 30).until(EC.invisibility_of_element_located((By.CLASS_NAME, 'text-muted')))
+
+            try:
+                # Wait a maximum of 30 seconds for Copying message to resolve
+                WebDriverWait(driver, 30).until(EC.invisibility_of_element_located((By.CLASS_NAME, 'text-muted')))
+            except TimeoutException:
+                # Reload the page and continue test
+                pass
 
             files_page.goto()
             origin_file = find_row_by_name(driver, provider, new_file)


### PR DESCRIPTION

<!-- Before you submit your Pull Request, please confirm that:

     - Any test that will create public data either has the `QAtest` tag or the `dont_run_on_production` marker
     - `core_functionality` is marked as such
     - Your tests will be able to run on *all* servers (all stagings, test)
 -->


## Purpose
Our drag and drop selenium test is failing due to a staging-specific issue. On test.osf.io, the files widget has trouble with updating the UI when a copy or a move has completed. The end user sees a banner saying "an email will be sent after the action has completed". This is an indicator that the status bar will read "copying \<filename>...." indefinitely. 

To fix this, we will wait an additional 10 seconds to see the message and reload the page. After reloading, we can continue
the test and assert the newly created file is present.


## Summary of Changes
- Wait 30 seconds for copy message to resolve
- Add try/except block to reload page if the UI never updates
- - Once the "copy is pending" banner shows on the front end, the UI will no longer update until the page is refreshed

## Reviewer's Actions
`git fetch <remote> pull/125/head:fix/drag-n-drop`

Run this test using
`pytest tests/test_project_files.py::TestFilesPage::test_dragon_drop -v -s`

## Testing Changes Moving Forward
N/A


## Ticket

https://openscience.atlassian.net/browse/ENG-2488
