### PR TITLE
Fix middle name test

### DIFF
--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -4,6 +4,9 @@ import settings
 
 from api import osf_api
 from pages import user
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support.ui import WebDriverWait
+from selenium.webdriver.support import expected_conditions as EC
 
 @pytest.fixture()
 def quickfile(session):
@@ -85,7 +88,7 @@ class TestUserSettings:
         settings_page.goto()
 
     @markers.core_functionality
-    def test_change_middle_name(self, profile_settings_page, fake):
+    def test_change_middle_name(self, driver, profile_settings_page, fake):
         new_name = fake.name()
         assert profile_settings_page.middle_name_input.get_attribute('value') != new_name
         profile_settings_page.middle_name_input.clear()
@@ -93,4 +96,4 @@ class TestUserSettings:
         profile_settings_page.save_button.click()
         profile_settings_page.update_success.here_then_gone()
         profile_settings_page.reload()
-        assert profile_settings_page.middle_name_input.get_attribute('value') == new_name
+        assert WebDriverWait(driver, 10).until(EC.text_to_be_present_in_element_value((By.CSS_SELECTOR, '#names > div > form > div:nth-child(5) > input'), new_name))


### PR DESCRIPTION
<!-- Before you submit your Pull Request, please confirm that:

     - Any test that will create public data either has the `QAtest` tag or the `dont_run_on_production` marker
     - `core_functionality` is marked as such
     - Your tests will be able to run on *all* servers (all stagings, test)
 -->


## Purpose
The test `test_change_middle_name` is failing. Sometimes the page loads before the content of the text name fields. They eventually load after about a second. 

The problem: Selenium is checking for the middle name immediately after the page is verified to load. 
The solution: Wait until the text loads to perform our assertion. 


## Summary of Changes
- Use implicit wait for middle name to load.


## Reviewer's Actions
`git fetch <remote> pull/136/head:middle_name`

Run this test using
`tests/test_user.py::TestUserSettings::test_change_middle_name -s -v`

## Testing Changes Moving Forward
In the future I'd like to reduce redundancy. If possible, I'd like to use `WebDriverWait` with our current locators. As opposed to re-declaring them using the `By` tuple. 


## Ticket
SEL: Project: Change Middle Name
https://openscience.atlassian.net/browse/ENG-2699
