### PR TITLE
Fix click of captcha to click correct element and only when captcha hasn't already been checked.

### DIFF
--- a/components/generic.py
+++ b/components/generic.py
@@ -16,7 +16,8 @@ class SignUpForm(BaseElement):
 
     def click_recaptcha(self):
         self.driver.switch_to.frame(self.driver.find_element_by_tag_name('iframe'))
-        Locator(By.CSS_SELECTOR, '.recaptcha-checkbox-checkmark').get_element(self.driver, 'capcha').click()
+        #only click the captcha checkbox if it isn't already checked
+        if Locator(By.ID, 'recaptcha-anchor').get_element(self.driver, 'recaptcha-anchor').get_attribute('aria-checked') == 'false':
+            Locator(By.CSS_SELECTOR, '.recaptcha-checkbox-border').get_element(self.driver, 'capcha').click()
         self.driver.switch_to.default_content()
-        #TODO: Replace with an expected condition that checks if aria-checked="true"
         sleep(2)


### PR DESCRIPTION
<!-- Before you submit your Pull Request, please confirm that:

     - Any test that will create public data either has the `QAtest` tag or the `dont_run_on_production` marker
     - `core_functionality` is marked as such
     - Your tests will be able to run on *all* servers (all stagings, test)
 -->

## Purpose
To fix the clicking of the captcha checkbox object on the create new user sign up page.  This was causing a failure of the test_register.py test.


## Summary of Changes
First check to see if the captcha has already been checked (attribute "aria-checked" is either "true" or "false"). If the captcha has not been checked (aria-checked = 'false'), then click the correct layer ("checkbox-border") of the captcha object to check the checkbox.


## Reviewer's Actions
`git fetch <remote> pull/<PR_number>/head:testFix/captcha`

Run this test using
`tests/test_register.py -s -v`

## Testing Changes Moving Forward
N/A


## Ticket
ENG-2512: SEL: Register: Create User
https://openscience.atlassian.net/browse/ENG-2512
