### PR TITLE
Fixes and cleanup of Navbar test covering 5 tickets

### DIFF
--- a/components/navbars.py
+++ b/components/navbars.py
@@ -59,9 +59,27 @@ class EmberNavbar(HomeNavbar):
     donate_link = Locator(By.XPATH, '//a[text()="Donate"]')
 
 
-class PreprintsNavbar(AbstractLegacyEmberNavbar):
+class PreprintsNavbar(EmberNavbar):
     title = Locator(By.CSS_SELECTOR, '.navbar-title')
+
+    home_link = Locator(By.CSS_SELECTOR, 'ul.dropdown-menu.service-dropdown > li:nth-child(1) > a')
+    preprints_link = Locator(By.CSS_SELECTOR, 'ul.dropdown-menu.service-dropdown > li:nth-child(2) > a')
+    registries_link = Locator(By.CSS_SELECTOR, 'ul.dropdown-menu.service-dropdown > li:nth-child(3) > a')
+    meetings_link = Locator(By.CSS_SELECTOR, 'ul.dropdown-menu.service-dropdown > li:nth-child(4) > a')
+    institutions_link = Locator(By.CSS_SELECTOR, 'ul.dropdown-menu.service-dropdown > li:nth-child(5) > a')
+
+    my_preprints_link = Locator(By.CSS_SELECTOR, '#secondary-navigation > ul > li:nth-last-child(6) > a')
     add_a_preprint_link = Locator(By.CSS_SELECTOR, '#secondary-navigation > ul > li:nth-last-child(5) > a')
+    search_link = Locator(By.CSS_SELECTOR, '#secondary-navigation > ul > li:nth-last-child(4) > a')
+    support_link = Locator(By.CSS_SELECTOR, '#secondary-navigation > ul > li:nth-last-child(3) > a')
+    donate_link = Locator(By.CSS_SELECTOR, '#secondary-navigation > ul > li.navbar-donate-button')
+    sign_up_button = Locator(By.CSS_SELECTOR, 'a.btn-success:nth-child(1)')
+    sign_in_button = Locator(By.CSS_SELECTOR, '.btn-top-login')
+
+    user_dropdown_profile = Locator(By.CSS_SELECTOR, 'ul.dropdown-menu-right > li:nth-child(1)')
+    user_dropdown_support = Locator(By.CSS_SELECTOR, 'ul.dropdown-menu-right > li:nth-child(2)')
+    user_dropdown_settings = Locator(By.CSS_SELECTOR, 'ul.dropdown-menu-right > li:nth-child(3)')
+    logout_link = Locator(By.CSS_SELECTOR, '#secondary-navigation > ul > li.dropdown.open > ul > li:nth-child(4) > a')
 
     def verify(self):
         return self.current_service.text == 'PREPRINTS'

--- a/components/navbars.py
+++ b/components/navbars.py
@@ -103,6 +103,8 @@ class RegistriesNavbar(EmberNavbar):
     user_dropdown_support = Locator(By.CSS_SELECTOR, 'ul.dropdown-menu-right > li:nth-child(2) > a')
     user_dropdown_settings = Locator(By.CSS_SELECTOR, 'a[data-analytics-name="Settings"]')
 
+    add_new_link = Locator(By.CSS_SELECTOR, 'a[data-test-add-new-button')
+
     def verify(self):
         return self.current_service.text == 'REGISTRIES'
 

--- a/components/navbars.py
+++ b/components/navbars.py
@@ -11,6 +11,7 @@ class Navbar(BaseElement):
     preprints_link = Locator(By.CSS_SELECTOR, 'a[data-analytics-name="PREPRINTS"]')
     registries_link = Locator(By.CSS_SELECTOR, 'a[data-analytics-name="REGISTRIES"]')
     meetings_link = Locator(By.CSS_SELECTOR, 'a[data-analytics-name="MEETINGS"]')
+    institutions_link = Locator(By.CSS_SELECTOR, 'a[data-analytics-name="INSTITUTIONS"]')
     search_link = Locator(By.XPATH, '//a[text()="Search"]')
     support_link = Locator(By.XPATH, '//a[text()="Support"]')
     donate_link = Locator(By.ID, 'navbar-donate')
@@ -78,6 +79,7 @@ class RegistriesNavbar(EmberNavbar):
     preprints_link = Locator(By.CSS_SELECTOR, 'ul._ServiceDropdownMenu_nar5mu > li:nth-child(2) > a')
     registries_link = Locator(By.CSS_SELECTOR, 'ul._ServiceDropdownMenu_nar5mu > li:nth-child(3) > a')
     meetings_link = Locator(By.CSS_SELECTOR, 'ul._ServiceDropdownMenu_nar5mu > li:nth-child(4) > a')
+    institutions_link = Locator(By.CSS_SELECTOR, 'ul._ServiceDropdownMenu_nar5mu > li:nth-child(5) > a')
     sign_up_button = Locator(By.CSS_SELECTOR, 'a[data-test-join')
 
     def verify(self):
@@ -88,3 +90,10 @@ class MeetingsNavbar(EmberNavbar):
 
     def verify(self):
         return self.current_service.text == 'MEETINGS'
+
+
+class InstitutionsNavbar(EmberNavbar):
+
+    def verify(self):
+        return self.current_service.text == 'INSTITUTIONS'
+

--- a/components/navbars.py
+++ b/components/navbars.py
@@ -12,9 +12,12 @@ class Navbar(BaseElement):
     registries_link = Locator(By.CSS_SELECTOR, 'a[data-analytics-name="REGISTRIES"]')
     meetings_link = Locator(By.CSS_SELECTOR, 'a[data-analytics-name="MEETINGS"]')
     institutions_link = Locator(By.CSS_SELECTOR, 'a[data-analytics-name="INSTITUTIONS"]')
-    search_link = Locator(By.XPATH, '//a[text()="Search"]')
-    support_link = Locator(By.XPATH, '//a[text()="Support"]')
+    
+    search_link = Locator(By.CSS_SELECTOR, '[data-test-nav-search-link]')
+    support_link = Locator(By.CSS_SELECTOR, '[data-test-nav-support-link]')
     donate_link = Locator(By.ID, 'navbar-donate')
+    sign_up_button = Locator(By.CSS_SELECTOR, '[data-test-ad-sign-up-button]')
+    sign_in_button = Locator(By.CSS_SELECTOR, '[data-test-sign-in-button]')
 
     # Preprints Locators
     user_dropdown = Locator(By.CSS_SELECTOR, 'ul.navbar-nav > li:nth-child(6) > a')
@@ -22,8 +25,6 @@ class Navbar(BaseElement):
     user_dropdown_support = Locator(By.CSS_SELECTOR, 'ul.dropdown-menu-right > li:nth-child(2)')
     user_dropdown_settings = Locator(By.CSS_SELECTOR, 'ul.dropdown-menu-right > li:nth-child(3)')
     logout_link = Locator(By.CSS_SELECTOR, '#secondary-navigation > ul > li.dropdown.open > ul > li:nth-child(4) > a')
-    sign_up_button = Locator(By.XPATH, '//a[text()="Sign Up"]')
-    sign_in_button = Locator(By.XPATH, '//a[text()="Sign In"]')
     current_service = Locator(By.CSS_SELECTOR, '#navbarScope .current-service > strong')
 
     def verify(self):
@@ -42,7 +43,7 @@ class AbstractLegacyEmberNavbar(Navbar):
 
 
 class HomeNavbar(Navbar):
-    my_projects_link = Locator(By.XPATH, '//a[text()="My Projects"]')
+    my_projects_link = Locator(By.CSS_SELECTOR, '[data-test-nav-my-projects-link]')
     my_quick_files_link = Locator(By.CSS_SELECTOR, '[data-test-nav-quickfiles-link]')
 
     def verify(self):
@@ -56,7 +57,7 @@ class EmberNavbar(HomeNavbar):
     user_dropdown_settings = Locator(By.CSS_SELECTOR, 'a[data-analytics-name="Settings"]')
     logout_link = Locator(By.CSS_SELECTOR, '[data-test-ad-logout]')
     sign_in_button = Locator(By.CSS_SELECTOR, '.btn-top-login')
-    donate_link = Locator(By.XPATH, '//a[text()="Donate"]')
+    donate_link = Locator(By.CSS_SELECTOR, '[data-test-nav-donate-link]')
 
 
 class PreprintsNavbar(EmberNavbar):

--- a/components/navbars.py
+++ b/components/navbars.py
@@ -42,6 +42,7 @@ class AbstractLegacyEmberNavbar(Navbar):
 
 class HomeNavbar(Navbar):
     my_projects_link = Locator(By.XPATH, '//a[text()="My Projects"]')
+    my_quick_files_link = Locator(By.CSS_SELECTOR, '[data-test-nav-quickfiles-link]')
 
     def verify(self):
         return self.current_service.text == 'HOME'

--- a/components/navbars.py
+++ b/components/navbars.py
@@ -86,19 +86,22 @@ class PreprintsNavbar(EmberNavbar):
 
 
 class RegistriesNavbar(EmberNavbar):
-    # For Registries Only -> This clicks the gravatar image. (Same effect)
-    user_dropdown = Locator(By.CSS_SELECTOR, 'img[data-test-gravatar]')
-
-    user_dropdown_profile = Locator(By.CSS_SELECTOR, 'ul.dropdown-menu-right > li:nth-child(1) > a')
-    user_dropdown_support = Locator(By.CSS_SELECTOR, 'ul.dropdown-menu-right > li:nth-child(2) > a')
-    user_dropdown_settings = Locator(By.CSS_SELECTOR, 'a[data-analytics-name="Settings"]')
-
     home_link = Locator(By.CSS_SELECTOR, 'ul._ServiceDropdownMenu_nar5mu > li:nth-child(1) > a')
     preprints_link = Locator(By.CSS_SELECTOR, 'ul._ServiceDropdownMenu_nar5mu > li:nth-child(2) > a')
     registries_link = Locator(By.CSS_SELECTOR, 'ul._ServiceDropdownMenu_nar5mu > li:nth-child(3) > a')
     meetings_link = Locator(By.CSS_SELECTOR, 'ul._ServiceDropdownMenu_nar5mu > li:nth-child(4) > a')
     institutions_link = Locator(By.CSS_SELECTOR, 'ul._ServiceDropdownMenu_nar5mu > li:nth-child(5) > a')
-    sign_up_button = Locator(By.CSS_SELECTOR, 'a[data-test-join')
+
+    help_link = Locator(By.CSS_SELECTOR, 'a[data-test-help')
+    donate_link = Locator(By.CSS_SELECTOR, 'a[data-test-donate')      
+    join_link = Locator(By.CSS_SELECTOR, 'a[data-test-join')
+    login_link = Locator(By.CSS_SELECTOR, 'a[data-test-login')
+
+    # For Registries Only -> This clicks the gravatar image. (Same effect)
+    user_dropdown = Locator(By.CSS_SELECTOR, 'img[data-test-gravatar]')
+    user_dropdown_profile = Locator(By.CSS_SELECTOR, 'ul.dropdown-menu-right > li:nth-child(1) > a')
+    user_dropdown_support = Locator(By.CSS_SELECTOR, 'ul.dropdown-menu-right > li:nth-child(2) > a')
+    user_dropdown_settings = Locator(By.CSS_SELECTOR, 'a[data-analytics-name="Settings"]')
 
     def verify(self):
         return self.current_service.text == 'REGISTRIES'

--- a/components/navbars.py
+++ b/components/navbars.py
@@ -5,26 +5,25 @@ from base.locators import BaseElement, Locator
 from selenium.webdriver.common.by import By
 
 
-class Navbar(BaseElement):
+#This is the navbar for legacy non-ember pages
+class HomeNavbar(BaseElement):
     service_dropdown = Locator(By.CSS_SELECTOR, '.fa-caret-down')
     home_link = Locator(By.CSS_SELECTOR, '.service-dropdown [data-analytics-name="HOME"]')
     preprints_link = Locator(By.CSS_SELECTOR, 'a[data-analytics-name="PREPRINTS"]')
     registries_link = Locator(By.CSS_SELECTOR, 'a[data-analytics-name="REGISTRIES"]')
     meetings_link = Locator(By.CSS_SELECTOR, 'a[data-analytics-name="MEETINGS"]')
     institutions_link = Locator(By.CSS_SELECTOR, 'a[data-analytics-name="INSTITUTIONS"]')
-    
-    search_link = Locator(By.CSS_SELECTOR, '[data-test-nav-search-link]')
-    support_link = Locator(By.CSS_SELECTOR, '[data-test-nav-support-link]')
+    search_link = Locator(By.ID, 'navbar-search')
+    support_link = Locator(By.ID, 'navbar-support')
     donate_link = Locator(By.ID, 'navbar-donate')
-    sign_up_button = Locator(By.CSS_SELECTOR, '[data-test-ad-sign-up-button]')
-    sign_in_button = Locator(By.CSS_SELECTOR, '[data-test-sign-in-button]')
 
-    # Preprints Locators
     user_dropdown = Locator(By.CSS_SELECTOR, 'ul.navbar-nav > li:nth-child(6) > a')
     user_dropdown_profile = Locator(By.CSS_SELECTOR, 'ul.dropdown-menu-right > li:nth-child(1)')
     user_dropdown_support = Locator(By.CSS_SELECTOR, 'ul.dropdown-menu-right > li:nth-child(2)')
     user_dropdown_settings = Locator(By.CSS_SELECTOR, 'ul.dropdown-menu-right > li:nth-child(3)')
     logout_link = Locator(By.CSS_SELECTOR, '#secondary-navigation > ul > li.dropdown.open > ul > li:nth-child(4) > a')
+    sign_up_button = Locator(By.CSS_SELECTOR, 'a.btn-success:nth-child(1)')
+    sign_in_button = Locator(By.CSS_SELECTOR, '.btn-top-login')
     current_service = Locator(By.CSS_SELECTOR, '#navbarScope .current-service > strong')
 
     def verify(self):
@@ -37,27 +36,16 @@ class Navbar(BaseElement):
         return self.sign_in_button.present()
 
 
-class AbstractLegacyEmberNavbar(Navbar):
-    user_dropdown = Locator(By.CSS_SELECTOR, 'ul.navbar-nav > li:nth-child(6) > a', settings.LONG_TIMEOUT)
-    sign_in_button = Locator(By.CSS_SELECTOR, '#secondary-navigation > ul.nav > li.ember-view.dropdown.sign-in > a.btn.btn-info.btn-top-login', settings.LONG_TIMEOUT)
+class EmberNavbar(HomeNavbar):
+    search_link = Locator(By.CSS_SELECTOR, '[data-test-nav-search-link]')
+    support_link = Locator(By.CSS_SELECTOR, '[data-test-nav-support-link]')
+    donate_link = Locator(By.CSS_SELECTOR, '[data-test-nav-donate-link]')
+    sign_up_button = Locator(By.CSS_SELECTOR, '[data-test-ad-sign-up-button]')
+    sign_in_button = Locator(By.CSS_SELECTOR, '[data-test-sign-in-button]')
 
-
-class HomeNavbar(Navbar):
+    logout_link = Locator(By.CSS_SELECTOR, '[data-test-ad-logout]')
     my_projects_link = Locator(By.CSS_SELECTOR, '[data-test-nav-my-projects-link]')
     my_quick_files_link = Locator(By.CSS_SELECTOR, '[data-test-nav-quickfiles-link]')
-
-    def verify(self):
-        return self.current_service.text == 'HOME'
-
-
-class EmberNavbar(HomeNavbar):
-    user_dropdown = Locator(By.CSS_SELECTOR, 'ul.navbar-nav > li:nth-child(6) > a')
-    user_dropdown_profile = Locator(By.CSS_SELECTOR, 'ul.auth-dropdown > li:nth-child(1)')
-    user_dropdown_support = Locator(By.CSS_SELECTOR, 'ul.auth-dropdown > li:nth-child(2)')
-    user_dropdown_settings = Locator(By.CSS_SELECTOR, 'a[data-analytics-name="Settings"]')
-    logout_link = Locator(By.CSS_SELECTOR, '[data-test-ad-logout]')
-    sign_in_button = Locator(By.CSS_SELECTOR, '.btn-top-login')
-    donate_link = Locator(By.CSS_SELECTOR, '[data-test-nav-donate-link]')
 
 
 class PreprintsNavbar(EmberNavbar):

--- a/components/navbars.py
+++ b/components/navbars.py
@@ -93,10 +93,10 @@ class RegistriesNavbar(EmberNavbar):
     meetings_link = Locator(By.CSS_SELECTOR, 'ul._ServiceDropdownMenu_nar5mu > li:nth-child(4) > a')
     institutions_link = Locator(By.CSS_SELECTOR, 'ul._ServiceDropdownMenu_nar5mu > li:nth-child(5) > a')
 
-    help_link = Locator(By.CSS_SELECTOR, 'a[data-test-help')
-    donate_link = Locator(By.CSS_SELECTOR, 'a[data-test-donate')      
-    join_link = Locator(By.CSS_SELECTOR, 'a[data-test-join')
-    login_link = Locator(By.CSS_SELECTOR, 'a[data-test-login')
+    help_link = Locator(By.CSS_SELECTOR, 'a[data-test-help]')
+    donate_link = Locator(By.CSS_SELECTOR, 'a[data-test-donate]')
+    join_link = Locator(By.CSS_SELECTOR, 'a[data-test-join]')
+    login_link = Locator(By.CSS_SELECTOR, 'a[data-test-login]')
 
     # For Registries Only -> This clicks the gravatar image. (Same effect)
     user_dropdown = Locator(By.CSS_SELECTOR, 'img[data-test-gravatar]')
@@ -104,7 +104,7 @@ class RegistriesNavbar(EmberNavbar):
     user_dropdown_support = Locator(By.CSS_SELECTOR, 'ul.dropdown-menu-right > li:nth-child(2) > a')
     user_dropdown_settings = Locator(By.CSS_SELECTOR, 'a[data-analytics-name="Settings"]')
 
-    add_new_link = Locator(By.CSS_SELECTOR, 'a[data-test-add-new-button')
+    add_new_link = Locator(By.CSS_SELECTOR, 'a[data-test-add-new-button]')
 
     def verify(self):
         return self.current_service.text == 'REGISTRIES'

--- a/pages/institutions.py
+++ b/pages/institutions.py
@@ -4,7 +4,7 @@ from selenium.webdriver.common.by import By
 
 from base.locators import Locator, ComponentLocator, GroupLocator
 from pages.base import OSFBasePage
-from components.navbars import EmberNavbar
+from components.navbars import InstitutionsNavbar
 
 class InstitutionsLandingPage(OSFBasePage):
     url = settings.OSF_HOME + '/institutions/'
@@ -18,7 +18,7 @@ class InstitutionsLandingPage(OSFBasePage):
     institution_list = GroupLocator(By.CSS_SELECTOR, 'span[data-test-institution-name]')
 
     #TODO: add institutional navbar
-    navbar = ComponentLocator(EmberNavbar)
+    navbar = ComponentLocator(InstitutionsNavbar)
 
 class InstitutionBrandedPage(OSFBasePage):
 

--- a/pages/registries.py
+++ b/pages/registries.py
@@ -42,3 +42,8 @@ class RegistriesDiscoverPage(BaseRegistriesPage):
 
 class RegistrationDetailPage(GuidBasePage):
     identity = Locator(By.CSS_SELECTOR, '[data-test-registration-title]')
+
+
+class RegistrationAddNewPage(BaseRegistriesPage):
+    url = settings.OSF_HOME + '/registries/osf/new'
+    identity = Locator(By.CLASS_NAME, 'Application__page', settings.LONG_TIMEOUT)

--- a/tests/test_navbar.py
+++ b/tests/test_navbar.py
@@ -202,42 +202,6 @@ class TestPreprintsNavbarLoggedIn(NavbarTestLoggedInMixin):
         assert 'myprojects/#preprints' in driver.current_url
 
 
-class TestMeetingsNavbar(NavbarTestLoggedOutMixin):
-
-    @pytest.fixture()
-    def page(self, driver):
-        page = MeetingsPage(driver)
-        page.goto()
-        return page
-
-    def test_support_link(self, page, driver):
-        page.navbar.support_link.click()
-        assert '360001550933' in driver.current_url or 'support' in driver.current_url
-
-        # For future use
-        # support_url = 'https://openscience.zendesk.com/hc/en-us/categories/360001550933'
-        # assert driver.current_url == support_url
-
-    def test_donate_link(self, page, driver):
-        page.navbar.donate_link.click()
-        donate_page = COSDonatePage(driver, verify=False)
-        assert_donate_page(driver, donate_page)
-
-    def test_sign_in_button(self, page, driver):
-        page.navbar.sign_in_button.click()
-        assert 'login' in driver.current_url
-
-
-@pytest.mark.usefixtures('must_be_logged_in')
-class TestMeetingsNavbarLoggedIn(NavbarTestLoggedInMixin):
-
-    @pytest.fixture()
-    def page(self, driver):
-        page = MeetingsPage(driver)
-        page.goto()
-        return page
-
-
 class TestRegistriesNavbar(NavbarTestLoggedOutMixin):
 
     @pytest.fixture()
@@ -281,6 +245,42 @@ class TestRegistriesNavbarLoggedIn(NavbarTestLoggedInMixin):
         page.navbar.add_new_link.click()
         RegistrationAddNewPage(driver, verify=True)
         
+
+class TestMeetingsNavbar(NavbarTestLoggedOutMixin):
+
+    @pytest.fixture()
+    def page(self, driver):
+        page = MeetingsPage(driver)
+        page.goto()
+        return page
+
+    def test_support_link(self, page, driver):
+        page.navbar.support_link.click()
+        assert '360001550933' in driver.current_url or 'support' in driver.current_url
+
+        # For future use
+        # support_url = 'https://openscience.zendesk.com/hc/en-us/categories/360001550933'
+        # assert driver.current_url == support_url
+
+    def test_donate_link(self, page, driver):
+        page.navbar.donate_link.click()
+        donate_page = COSDonatePage(driver, verify=False)
+        assert_donate_page(driver, donate_page)
+
+    def test_sign_in_button(self, page, driver):
+        page.navbar.sign_in_button.click()
+        assert 'login' in driver.current_url
+
+
+@pytest.mark.usefixtures('must_be_logged_in')
+class TestMeetingsNavbarLoggedIn(NavbarTestLoggedInMixin):
+
+    @pytest.fixture()
+    def page(self, driver):
+        page = MeetingsPage(driver)
+        page.goto()
+        return page
+
 
 class TestInstitutionsNavbar(NavbarTestLoggedOutMixin):
 

--- a/tests/test_navbar.py
+++ b/tests/test_navbar.py
@@ -17,8 +17,6 @@ from pages.quickfiles import QuickfilesPage
 from pages.institutions import InstitutionsLandingPage
 
 
-# TODO: Test Navbar from all services including reviews and such - they might not have the same navbar always
-
 class NavbarTestLoggedOutMixin:
     """Mixin used to inject generic tests
     """
@@ -51,6 +49,15 @@ class NavbarTestLoggedOutMixin:
         page.navbar.institutions_link.click()
         InstitutionsLandingPage(driver, verify=True)     
 
+    def test_donate_link(self, page, driver):
+        page.navbar.donate_link.click()
+        donate_page = COSDonatePage(driver, verify=False)
+        assert_donate_page(driver, donate_page)
+
+    def test_sign_in_button(self, page, driver):
+        page.navbar.sign_in_button.click()
+        LoginPage(driver, verify=True)     
+
     def test_sign_up_button(self, driver, page):
         page.navbar.sign_up_button.click()
         RegisterPage(driver, verify=True)
@@ -59,7 +66,6 @@ class NavbarTestLoggedOutMixin:
         assert page.navbar.user_dropdown.absent()
 
 
-# Class used to inject generic tests
 class NavbarTestLoggedInMixin:
     """Mixin used to inject generic tests
     """
@@ -123,19 +129,9 @@ class TestOSFHomeNavbar(NavbarTestLoggedOutMixin):
         page.navbar.support_link.click()
         assert SupportPage(driver, verify=True)
 
-    def test_donate_link(self, page, driver):
-        page.navbar.donate_link.click()
-        donate_page = COSDonatePage(driver, verify=False)
-        assert_donate_page(driver, donate_page)
-
-    def test_sign_in_button(self, page, driver):
-        page.navbar.sign_in_button.click()
-        LoginPage(driver, verify=True)
-
 
 class TestOSFHomeNavbarLoggedIn(NavbarTestLoggedInMixin):
 
-    # Profile settings page
     @pytest.fixture()
     def page(self, driver, must_be_logged_in):
         page = DashboardPage(driver)
@@ -167,20 +163,11 @@ class TestPreprintsNavbar(NavbarTestLoggedOutMixin):
         page.navbar.support_link.click()
         support_url = 'https://help.osf.io/hc/en-us/categories/360001530554-Preprints'
         assert driver.current_url == support_url
-    
-    def test_donate_link(self, page, driver):
-        page.navbar.donate_link.click()
-        donate_page = COSDonatePage(driver, verify=False)
-        assert_donate_page(driver, donate_page)
 
     def test_sign_up_button(self, page, driver):
         page.navbar.sign_up_button.click()
         #Sign Up button takes you to a more specific OSF Preprints sign up page
         assert 'campaign=osf-preprints' in driver.current_url
-
-    def test_sign_in_button(self, page, driver):
-        page.navbar.sign_in_button.click()
-        LoginPage(driver, verify=True)
 
 
 @pytest.mark.usefixtures('must_be_logged_in')
@@ -214,11 +201,6 @@ class TestRegistriesNavbar(NavbarTestLoggedOutMixin):
         page.navbar.help_link.click()
         help_url = 'https://help.osf.io/hc/en-us/categories/360001550953'
         assert driver.current_url == help_url
-    
-    def test_donate_link(self, page, driver):
-        page.navbar.donate_link.click()
-        donate_page = COSDonatePage(driver, verify=False)
-        assert_donate_page(driver, donate_page)
 
     #In the Registries navbar there is no Sign Up button, instead it is a Join link
     def test_sign_up_button(self, page, driver):
@@ -254,6 +236,10 @@ class TestMeetingsNavbar(NavbarTestLoggedOutMixin):
         page.goto()
         return page
 
+    def test_search_link(self, driver, page):
+        page.navbar.search_link.click()
+        SearchPage(driver, verify=True)    
+
     def test_support_link(self, page, driver):
         page.navbar.support_link.click()
         assert '360001550933' in driver.current_url or 'support' in driver.current_url
@@ -261,15 +247,6 @@ class TestMeetingsNavbar(NavbarTestLoggedOutMixin):
         # For future use
         # support_url = 'https://openscience.zendesk.com/hc/en-us/categories/360001550933'
         # assert driver.current_url == support_url
-
-    def test_donate_link(self, page, driver):
-        page.navbar.donate_link.click()
-        donate_page = COSDonatePage(driver, verify=False)
-        assert_donate_page(driver, donate_page)
-
-    def test_sign_in_button(self, page, driver):
-        page.navbar.sign_in_button.click()
-        assert 'login' in driver.current_url
 
 
 @pytest.mark.usefixtures('must_be_logged_in')
@@ -280,6 +257,14 @@ class TestMeetingsNavbarLoggedIn(NavbarTestLoggedInMixin):
         page = MeetingsPage(driver)
         page.goto()
         return page
+
+    def test_my_projects_link(self, page, driver):
+        page.navbar.my_projects_link.click()
+        assert MyProjectsPage(driver, verify=True)
+
+    def test_my_quick_files_link(self, page, driver):
+        page.navbar.my_quick_files_link.click()
+        QuickfilesPage(driver, verify=True)    
 
 
 class TestInstitutionsNavbar(NavbarTestLoggedOutMixin):

--- a/tests/test_navbar.py
+++ b/tests/test_navbar.py
@@ -13,6 +13,7 @@ from pages.dashboard import DashboardPage
 from pages.registries import RegistriesLandingPage
 from pages.user import UserProfilePage, ProfileInformationPage
 from pages.preprints import PreprintLandingPage, PreprintSubmitPage
+from pages.quickfiles import QuickfilesPage
 
 
 # TODO: Test Navbar from all services including reviews and such - they might not have the same navbar always
@@ -138,6 +139,11 @@ class TestOSFHomeNavbarLoggedIn(NavbarTestLoggedInMixin):
     def test_my_projects_link(self, page, driver):
         page.navbar.my_projects_link.click()
         assert MyProjectsPage(driver, verify=True)
+
+    def test_my_quick_files_link(self, page, driver):
+        page.navbar.my_quick_files_link.click()
+        QuickfilesPage(driver, verify=True)
+
 
 # TODO: Complete this test after ENG-1103 is resolved
 # class TestPreprintsNavbar(NavbarTestLoggedOutMixin):

--- a/tests/test_navbar.py
+++ b/tests/test_navbar.py
@@ -241,24 +241,26 @@ class TestRegistriesNavbar(NavbarTestLoggedOutMixin):
         page.goto()
         return page
 
-    # todo: add id to those html tags in ember osf to make the find_element possible
-    # def test_search_link(self):
-    #     page.navbar.search_link.click()
-    #     search_url = settings.OSF_HOME + '/search/'
-    #     assert driver.current_url == search_url
-    #
-    # def test_support_link(self):
-    #     page.navbar.support_link.click()
-    #     support_url = settings.OSF_HOME + '/support/'
-    #     assert driver.current_url == support_url
-    #
-    # def test_donate_link(self):
-    #     page.navbar.donate_link.click()
-    #     assert 'cos.io/donate-to-cos' in driver.current_url
-    #
-    # def test_sign_in_button(self):
-    #     page.navbar.sign_in_button.click()
-    #     assert 'login' in driver.current_url
+    def test_help_link(self, page, driver):
+        page.navbar.help_link.click()
+        help_url = 'https://help.osf.io/hc/en-us/categories/360001550953'
+        assert driver.current_url == help_url
+    
+    def test_donate_link(self, page, driver):
+        page.navbar.donate_link.click()
+        donate_page = COSDonatePage(driver, verify=False)
+        assert_donate_page(driver, donate_page)
+
+    #In the Registries navbar there is no Sign Up button, instead it is a Join link
+    def test_sign_up_button(self, page, driver):
+        page.navbar.join_link.click()
+        #Join link takes you to a more specific OSF Registries sign up page
+        assert 'campaign=osf-registries' in driver.current_url
+
+    #In the Registries navbar there is no Sign In button, instead it is a Login link
+    def test_sign_in_button(self, page, driver):
+        page.navbar.login_link.click()
+        LoginPage(driver, verify=True)
 
 
 @pytest.mark.usefixtures('must_be_logged_in')

--- a/tests/test_navbar.py
+++ b/tests/test_navbar.py
@@ -12,7 +12,7 @@ from pages.project import MyProjectsPage
 from pages.dashboard import DashboardPage
 from pages.registries import RegistriesLandingPage
 from pages.user import UserProfilePage, ProfileInformationPage
-from pages.preprints import PreprintLandingPage, PreprintSubmitPage
+from pages.preprints import PreprintLandingPage, PreprintSubmitPage, PreprintDiscoverPage
 from pages.quickfiles import QuickfilesPage
 from pages.institutions import InstitutionsLandingPage
 
@@ -151,33 +151,36 @@ class TestOSFHomeNavbarLoggedIn(NavbarTestLoggedInMixin):
         QuickfilesPage(driver, verify=True)
 
 
-# TODO: Complete this test after ENG-1103 is resolved
-# class TestPreprintsNavbar(NavbarTestLoggedOutMixin):
-#
-#     @pytest.fixture()
-#     def page(self, driver):
-#         page = PreprintLandingPage(driver)
-#         page.goto()
-#         return page
+class TestPreprintsNavbar(NavbarTestLoggedOutMixin):
 
-    # todo: add id to those html tags in ember osf to make the find_element possible
-    # def test_search_link(self):
-    #     page.navbar.search_link.click()
-    #     search_url = settings.OSF_HOME + '/search/'
-    #     assert driver.current_url == search_url
-    #
-    # def test_support_link(self):
-    #     page.navbar.support_link.click()
-    #     support_url = settings.OSF_HOME + '/support/'
-    #     assert driver.current_url == support_url
-    #
-    # def test_donate_link(self):
-    #     page.navbar.donate_link.click()
-    #     assert 'cos.io/donate-to-cos' in driver.current_url
-    #
-    # def test_sign_in_button(self):
-    #     page.navbar.sign_in_button.click()
-    #     assert 'login' in driver.current_url
+    @pytest.fixture()
+    def page(self, driver):
+        page = PreprintLandingPage(driver)
+        page.goto()
+        return page
+
+    def test_search_link(self, page, driver):
+        page.navbar.search_link.click()
+        PreprintDiscoverPage(driver, verify=True)
+    
+    def test_support_link(self, page, driver):
+        page.navbar.support_link.click()
+        support_url = 'https://help.osf.io/hc/en-us/categories/360001530554-Preprints'
+        assert driver.current_url == support_url
+    
+    def test_donate_link(self, page, driver):
+        page.navbar.donate_link.click()
+        donate_page = COSDonatePage(driver, verify=False)
+        assert_donate_page(driver, donate_page)
+
+    def test_sign_up_button(self, page, driver):
+        page.navbar.sign_up_button.click()
+        #Sign Up button takes you to a more specific OSF Preprints sign up page
+        assert 'campaign=osf-preprints' in driver.current_url
+
+    def test_sign_in_button(self, page, driver):
+        page.navbar.sign_in_button.click()
+        LoginPage(driver, verify=True)
 
 
 @pytest.mark.usefixtures('must_be_logged_in')

--- a/tests/test_navbar.py
+++ b/tests/test_navbar.py
@@ -104,7 +104,7 @@ class NavbarTestLoggedInMixin:
 
 @markers.smoke_test
 @markers.core_functionality
-class TestOSFHomeNavbar(NavbarTestLoggedOutMixin):
+class TestOSFHomeNavbarLoggedOut(NavbarTestLoggedOutMixin):
 
     @pytest.fixture()
     def page(self, driver):
@@ -145,7 +145,7 @@ class TestOSFHomeNavbarLoggedIn(NavbarTestLoggedInMixin):
 
 @markers.smoke_test
 @markers.core_functionality
-class TestPreprintsNavbar(NavbarTestLoggedOutMixin):
+class TestPreprintsNavbarLoggedOut(NavbarTestLoggedOutMixin):
 
     @pytest.fixture()
     def page(self, driver):
@@ -191,7 +191,7 @@ class TestPreprintsNavbarLoggedIn(NavbarTestLoggedInMixin):
 
 @markers.smoke_test
 @markers.core_functionality
-class TestRegistriesNavbar(NavbarTestLoggedOutMixin):
+class TestRegistriesNavbarLoggedOut(NavbarTestLoggedOutMixin):
 
     @pytest.fixture()
     def page(self, driver):
@@ -234,7 +234,7 @@ class TestRegistriesNavbarLoggedIn(NavbarTestLoggedInMixin):
 
 @markers.smoke_test
 @markers.core_functionality
-class TestMeetingsNavbar(NavbarTestLoggedOutMixin):
+class TestMeetingsNavbarLoggedOut(NavbarTestLoggedOutMixin):
 
     @pytest.fixture()
     def page(self, driver):
@@ -277,7 +277,7 @@ class TestMeetingsNavbarLoggedIn(NavbarTestLoggedInMixin):
 
 @markers.smoke_test
 @markers.core_functionality
-class TestInstitutionsNavbar(NavbarTestLoggedOutMixin):
+class TestInstitutionsNavbarLoggedOut(NavbarTestLoggedOutMixin):
 
     @pytest.fixture()
     def page(self, driver):

--- a/tests/test_navbar.py
+++ b/tests/test_navbar.py
@@ -102,6 +102,8 @@ class NavbarTestLoggedInMixin:
         login(driver)
 
 
+@markers.smoke_test
+@markers.core_functionality
 class TestOSFHomeNavbar(NavbarTestLoggedOutMixin):
 
     @pytest.fixture()
@@ -110,26 +112,20 @@ class TestOSFHomeNavbar(NavbarTestLoggedOutMixin):
         page.goto()
         return page
 
-    @markers.smoke_test
-    @markers.core_functionality
     def test_my_projects_link_not_present(self, page):
-        """Used as a core test to make sure the landing page loads.
-        """
         assert page.navbar.my_projects_link.absent()
 
     def test_search_link(self, driver, page):
         page.navbar.search_link.click()
         assert SearchPage(driver, verify=True)
 
-    @markers.smoke_test
-    @markers.core_functionality
     def test_support_link(self, page, driver):
-        """Used as a core test to make sure the support page loads.
-        """
         page.navbar.support_link.click()
         assert SupportPage(driver, verify=True)
 
 
+@markers.smoke_test
+@markers.core_functionality
 class TestOSFHomeNavbarLoggedIn(NavbarTestLoggedInMixin):
 
     @pytest.fixture()
@@ -147,6 +143,8 @@ class TestOSFHomeNavbarLoggedIn(NavbarTestLoggedInMixin):
         QuickfilesPage(driver, verify=True)
 
 
+@markers.smoke_test
+@markers.core_functionality
 class TestPreprintsNavbar(NavbarTestLoggedOutMixin):
 
     @pytest.fixture()
@@ -170,6 +168,8 @@ class TestPreprintsNavbar(NavbarTestLoggedOutMixin):
         assert 'campaign=osf-preprints' in driver.current_url
 
 
+@markers.smoke_test
+@markers.core_functionality
 @pytest.mark.usefixtures('must_be_logged_in')
 class TestPreprintsNavbarLoggedIn(NavbarTestLoggedInMixin):
 
@@ -189,6 +189,8 @@ class TestPreprintsNavbarLoggedIn(NavbarTestLoggedInMixin):
         assert 'myprojects/#preprints' in driver.current_url
 
 
+@markers.smoke_test
+@markers.core_functionality
 class TestRegistriesNavbar(NavbarTestLoggedOutMixin):
 
     @pytest.fixture()
@@ -214,6 +216,8 @@ class TestRegistriesNavbar(NavbarTestLoggedOutMixin):
         LoginPage(driver, verify=True)
 
 
+@markers.smoke_test
+@markers.core_functionality
 @pytest.mark.usefixtures('must_be_logged_in')
 class TestRegistriesNavbarLoggedIn(NavbarTestLoggedInMixin):
 
@@ -228,6 +232,8 @@ class TestRegistriesNavbarLoggedIn(NavbarTestLoggedInMixin):
         RegistrationAddNewPage(driver, verify=True)
         
 
+@markers.smoke_test
+@markers.core_functionality
 class TestMeetingsNavbar(NavbarTestLoggedOutMixin):
 
     @pytest.fixture()
@@ -249,6 +255,8 @@ class TestMeetingsNavbar(NavbarTestLoggedOutMixin):
         # assert driver.current_url == support_url
 
 
+@markers.smoke_test
+@markers.core_functionality
 @pytest.mark.usefixtures('must_be_logged_in')
 class TestMeetingsNavbarLoggedIn(NavbarTestLoggedInMixin):
 
@@ -267,6 +275,8 @@ class TestMeetingsNavbarLoggedIn(NavbarTestLoggedInMixin):
         QuickfilesPage(driver, verify=True)    
 
 
+@markers.smoke_test
+@markers.core_functionality
 class TestInstitutionsNavbar(NavbarTestLoggedOutMixin):
 
     @pytest.fixture()
@@ -284,6 +294,8 @@ class TestInstitutionsNavbar(NavbarTestLoggedOutMixin):
         SupportPage(driver, verify=True)
 
 
+@markers.smoke_test
+@markers.core_functionality
 @pytest.mark.usefixtures('must_be_logged_in')
 class TestInstitutionsNavbarLoggedIn(NavbarTestLoggedInMixin):
 

--- a/tests/test_navbar.py
+++ b/tests/test_navbar.py
@@ -10,7 +10,7 @@ from pages.meetings import MeetingsPage
 from pages.register import RegisterPage
 from pages.project import MyProjectsPage
 from pages.dashboard import DashboardPage
-from pages.registries import RegistriesLandingPage
+from pages.registries import RegistriesLandingPage, RegistrationAddNewPage
 from pages.user import UserProfilePage, ProfileInformationPage
 from pages.preprints import PreprintLandingPage, PreprintSubmitPage, PreprintDiscoverPage
 from pages.quickfiles import QuickfilesPage
@@ -272,6 +272,10 @@ class TestRegistriesNavbarLoggedIn(NavbarTestLoggedInMixin):
         page.goto()
         return page
 
+    def test_add_new_link(self, page, driver):
+        page.navbar.add_new_link.click()
+        RegistrationAddNewPage(driver, verify=True)
+        
 
 class TestInstitutionsNavbar(NavbarTestLoggedOutMixin):
 

--- a/tests/test_navbar.py
+++ b/tests/test_navbar.py
@@ -196,6 +196,11 @@ class TestPreprintsNavbarLoggedIn(NavbarTestLoggedInMixin):
         page.navbar.add_a_preprint_link.click()
         PreprintSubmitPage(driver, verify=True)
 
+    def test_my_preprints_link(self, page, driver):
+        page.navbar.my_preprints_link.click()
+        #My Preprints link actually navigates to My Preprints section of My Projects page
+        assert 'myprojects/#preprints' in driver.current_url
+
 
 class TestMeetingsNavbar(NavbarTestLoggedOutMixin):
 

--- a/tests/test_navbar.py
+++ b/tests/test_navbar.py
@@ -14,6 +14,7 @@ from pages.registries import RegistriesLandingPage
 from pages.user import UserProfilePage, ProfileInformationPage
 from pages.preprints import PreprintLandingPage, PreprintSubmitPage
 from pages.quickfiles import QuickfilesPage
+from pages.institutions import InstitutionsLandingPage
 
 
 # TODO: Test Navbar from all services including reviews and such - they might not have the same navbar always
@@ -44,6 +45,11 @@ class NavbarTestLoggedOutMixin:
         page.navbar.service_dropdown.click()
         page.navbar.meetings_link.click()
         MeetingsPage(driver, verify=True)
+
+    def test_institutions_dropdown_link(self, page, driver):
+        page.navbar.service_dropdown.click()
+        page.navbar.institutions_link.click()
+        InstitutionsLandingPage(driver, verify=True)     
 
     def test_sign_up_button(self, driver, page):
         page.navbar.sign_up_button.click()
@@ -260,6 +266,41 @@ class TestRegistriesNavbarLoggedIn(NavbarTestLoggedInMixin):
         page = RegistriesLandingPage(driver)
         page.goto()
         return page
+
+
+class TestInstitutionsNavbar(NavbarTestLoggedOutMixin):
+
+    @pytest.fixture()
+    def page(self, driver):
+        page = InstitutionsLandingPage(driver)
+        page.goto()
+        return page
+
+    def test_search_link(self, driver, page):
+        page.navbar.search_link.click()
+        SearchPage(driver, verify=True)     
+
+    def test_support_link(self, page, driver):
+        page.navbar.support_link.click()
+        SupportPage(driver, verify=True)
+
+
+@pytest.mark.usefixtures('must_be_logged_in')
+class TestInstitutionsNavbarLoggedIn(NavbarTestLoggedInMixin):
+
+    @pytest.fixture()
+    def page(self, driver):
+        page = InstitutionsLandingPage(driver)
+        page.goto()
+        return page
+
+    def test_my_projects_link(self, page, driver):
+        page.navbar.my_projects_link.click()
+        assert MyProjectsPage(driver, verify=True)
+
+    def test_my_quick_files_link(self, page, driver):
+        page.navbar.my_quick_files_link.click()
+        QuickfilesPage(driver, verify=True)
 
 
 def assert_donate_page(driver, donate_page):


### PR DESCRIPTION
<!-- Before you submit your Pull Request, please confirm that:

     - Any test that will create public data either has the `QAtest` tag or the `dont_run_on_production` marker
     - `core_functionality` is marked as such
     - Your tests will be able to run on *all* servers (all stagings, test)
 -->


## Purpose
To apply fixes and cleanup of tests/test_navbar.py as described in 5 different tickets.  See details below.


## Summary of Changes
1.  ENG-857: Added test step to test "My Quick Files" link to test_navbar.py in TestOSFHomeNavbarLoggedIn class.  Also updated components/navbars.py to include quick files link.
2. ENG-858: Added test steps to test services dropdown navigation and all links from OSF Institutions landing page to tests/test_navbar.py.  Also added testing of Institutions link from services dropdown from all other service landing pages.  In components/navbar.py, I created a new InstitutionsNavbar class that inherits from EmberNavbar and added all relevant link definitions for Institutions.  Also updated pages/institutions.py to use InstitutionsNavbar instead of EmberNavbar.
3.  ENG-1126: Uncommented TestPreprintsNavbar class in tests/test_navbar.py and updated all relevant Preprints links in components/navbars.py.
4.  ENG-1127: Uncommented test steps in TestRegistriesNavbar class in tests/test_navbar.py and updated all relevant Registries links in components/navbars.py.
5.  ENG-830:  Reviewed tests/test_navabr.py and components/navbars.py and made the following updates:
    a. Added test step to test "Add New" link to TestRegistriesNavbarLoggedIn class in tests/test_navbar.py and also  added definition of add new link to components/navbars.py in the RegistriesNavbar class. Also added RegistrationAddNewPage class to pages/registries.py.
    b. Added test step to test "My Preprints" link to TestPreprintsNavbarLoggedIn class in tests/test_navbar.py.
    c. Replaced all XPATHs with CSS_SELECTORs in the Locators for elements in components/navbars.py.
    d. Re-ordered test steps in tests/test_navbar.py so that test steps follow the same order of services in the service dropdown (i.e. Home, Preprints, Registries, Meetings, Institutions). This makes this rather long test easier to read.
    e. Moved some common test steps into NavbarTestLoggedOutMixin in tests/test_navbar.py and added a few missing test steps. Also cleanup and deleting of old comments.
    f. **REVERTED: Deleted a couple of unnecessary intermediary classes (AbstractLegacyEmberNavbar and HomeNavbar) from components/navbar.py and updated pages/base.py to use EmberNavbar instead of HomeNavbar.** 
    g.  Added @markers.smoke_test and @markers.core_functionality markers to each test class in tests/test_navbar.py.  Now all test steps will run in the nightly Production Smoke Test run.
    h. Added corrections requested by Fitz including adding back missing end bracket ']' to several locators in components/navbars.py and renaming classes in tests/test_navbar.py to include "LoggedOut" to make them more consistent.  After reverting previous commit that deleted unnecessary intermediary classes in components/navbars.py, I consolidated all of the legacy navbar classes into one class: HomeNavbar and then set the EmberNavbar class to inherit from it.  All other service specific navbar classes continue to inherit from EmberNavbar.


## Reviewer's Actions
`git fetch <remote> pull/<PR_number>/head:testFix/navbar_2`

Run this test using
`tests/test_navbar.py -s -v`

## Testing Changes Moving Forward
N/A


## Tickets
1. ENG-857: SEL: Add Quickfiles to navbars tests
https://openscience.atlassian.net/browse/ENG-857

2. ENG-858: SEL: Add Institutions to navbars tests
https://openscience.atlassian.net/browse/ENG-858

3. ENG-1126: SEL: Update navbar preprints test [Blocked]
https://openscience.atlassian.net/browse/ENG-1126

4. ENG-1127: SEL: Uncomment registries navbar test
https://openscience.atlassian.net/browse/ENG-1127

5. ENG-830: SEL: audit navbar tests for thoroughness
https://openscience.atlassian.net/browse/ENG-830
