### PR TITLE
Fix linting errors in components/navbars.py and tests/test_navbar.py found by flake8 in nightly test runs.

### DIFF
--- a/components/navbars.py
+++ b/components/navbars.py
@@ -1,5 +1,3 @@
-import settings
-
 from base.locators import BaseElement, Locator
 
 from selenium.webdriver.common.by import By
@@ -108,4 +106,3 @@ class InstitutionsNavbar(EmberNavbar):
 
     def verify(self):
         return self.current_service.text == 'INSTITUTIONS'
-

--- a/pages/project.py
+++ b/pages/project.py
@@ -85,7 +85,7 @@ class FilesPage(GuidBasePage):
     delete_modal = Locator(By.CSS_SELECTOR, 'span.btn:nth-child(1)')
 
 
-'''Note that the class FilesPage in pages/project.py is used for test_project_files.py.
+"""Note that the class FilesPage in pages/project.py is used for test_project_files.py.
 The class FileWidget in components/project.py is used for tests test_file_widget_loads
 and test_addon_files_load in test_project.py.
-In the future, we may want to put all files tests in one place.'''
+In the future, we may want to put all files tests in one place."""

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
 invoke==0.15.0
 selenium==3.141.0
 pytest==3.5.0
-flake8==2.4.0
-flake8-quotes==0.3.0
+flake8==3.9.1
+flake8-quotes==3.2.0
 autopep8==1.3.3
 requests>=2.20.0
 pythosf==0.0.9

--- a/tests/test_navbar.py
+++ b/tests/test_navbar.py
@@ -47,7 +47,7 @@ class NavbarTestLoggedOutMixin:
     def test_institutions_dropdown_link(self, page, driver):
         page.navbar.service_dropdown.click()
         page.navbar.institutions_link.click()
-        InstitutionsLandingPage(driver, verify=True)     
+        InstitutionsLandingPage(driver, verify=True)
 
     def test_donate_link(self, page, driver):
         page.navbar.donate_link.click()
@@ -56,7 +56,7 @@ class NavbarTestLoggedOutMixin:
 
     def test_sign_in_button(self, page, driver):
         page.navbar.sign_in_button.click()
-        LoginPage(driver, verify=True)     
+        LoginPage(driver, verify=True)
 
     def test_sign_up_button(self, driver, page):
         page.navbar.sign_up_button.click()
@@ -156,7 +156,7 @@ class TestPreprintsNavbarLoggedOut(NavbarTestLoggedOutMixin):
     def test_search_link(self, page, driver):
         page.navbar.search_link.click()
         PreprintDiscoverPage(driver, verify=True)
-    
+
     def test_support_link(self, page, driver):
         page.navbar.support_link.click()
         support_url = 'https://help.osf.io/hc/en-us/categories/360001530554-Preprints'
@@ -230,7 +230,7 @@ class TestRegistriesNavbarLoggedIn(NavbarTestLoggedInMixin):
     def test_add_new_link(self, page, driver):
         page.navbar.add_new_link.click()
         RegistrationAddNewPage(driver, verify=True)
-        
+
 
 @markers.smoke_test
 @markers.core_functionality
@@ -244,7 +244,7 @@ class TestMeetingsNavbarLoggedOut(NavbarTestLoggedOutMixin):
 
     def test_search_link(self, driver, page):
         page.navbar.search_link.click()
-        SearchPage(driver, verify=True)    
+        SearchPage(driver, verify=True)
 
     def test_support_link(self, page, driver):
         page.navbar.support_link.click()
@@ -272,7 +272,7 @@ class TestMeetingsNavbarLoggedIn(NavbarTestLoggedInMixin):
 
     def test_my_quick_files_link(self, page, driver):
         page.navbar.my_quick_files_link.click()
-        QuickfilesPage(driver, verify=True)    
+        QuickfilesPage(driver, verify=True)
 
 
 @markers.smoke_test
@@ -287,7 +287,7 @@ class TestInstitutionsNavbarLoggedOut(NavbarTestLoggedOutMixin):
 
     def test_search_link(self, driver, page):
         page.navbar.search_link.click()
-        SearchPage(driver, verify=True)     
+        SearchPage(driver, verify=True)
 
     def test_support_link(self, page, driver):
         page.navbar.support_link.click()

--- a/tests/test_project_files.py
+++ b/tests/test_project_files.py
@@ -15,12 +15,12 @@ from selenium.webdriver.common.by import By
 from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support import expected_conditions as EC
 
-'''
+"""
 *** NOTE ***
 For the test user running this test, the following addons must be manually
 authorized in user settings, or else the test will fail to run:
     - 'box', 'dropbox', 's3', 'owncloud'
-'''
+"""
 
 
 def format_provider_name(row):
@@ -380,7 +380,7 @@ class TestFilesPage:
             osf_api.delete_addon_files(session, provider, current_browser, guid=node_id)
 
 
-'''
+"""
 TODO:
 - improve downloads test to check for positive result
 - write an uploads test
@@ -390,4 +390,4 @@ Addons this test does not cover, and reasons:
     Github - requested add-on not currently configurable via API
     Dataverse - requested add-on not currently configurable via API
     Figshare - has a non-conventional file setup not suited for normal file actions
-'''
+"""


### PR DESCRIPTION
<!-- Before you submit your Pull Request, please confirm that:

     - Any test that will create public data either has the `QAtest` tag or the `dont_run_on_production` marker
     - `core_functionality` is marked as such
     - Your tests will be able to run on *all* servers (all stagings, test)
 -->


## Purpose
To fix the nightly test run failings due to a linting error in components/navbars.py. UPDATE: Also updating requirements.txt file to include latest versions of flake8 and flake8-quotes.

## Summary of Changes
Fixed the one serious error in components/navbars.py by deleting the import of settings which is no longer used.  Also deleted the extra blank line at the end of the file which caused a warning from flake8.  While I was at it I also fixed the warnings in tests/test_navbar.py due to extra spaces on several lines.  Note: These all should have been caught on my local machine before I committed the changes, but for some reason my install and configuration of flake8 is not working.  Will need to investigate this further.  UPDATE: After further investigation it was determined that I was using an outdated version of flake8 (v2.4.0) as a result of the requirements.txt fie including this older version.  So this PR also includes an update to the requirements.txt file to bring flake8 and flake8-quotes up to date. After upgrading flake8 and running against the osf-selenium-tests repository, 3 new linting errors were discovered in tests/test_project_file.py and pages/project.py.  Corrections were made to these 2 files and also included as part of this PR.

Errors from nightly test run:
flake8 .
./components/navbars.py:1:1: F401 'settings' imported but unused
./components/navbars.py:111:1: W391 blank line at end of file
./tests/test_navbar.py:50:53: W291 trailing whitespace
./tests/test_navbar.py:59:39: W291 trailing whitespace
./tests/test_navbar.py:159:1: W293 blank line contains whitespace
./tests/test_navbar.py:233:1: W293 blank line contains whitespace
./tests/test_navbar.py:247:40: W291 trailing whitespace
./tests/test_navbar.py:275:44: W291 trailing whitespace
./tests/test_navbar.py:290:40: W291 trailing whitespace
Error: Process completed with exit code 1.

Additional Linting Errors after upgrade of flake8:
./tests/test_project_files.py:18:1: Q001 Remove bad quotes from multiline string
./tests/test_project_files.py:383:1: Q001 Remove bad quotes from multiline string
./pages/project.py:88:1: Q001 Remove bad quotes from multiline string


## Reviewer's Actions
`git fetch <remote> pull/<PR_number>/head:testFix/navbarFlake8`

Run this test using
`tests/test_navbar.py -s -v`
`tests/test_project_files.py -s -v`

## Testing Changes Moving Forward
manually run flake8 before any future commits.


## Ticket
NA

