### PR TITLE
Updating identity locator for Registries Discover page

### DIFF
--- a/pages/registries.py
+++ b/pages/registries.py
@@ -25,8 +25,8 @@ class RegistriesLandingPage(BaseRegistriesPage):
 class RegistriesDiscoverPage(BaseRegistriesPage):
     url = settings.OSF_HOME + '/registries/discover'
 
-    identity = Locator(By.CSS_SELECTOR, '[data-test-share-logo]')
-    loading_indicator = Locator(By.CSS_SELECTOR, '.ball-scale')
+    identity = Locator(By.CSS_SELECTOR, 'div[data-analytics-scope="Registries Discover page"]')
+    loading_indicator = Locator(By.CSS_SELECTOR, '.ball-scale', settings.LONG_TIMEOUT)
     osf_filter = Locator(By.CSS_SELECTOR, '[data-test-source-filter-id$="OSF Registries"]')
 
     # Group Locators


### PR DESCRIPTION
<!-- Before you submit your Pull Request, please confirm that:

     - Any test that will create public data either has the `QAtest` tag or the `dont_run_on_production` marker
     - `core_functionality` is marked as such
     - Your tests will be able to run on *all* servers (all stagings, test)
 -->


## Purpose
To fix failing test in nightly Production Selenium Smoke Test run. Failing test is: TestRegistriesDiscoverPage::test_search_results_exist

## Summary of Changes
The test is failing because the identity locator for the Registries Discover page uses: '[data-test-share-logo]' and the Share logo no longer appears on the Registries Discover page.  So I changed the locator to use a more appropriate CSS Selector ('div[data-analytics-scope="Registries Discover page"]').  Also added long timeout (30 sec) setting to loading indicator to help with issue of search results taking a long time to load in some instances.

## Reviewer's Actions
`git fetch <remote> pull/<PR_number>/head:testFix/registries`

Run this test using
`tests/test_registries.py -s -v`

## Testing Changes Moving Forward
N/A


## Ticket

https://openscience.atlassian.net/browse/ENG-2820
