### PR TITLE
[CR] Unbreak Github Actions build

### DIFF
--- a/.github/workflows/production_smoke_tests.yml
+++ b/.github/workflows/production_smoke_tests.yml
@@ -22,7 +22,9 @@ env:
 jobs:
 
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
+    env:
+      GHA_DISTRO: ubuntu-20.04
     if: "!contains(github.event.head_commit.message, 'skip ci')"
     strategy:
       matrix:
@@ -39,7 +41,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ${{ env.pythonLocation }}
-          key: ${{ env.pythonLocation }}-${{ hashFiles('requirements.txt') }}
+          key: ${{ env.GHA_DISTRO }}-${{ env.pythonLocation }}-${{ hashFiles('requirements.txt') }}
       - name: install dependencies
         if: steps.pip-cache-step.outputs.cache-hit != 'true'
         run: |
@@ -50,7 +52,9 @@ jobs:
   smoke_test:
     name: Prod smoke tests (${{ matrix.browser }})
     needs: build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
+    env:
+      GHA_DISTRO: ubuntu-20.04
     strategy:
       fail-fast: false
       max-parallel: 1  # run in series
@@ -66,7 +70,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ${{ env.pythonLocation }}
-          key: ${{ env.pythonLocation }}-${{ hashFiles('requirements.txt') }}
+          key: ${{ env.GHA_DISTRO }}-${{ env.pythonLocation }}-${{ hashFiles('requirements.txt') }}
       - name: run smoke tests
         env:
           PREFERRED_NODE: ra4bf

--- a/.github/workflows/selenium_staging_tests.yml
+++ b/.github/workflows/selenium_staging_tests.yml
@@ -28,7 +28,9 @@ env:
 jobs:
 
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
+    env:
+      GHA_DISTRO: ubuntu-20.04
     if: "!contains(github.event.head_commit.message, 'skip ci')"
     strategy:
       matrix:
@@ -45,7 +47,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ${{ env.pythonLocation }}
-          key: ${{ env.pythonLocation }}-${{ hashFiles('requirements.txt') }}
+          key: ${{ env.GHA_DISTRO }}-${{ env.pythonLocation }}-${{ hashFiles('requirements.txt') }}
       - name: install dependencies
         if: steps.pip-cache-step.outputs.cache-hit != 'true'
         run: |
@@ -56,7 +58,9 @@ jobs:
   staging_test:
     name: Staging tests (${{ matrix.browser }})
     needs: build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
+    env:
+      GHA_DISTRO: ubuntu-20.04
     strategy:
       fail-fast: false
       max-parallel: 1  # run in series
@@ -72,7 +76,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ${{ env.pythonLocation }}
-          key: ${{ env.pythonLocation }}-${{ hashFiles('requirements.txt') }}
+          key: ${{ env.GHA_DISTRO }}-${{ env.pythonLocation }}-${{ hashFiles('requirements.txt') }}
       - name: run staging tests, part one
         env:
           TEST_BUILD: ${{ matrix.browser }}


### PR DESCRIPTION
## Purpose

We were using `runs-on: ubuntu-latest` for our jobs.  `ubuntu-latest` recently got repointed from `ubuntu-18.04` to `ubuntu-20.04`.  Our cached python build environment was failing, b/c some of the non-python libraries that we built against had changed their soname. Our cache key wasn't accounting for the change in the distro.

## Summary of Changes

* Switch from `runs-on: ubuntu-latest` to `runs-on: ubuntu-20.04`.  Let's go ahead and pin it now, should last us awhile.
* Add an env key with the distro id (`ubuntu-20.04`) and prepend it to the built deps cache key.  If at some point in the future we do a `s/ubuntu-20.04/ubuntu-22.04/`, this should ensure that our deps are rebuilt.
* It would be nice if we could set the dist id in one place, but I couldn't figure out how to do that in a way where both `runs-on:` and `key:` could access it.

## Reviewer's Actions

No local reviewing needed, this just affects GHA.

## Testing Changes Moving Forward

No effect.

## Ticket

No ticket.

