### PR TITLE
Fixes to Preprints test covering 4 tickets

### DIFF
--- a/pages/preprints.py
+++ b/pages/preprints.py
@@ -87,7 +87,9 @@ class PreprintSubmitPage(BasePreprintPage):
 
     authors_save_button = Locator(By.CSS_SELECTOR, '#preprint-form-authors .btn-primary', settings.QUICK_TIMEOUT)
 
-    conflict_of_interest = Locator(By.ID, 'coiNo', settings.QUICK_TIMEOUT)
+    conflict_of_interest_yes = Locator(By.ID, 'coiYes', settings.QUICK_TIMEOUT)
+    conflict_of_interest_no = Locator(By.ID, 'coiNo', settings.QUICK_TIMEOUT)
+    no_coi_text_box = Locator(By.CSS_SELECTOR, '[data-test-has-no-coi]', settings.QUICK_TIMEOUT)
     coi_save_button = Locator(By.CSS_SELECTOR, '[data-test-coi-continue]')
 
     supplemental_create_new_project = Locator(By.CSS_SELECTOR, 'div[class="start"] > div[class="row"] > div:nth-child(2)', settings.QUICK_TIMEOUT)

--- a/pages/preprints.py
+++ b/pages/preprints.py
@@ -48,6 +48,7 @@ class BasePreprintPage(OSFBasePage):
 class PreprintLandingPage(BasePreprintPage):
     identity = Locator(By.CSS_SELECTOR, '.ember-application .preprint-header', settings.LONG_TIMEOUT)
     add_preprint_button = Locator(By.CLASS_NAME, 'preprint-submit-button', settings.LONG_TIMEOUT)
+    search_input = Locator(By.ID, 'searchBox')
     search_button = Locator(By.CSS_SELECTOR, '.preprint-search .btn-default')
     submit_navbar = Locator(By.CSS_SELECTOR, '.branded-nav > :nth-child(2)')
     submit_button = Locator(By.CSS_SELECTOR, '.btn.btn-success')
@@ -66,6 +67,7 @@ class PreprintSubmitPage(BasePreprintPage):
     upload_project_help_text = Locator(By.CSS_SELECTOR, '.ember-power-select-option--search-message')
     upload_project_selector_project = Locator(By.CSS_SELECTOR, '.ember-power-select-option')
     upload_select_file = Locator(By.CSS_SELECTOR, '.file-browser-item > a:nth-child(2)')
+    upload_preprint_title_input = Locator(By.NAME, 'title')
     upload_file_save_continue = Locator(By.CSS_SELECTOR, 'div[class="p-t-xs pull-right"] > button[class="btn btn-primary"]')
 
     # Author Assertions
@@ -105,6 +107,7 @@ class PreprintDiscoverPage(BasePreprintPage):
 
     identity = Locator(By.ID, 'share-logo')
     loading_indicator = Locator(By.CSS_SELECTOR, '.ball-scale')
+    search_button = Locator(By.CSS_SELECTOR, 'div.search-header > div > div > div > div.input-group.input-group-lg > span > button:nth-child(2)')
 
     # Group Locators
     search_results = GroupLocator(By.CSS_SELECTOR, '.search-result h4 > a')
@@ -117,3 +120,16 @@ class PreprintDetailPage(GuidBasePage, BasePreprintPage):
     identity = Locator(By.ID, 'preprintTitle', settings.LONG_TIMEOUT)
     title = Locator(By.ID, 'preprintTitle', settings.LONG_TIMEOUT)
     view_page = Locator(By.ID, 'view-page')
+    coi_assert_container = Locator(By.CSS_SELECTOR, '.author-assertions > div:nth-child(1)')
+    coi_dropdown_arrow = Locator(By.CSS_SELECTOR, '.author-assertions > div:nth-child(1) > span > div > .fa.fa-caret-down')
+    pub_data_assert_container = Locator(By.CSS_SELECTOR, '.author-assertions > div:nth-child(2)')
+    pub_data_dropdown_arrow = Locator(By.CSS_SELECTOR, '.author-assertions > div:nth-child(2) > span > div > .fa.fa-caret-down')
+    prereg_assert_container = Locator(By.CSS_SELECTOR, '.author-assertions > div:nth-child(3)')
+    prereg_dropdown_arrow = Locator(By.CSS_SELECTOR, '.author-assertions > div:nth-child(3) > span > div > .fa.fa-caret-down')
+    dropdown_content = Locator(By.CSS_SELECTOR, '#ember-basic-dropdown-wormhole > div')
+    abstract_text = Locator(By.CLASS_NAME, 'abstract')
+    license_text = Locator(By.CSS_SELECTOR, '.p-t-xs.license-text')
+    license_detail_arrow = Locator(By.CSS_SELECTOR, '.p-t-xs.license-text > span > .fa.fa-caret-right')
+    license_detail_text = Locator(By.CSS_SELECTOR, '.p-t-xs.license-text > pre')
+    discipline_text = Locator(By.CLASS_NAME, 'subject-preview')
+    fileName = Locator(By.ID, 'selectedFileName')

--- a/tests/test_preprints.py
+++ b/tests/test_preprints.py
@@ -129,12 +129,17 @@ def custom_providers():
 
 class TestBrandedProviders:
 
-    @pytest.fixture(params=custom_providers(), ids=[prov['id'] for prov in custom_providers()])
+    @pytest.fixture(params=providers(), ids=[prov['id'] for prov in providers()])
     def provider(self, request):
         return request.param
 
     def test_landing_page_loads(self, driver, provider):
         PreprintLandingPage(driver, provider=provider).goto()
+        if provider['attributes']['domain_redirect_enabled']:
+            #Make sure the landing page url matches the expected domian
+            assert driver.current_url == provider['attributes']['domain']
+        else:
+            assert 'osf.io/preprints/' in driver.current_url
 
     def test_discover_page_loads(self, driver, provider):
         PreprintDiscoverPage(driver, provider=provider).goto()
@@ -150,9 +155,17 @@ class TestBrandedProviders:
             assert 'submit' not in landing_page.submit_navbar.text
             assert not landing_page.submit_button.present()
 
-    @markers.smoke_test
-    @markers.core_functionality
-    @pytest.mark.skipif(not settings.PRODUCTION, reason='Cannot test on stagings as they share SHARE')
+
+#The following class only runs in Production for Branded Providers that have a Custom Domain
+@markers.smoke_test
+@markers.core_functionality
+@pytest.mark.skipif(not settings.PRODUCTION, reason='Cannot test on stagings as they share SHARE')
+class TestCustomDomainsInProd:
+
+    @pytest.fixture(params=custom_providers(), ids=[prov['id'] for prov in custom_providers()])
+    def provider(self, request):
+        return request.param
+
     def test_detail_page(self, session, driver, provider):
         """Test a preprint detail page by grabbing the first search result from the discover page.
         """

--- a/tests/test_preprints.py
+++ b/tests/test_preprints.py
@@ -8,6 +8,7 @@ from api import osf_api
 from utils import find_current_browser
 from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support import expected_conditions as EC
+from selenium.webdriver.support.select import Select
 
 from pages.preprints import (
     PreprintLandingPage,
@@ -52,13 +53,22 @@ class TestPreprintWorkflow:
         submit_page.public_available_button.click()
         submit_page.public_data_input.click()
         submit_page.public_data_input.send_keys_deliberately('https://osf.io/')
+        #Need to scroll down since the Preregistration radio buttons are obscured by the Dev mode warning in test environments
+        currentYPos = driver.execute_script('return window.scrollY;')
+        driver.execute_script("window.scrollTo(0, arguments[0])", currentYPos + 200)
         submit_page.preregistration_no_button.click()
         submit_page.preregistration_input.click()
         submit_page.preregistration_input.send_keys_deliberately('QA Testing')
         submit_page.save_author_assertions.click()
 
         submit_page.basics_license_dropdown.click()
-        submit_page.basics_universal_license.click()
+        #The order of the options in the license dropdown is not consistent across test environments, so we can't use the 
+        # basics_universal_license element as defined in pages/preprints.py since it uses its index position (3rd option in list)
+        licenseSelect = Select(submit_page.basics_license_dropdown)
+        licenseSelect.select_by_visible_text('CC0 1.0 Universal')
+        #Need to scroll down since the Keyword/tags section is obscured by the Dev mode warning in the test environments
+        currentYPos = driver.execute_script('return window.scrollY;')
+        driver.execute_script("window.scrollTo(0, arguments[0])", currentYPos + 200)
         submit_page.basics_tags_section.click()
         submit_page.basics_tags_input.send_keys('selenium\r')
         submit_page.basics_abstract_input.click()
@@ -86,11 +96,11 @@ class TestPreprintWorkflow:
         WebDriverWait(driver, 10).until(EC.visibility_of(preprint_detail.title))
 
         assert preprint_detail.title.text == project_with_file.title
-        match = re.search(r'Supplemental Materials\s+test\.osf\.io/([a-z0-9]{5})', preprint_detail.view_page.text)
+        match = re.search(r'Supplemental Materials\s+([a-z0-9]{4,8})\.osf\.io/([a-z0-9]{5})', preprint_detail.view_page.text)
         assert match is not None
 
         # Delete supplemental project created during workflow
-        supplemental_guid = match.group(1)
+        supplemental_guid = match.group(2)
         osf_api.delete_project(session, supplemental_guid, None)
 
     @markers.smoke_test

--- a/tests/test_preprints.py
+++ b/tests/test_preprints.py
@@ -3,9 +3,12 @@ import markers
 import settings
 import logging
 import re
+import os
 
 from api import osf_api
 from utils import find_current_browser
+from datetime import datetime
+from time import sleep
 from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.support.select import Select
@@ -31,10 +34,21 @@ def landing_page(driver):
 @pytest.mark.usefixtures('must_be_logged_in')
 class TestPreprintWorkflow:
 
+    @pytest.fixture()
+    def preprint_project(self, session):
+        now = datetime.now()
+        dtStamp = now.strftime('%m%d%Y-%H%M%S')
+        preprintTitle = 'OSF Test Preprint created on ' + dtStamp
+        tags = ['preprint test', os.environ['PYTEST_CURRENT_TEST']]
+        preprint_project = osf_api.create_project(session, title=preprintTitle, tags=tags)
+        osf_api.upload_fake_file(session, preprint_project)
+        yield preprint_project
+        preprint_project.delete()
+
     @markers.dont_run_on_prod
     @markers.core_functionality
     @pytest.mark.usefixtures('delete_user_projects_at_setup')
-    def test_create_preprint_from_landing(self, session, driver, landing_page, project_with_file):
+    def test_create_preprint_from_landing(self, session, driver, landing_page, preprint_project):
 
         landing_page.add_preprint_button.click()
         submit_page = PreprintSubmitPage(driver, verify=True)
@@ -65,7 +79,7 @@ class TestPreprintWorkflow:
         submit_page.public_data_input.send_keys_deliberately('https://osf.io/')
         # Need to scroll down since the Preregistration radio buttons are obscured by the Dev mode warning in test environments
         currentYPos = driver.execute_script('return window.scrollY;')
-        driver.execute_script("window.scrollTo(0, arguments[0])", currentYPos + 200)
+        driver.execute_script('window.scrollTo(0, arguments[0])', currentYPos + 200)
         assert submit_page.preregistration_input.absent()
         submit_page.preregistration_no_button.click()
         assert submit_page.preregistration_input.present()
@@ -76,13 +90,13 @@ class TestPreprintWorkflow:
         submit_page.save_author_assertions.click()
 
         submit_page.basics_license_dropdown.click()
-        # The order of the options in the license dropdown is not consistent across test environments, so we can't use the 
+        # The order of the options in the license dropdown is not consistent across test environments, so we can't use the
         # basics_universal_license element as defined in pages/preprints.py since it uses its index position (3rd option in list)
         licenseSelect = Select(submit_page.basics_license_dropdown)
         licenseSelect.select_by_visible_text('CC0 1.0 Universal')
         # Need to scroll down since the Keyword/tags section is obscured by the Dev mode warning in the test environments
         currentYPos = driver.execute_script('return window.scrollY;')
-        driver.execute_script("window.scrollTo(0, arguments[0])", currentYPos + 200)
+        driver.execute_script('window.scrollTo(0, arguments[0])', currentYPos + 200)
         submit_page.basics_tags_section.click()
         submit_page.basics_tags_input.send_keys('selenium\r')
         submit_page.basics_abstract_input.click()
@@ -114,7 +128,76 @@ class TestPreprintWorkflow:
         preprint_detail = PreprintDetailPage(driver, verify=True)
         WebDriverWait(driver, 10).until(EC.visibility_of(preprint_detail.title))
 
-        assert preprint_detail.title.text == project_with_file.title
+        assert preprint_detail.title.text == preprint_project.title
+        # All 3 Author Assertion sections on Detail page are not displaying in Stage 1 for some reason
+        if not settings.STAGE1:
+            assert preprint_detail.coi_assert_container.text == 'Conflict of InterestNo'
+            preprint_detail.coi_dropdown_arrow.click()
+            assert preprint_detail.dropdown_content.text == 'Author asserted no Conflict of Interest'
+            assert preprint_detail.pub_data_assert_container.text == 'Public DataAvailable'
+            preprint_detail.pub_data_dropdown_arrow.click()
+            assert preprint_detail.dropdown_content.text == 'https://osf.io/'
+            assert preprint_detail.prereg_assert_container.text == 'PreregistrationNo'
+            preprint_detail.prereg_dropdown_arrow.click()
+            assert preprint_detail.dropdown_content.text == 'QA Testing'
+        assert preprint_detail.abstract_text.text == 'Center for Open Selenium'
+        assert preprint_detail.license_text.text == 'License\nCC0 1.0 Universal'
+        preprint_detail.license_detail_arrow.click()
+        assert 'Statement of Purpose' in preprint_detail.license_detail_text.text
+        assert preprint_detail.discipline_text.text == 'Architecture'
+        assert preprint_detail.fileName.text == 'osf selenium test file for testing because its fake.txt'
+
+        match = re.search(r'Supplemental Materials\s+([a-z0-9]{4,8})\.osf\.io/([a-z0-9]{5})', preprint_detail.view_page.text)
+        assert match is not None
+        sleep(3)
+
+        # Now go back to the OSF landing page and search for the preprint we just created and verify that it appears in search
+        # results and that we can open the details page from there
+        landing_page.goto()
+        landing_page.search_input.click()
+        landing_page.search_input.send_keys(preprint_project.title)
+        landing_page.search_button.click()
+        discover_page = PreprintDiscoverPage(driver, verify=True)
+        discover_page.loading_indicator.here_then_gone()
+        search_results = discover_page.search_results
+        # It may take a few seconds for the newly created preprint to appear in the search results
+        preprint_found = False
+        count = 0
+        while not preprint_found:
+            count += 1
+            if search_results[0].text == preprint_project.title:
+                preprint_found = True
+            else:
+                discover_page.search_button.click()
+                sleep(1)
+                discover_page.loading_indicator.here_then_gone()
+                # need to refresh the search results list
+                search_results = driver.find_elements(By.CSS_SELECTOR, '.search-result h4 > a')
+                if count > 5:
+                    raise Exception('Could not find preprint in search results')
+                    break
+
+        search_results[0].click()
+        preprint_detail = PreprintDetailPage(driver, verify=True)
+        WebDriverWait(driver, 10).until(EC.visibility_of(preprint_detail.title))
+        assert preprint_detail.title.text == preprint_project.title
+        if not settings.STAGE1:
+            assert preprint_detail.coi_assert_container.text == 'Conflict of InterestNo'
+            preprint_detail.coi_dropdown_arrow.click()
+            assert preprint_detail.dropdown_content.text == 'Author asserted no Conflict of Interest'
+            assert preprint_detail.pub_data_assert_container.text == 'Public DataAvailable'
+            preprint_detail.pub_data_dropdown_arrow.click()
+            assert preprint_detail.dropdown_content.text == 'https://osf.io/'
+            assert preprint_detail.prereg_assert_container.text == 'PreregistrationNo'
+            preprint_detail.prereg_dropdown_arrow.click()
+            assert preprint_detail.dropdown_content.text == 'QA Testing'
+        assert preprint_detail.abstract_text.text == 'Center for Open Selenium'
+        assert preprint_detail.license_text.text == 'License\nCC0 1.0 Universal'
+        preprint_detail.license_detail_arrow.click()
+        assert 'Statement of Purpose' in preprint_detail.license_detail_text.text
+        assert preprint_detail.discipline_text.text == 'Architecture'
+        assert preprint_detail.fileName.text == 'osf selenium test file for testing because its fake.txt'
+
         match = re.search(r'Supplemental Materials\s+([a-z0-9]{4,8})\.osf\.io/([a-z0-9]{5})', preprint_detail.view_page.text)
         assert match is not None
 


### PR DESCRIPTION
<!-- Before you submit your Pull Request, please confirm that:

     - Any test that will create public data either has the `QAtest` tag or the `dont_run_on_production` marker
     - `core_functionality` is marked as such
     - Your tests will be able to run on *all* servers (all stagings, test)
 -->


## Purpose
To apply fixes to tests/test_preprints.py as described in 4 different tickets. See details below.

## Summary of Changes

1. ENG-2506: Added steps to test_create_preprint_from_landing in tests/test_preprints.py to scroll down the page so that certain elements will not be obscured by the Dev Mode warning message displayed at the bottom of the page in the test environments. This is especially necessary when running on smaller laptop screens. Also updated the way we select the license type from the dropdown listbox since there are inconsistencies in the order of the items in the list.  We can no longer choose by index/position number and must choose by the actual text of item in the list.  Lastly, I updated the regular expression used to get the guid of the Supplemental Materials project so that the project can be deleted as cleanup.  The previous version of the regular expression only worked in the test environment, so I updated it to work in all staging environments as well.
2. ENG-1424: Modified the class TestBrandedProviders in tests/tests_preprints.py to include all branded providers not just those with custom domains and added steps to verify the current url of the branded provider preprint landing page.  If the branded provider does have a custom domain we now verify the current url against the expected domain from the osf api attributes.  Also created a new class TestCustomDomainsInProd for testing the preprint detail page for providers with custom domains in prod only.  Thus the current test steps as performed in the nightly Production Smoke test runs are not effected by the other code changes.
3. ENG-2022: Added several assert statements to test_create_preprint_from_landing in tests/test_preprints.py in order to verify the condition or presence of elements in the Author Assertions and Conflict of Interest sections on the Submit Preprint form.  These changes also required modifications to pages/preprints.py.
4. ENG-1015: Modified test_create_preprint_from_landing in tests/test_preprints.py to create a preprint with a unique name each time by appending a date and time stamp to the preprint title.  Steps were also added to test the preprint search capabilities by searching for this uniquely named preprint from the Preprint Landing/Discover page.  Additional verification steps were also added to verify various elements on the Preprint Details page for the newly created preprint.  These changes also required modifications to pages/preprints.py.

## Reviewer's Actions
`git fetch <remote> pull/<PR_number>/head:testFix/preprints`

Run this test using
`tests/tests_preprints.py -s -v`

## Testing Changes Moving Forward
N/A

## Ticket

1. ENG-2506: SEL: Meetings: Preprint: Create preprint form landing  
https://openscience.atlassian.net/browse/ENG-2506
2. ENG-1424: SEL: Test all preprint service providers
https://openscience.atlassian.net/browse/ENG-1424
3. ENG-2022: SEL: Verify Author Assertions
https://openscience.atlassian.net/browse/ENG-2022
4. ENG-1015: SEL: Preprints: stay on current server when clicking search result https://openscience.atlassian.net/browse/ENG-1015

