### PR TITLE
Fixes for test_landing.py and for captcha checkbox on sign up form in components/generic.py

### DIFF
--- a/components/generic.py
+++ b/components/generic.py
@@ -16,7 +16,8 @@ class SignUpForm(BaseElement):
 
     def click_recaptcha(self):
         self.driver.switch_to.frame(self.driver.find_element_by_tag_name('iframe'))
-        Locator(By.CSS_SELECTOR, '.recaptcha-checkbox-checkmark').get_element(self.driver, 'capcha').click()
+        #only click the captcha checkbox if it isn't already checked
+        if Locator(By.ID, 'recaptcha-anchor').get_element(self.driver, 'recaptcha-anchor').get_attribute('aria-checked') == 'false':
+            Locator(By.CSS_SELECTOR, '.recaptcha-checkbox-border').get_element(self.driver, 'capcha').click()
         self.driver.switch_to.default_content()
-        #TODO: Replace with an expected condition that checks if aria-checked="true"
         sleep(2)

--- a/tests/test_landing.py
+++ b/tests/test_landing.py
@@ -15,6 +15,8 @@ class TestLandingPage(CreateUserMixin):
 
     @pytest.fixture()
     def page(self, landing_page):
+        #Need to actually click the Sign Up button on the navbar to get to the sign up form
+        landing_page.navbar.sign_up_button.click()
         return landing_page
 
 


### PR DESCRIPTION
<!-- Before you submit your Pull Request, please confirm that:

     - Any test that will create public data either has the `QAtest` tag or the `dont_run_on_production` marker
     - `core_functionality` is marked as such
     - Your tests will be able to run on *all* servers (all stagings, test)
 -->


## Purpose
To fix the failure of test_landing.py in the testing environments (Stage 1, Stage 2, and Stage 3 - test is skipped in Test and Production environments)


## Summary of Changes
The test was failing in the test_create_user function in components/generic.py because the test was expecting to be on the Sign Up New User OSF page.  So I added a step in tests/test_landing.py to click the Sign Up button in the main navigation bar to first navigate to the Sign Up Form page.  After rerunning with this fix I encountered another error where the captcha checkbox on the sign up form was not being recognized.  I then added a fix for this issue in components/generic.py to click the correct captcha checkbox element if the checkbox isn't already checked.


## Reviewer's Actions
`git fetch <remote> pull/<PR_number>/head:test_fixes`

Run this test using
`tests/test_landing.py -s -v`

## Testing Changes Moving Forward
N/A


## Ticket
ENG-2508:  SEL: Landing: Create User test
https://openscience.atlassian.net/browse/ENG-2508
