### PR TITLE
Set midnight test runs to series

### DIFF
--- a/.github/workflows/production_smoke_tests.yml
+++ b/.github/workflows/production_smoke_tests.yml
@@ -52,6 +52,7 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       max-parallel: 1  # run in series
       matrix:
         browser: [chrome, firefox, edge]

--- a/.github/workflows/selenium_staging_tests.yml
+++ b/.github/workflows/selenium_staging_tests.yml
@@ -2,8 +2,8 @@ name: Selenium Staging Tests
 
 on:
   schedule:
-    # 5am UTC = Midnight EST
-    - cron: '0 5 * * *'
+    # 4am UTC = 11pm EST
+    - cron: '0 4 * * *'
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/.github/workflows/selenium_staging_tests.yml
+++ b/.github/workflows/selenium_staging_tests.yml
@@ -59,6 +59,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
+      max-parallel: 1  # run in series
       matrix:
         browser: [chrome, firefox, edge]
     steps:

--- a/.github/workflows/selenium_staging_tests.yml
+++ b/.github/workflows/selenium_staging_tests.yml
@@ -58,6 +58,7 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         browser: [chrome, firefox, edge]
     steps:


### PR DESCRIPTION
<!-- Before you submit your Pull Request, please confirm that:

     - Any test that will create public data either has the `QAtest` tag or the `dont_run_on_production` marker
     - `core_functionality` is marked as such
     - Your tests will be able to run on *all* servers (all stagings, test)
 -->


## Purpose
Schedule our midnight tests to run in series. This way, we can increase reliability of tests and gather information the next day. Also, the `fail-fast` variable kills our matrix-job once a browser fails 3 times. By setting this to `false` all other browsers will continue to test after a failure is reached. 

Lastly, the optimum hour for testing is midnight EST. Since our test will run longer, we will start the test earlier to take advantage of some time before and after midnight EST. 


## Summary of Changes
- Set midnight staging tests to run in series
- Set `fail-fast` variable to false
- Schedule staging tests to start  1 hour earlier


## Reviewer's Actions
`git fetch <remote> pull/129/head:feature/scheduled-tests-series`

Run this test using
- Scheduled test results in the Github Actions tab

## Testing Changes Moving Forward
Ideally we would like to run all of our tests to run in parallel. We can make any necessary changes when we find a workaround for the flaky test environments. 

## Ticket
N/A
