### PR TITLE
Updates to Locators for newCAS login page changes

### DIFF
--- a/pages/login.py
+++ b/pages/login.py
@@ -9,7 +9,7 @@ from pages.base import BasePage, OSFBasePage
 class LoginPage(BasePage):
     url = settings.OSF_HOME + '/login'
 
-    identity = Locator(By.CLASS_NAME, 'login.mdc-typography', settings.LONG_TIMEOUT)
+    identity = Locator(By.ID, 'loginForm', settings.LONG_TIMEOUT)
     username_input = Locator(By.ID, 'username')
     password_input = Locator(By.ID, 'password')
     submit_button = Locator(By.NAME, 'submit')

--- a/pages/login.py
+++ b/pages/login.py
@@ -9,13 +9,13 @@ from pages.base import BasePage, OSFBasePage
 class LoginPage(BasePage):
     url = settings.OSF_HOME + '/login'
 
-    identity = Locator(By.CSS_SELECTOR, '#cas', settings.LONG_TIMEOUT)
+    identity = Locator(By.CLASS_NAME, 'login.mdc-typography', settings.LONG_TIMEOUT)
     username_input = Locator(By.ID, 'username')
     password_input = Locator(By.ID, 'password')
     submit_button = Locator(By.NAME, 'submit')
     remember_me_checkbox = Locator(By.ID, 'rememberMe')
-    institutional_login_button = Locator(By.ID, 'alt-login-inst')
-    orcid_login_button = Locator(By.ID, 'alt-login-orcid')
+    institutional_login_button = Locator(By.ID, 'instnLogin')
+    orcid_login_button = Locator(By.ID, 'orcidlogin')
 
     if 'localhost:5000' in settings.OSF_HOME:
         submit_button = Locator(By.ID, 'submit')
@@ -37,8 +37,8 @@ class LoginPage(BasePage):
 class InstitutionalLoginPage(BasePage):
     url = settings.OSF_HOME + '/login?campaign=institution'
 
-    identity = Locator(By.CSS_SELECTOR, '#institution-form-select')
-    dropdown_options = GroupLocator(By.CSS_SELECTOR, '#institution-form-select option')
+    identity = Locator(By.CSS_SELECTOR, '#institutionSelect')
+    dropdown_options = GroupLocator(By.CSS_SELECTOR, '#institutionSelect option')
 
 
 def login(driver, user=settings.USER_ONE, password=settings.USER_ONE_PASSWORD):


### PR DESCRIPTION
<!-- Before you submit your Pull Request, please confirm that:

     - Any test that will create public data either has the `QAtest` tag or the `dont_run_on_production` marker
     - `core_functionality` is marked as such
     - Your tests will be able to run on *all* servers (all stagings, test)
 -->


## Purpose
To apply fixes for some of the element locators on the OSF login page to accommodate changes for the newCAS system.


## Summary of Changes
Updated Locators for a few of the elements on the OSF Login page (pages/login.py) including the page identifier and the locators for the Institution login button and the ORCID login button.  Also updated locators for elements on the  Institution Login page.


## Reviewer's Actions
`git fetch <remote> pull/<PR_number>/head:testFix/newCASlogin`

Run this test using
`tests/test_login.py -s -v`

## Testing Changes Moving Forward
N/A


## Ticket
ENG-2718: SEL: Update login tests for newCAS
https://openscience.atlassian.net/browse/ENG-2718
