### PR TITLE
Update locator for more_arrow on create new project modal

### DIFF
--- a/components/dashboard.py
+++ b/components/dashboard.py
@@ -13,7 +13,7 @@ class EmberCreateProjectModal(BaseElement):
     title_input = Locator(By.CSS_SELECTOR, '._NewProject__label_fz56y2 input')
     select_all_link = Locator(By.XPATH, '//button[text()="Select all"]')
     remove_all_link = Locator(By.XPATH, '//button[text()="Remove all"]')
-    more_arrow = Locator(By.CLASS_NAME, 'fa')
+    more_arrow = Locator(By.CSS_SELECTOR, 'button[data-analytics-name="Toggle more"]')
     description_input = Locator(By.CLASS_NAME, 'project-desc')
     template_dropdown = Locator(By.CLASS_NAME, 'ember-power-select-placeholder')
 


### PR DESCRIPTION
<!-- Before you submit your Pull Request, please confirm that:

     - Any test that will create public data either has the `QAtest` tag or the `dont_run_on_production` marker
     - `core_functionality` is marked as such
     - Your tests will be able to run on *all* servers (all stagings, test)
 -->


## Purpose
To fix failing test in nightly Selenium Staging Test run. Failing test is: tests/test_dashboard.py::TestDashboardPage::test_create_project_modal_buttons

## Summary of Changes
The test is failing on the click of the More arrow on the Create New Project modal window.  The locator definition is no longer valid for this element. So I updated the locator for the more_arrow element to a valid CSS_SELECTOR value in components/dashboard.py.


## Reviewer's Actions
`git fetch <remote> pull/<PR_number>/head:testFix/dashboard`

Run this test using
`tests/test_dashboard.py -s -v`

## Testing Changes Moving Forward
N/A


## Ticket

https://openscience.atlassian.net/browse/ENG-2823
