### PR TITLE
Remove create new user steps and add verification of being on landing page.

### DIFF
--- a/tests/test_landing.py
+++ b/tests/test_landing.py
@@ -1,7 +1,6 @@
 import pytest
 import markers
 
-from tests.generic import CreateUserMixin
 from pages.landing import LandingPage, RegisteredReportsLandingPage
 
 @pytest.fixture()
@@ -11,11 +10,17 @@ def landing_page(driver):
     return landing_page
 
 
-class TestLandingPage(CreateUserMixin):
+class TestHomeLandingPage:
 
     @pytest.fixture()
     def page(self, landing_page):
         return landing_page
+
+    @markers.core_functionality
+    def test_landing_page(self, driver):
+        LandingPage(driver, verify=True)
+
+    #TO DO: Come back later and add other tests for elements on OSF Home page - see ENG-826
 
 
 class TestRegisteredReportsLandingPage:


### PR DESCRIPTION
<!-- Before you submit your Pull Request, please confirm that:

     - Any test that will create public data either has the `QAtest` tag or the `dont_run_on_production` marker
     - `core_functionality` is marked as such
     - Your tests will be able to run on *all* servers (all stagings, test)
 -->


## Purpose
To fix the failing test: test_landing.py. 


## Summary of Changes
The landing test was originally failing due to the inclusion of 'CreateUserMixin' in the TestLandingPage class. This mixin included steps to create a new user from the OSF Sign Up page.  Upon further investigation it was revealed that these test steps are actually redundant, since test_register.py already performs this test.  So it was decided to remove CreateUserMixin from the test.  After this removal, the TestLandingPage class was not actually performing any verification steps, so a new step was added to verify that the OSF Home Landing page is actually loaded.  An added benefit of removing CreateUserMixin from test_landing.py is that this test can now be run in all environments.  Test markers (dont_run_on_prod and skipif(settings.TEST... ) existed in the mixin that caused test_landing.py to be skipped in the Test and Prod environments.  Once this PR has been merged, the test should automatically be run in the nightly test runs.

## Reviewer's Actions
`git fetch <remote> pull/<PR_number>/head:testFix/remRegLand`

Run this test using
`tests/test_landing.py -s -v`

## Testing Changes Moving Forward
Ticket ENG-826 is open for making additional changes to test_landing.py.  More test steps need to be added to test all of the elements on the OSF Home page.


## Ticket
ENG-2508: SEL: Landing: Create User test
https://openscience.atlassian.net/browse/ENG-2508
