### PR TITLE
Update several button locators on My Quick Files page

### DIFF
--- a/pages/quickfiles.py
+++ b/pages/quickfiles.py
@@ -27,12 +27,12 @@ class QuickfilesPage(BaseQuickfilesPage, GuidBasePage):
     loading_indicator = Locator(By.CSS_SELECTOR, '.ball-scale')
     upload_button = Locator(By.CSS_SELECTOR, '.dz-upload-button')
     share_button = Locator(By.CSS_SELECTOR, '.btn .fa-share-alt')
-    view_button = Locator(By.CSS_SELECTOR, '.btn .fa-file-o')
+    view_button = Locator(By.CSS_SELECTOR, '[data-test-view-button]')
     help_button = Locator(By.CSS_SELECTOR, '.btn .fa-info')
     filter_button = Locator(By.CSS_SELECTOR, '.btn .fa-search')
-    rename_button = Locator(By.CSS_SELECTOR, '.btn .fa-pencil')
-    delete_button = Locator(By.CSS_SELECTOR, '.btn .fa-trash')
-    move_button = Locator(By.CSS_SELECTOR, '.btn .fa-level-up')
+    rename_button = Locator(By.CSS_SELECTOR, '[data-test-rename-file-button]')
+    delete_button = Locator(By.CSS_SELECTOR, '[data-test-delete-file-button]')
+    move_button = Locator(By.CSS_SELECTOR, '[data-test-move-button]')
 
     # Group Locators
     files = GroupLocator(By.CSS_SELECTOR, '._file-browser-item_1v8xgw')


### PR DESCRIPTION
<!-- Before you submit your Pull Request, please confirm that:

     - Any test that will create public data either has the `QAtest` tag or the `dont_run_on_production` marker
     - `core_functionality` is marked as such
     - Your tests will be able to run on *all* servers (all stagings, test)
 -->


## Purpose
To fix the failing test: tests/test_quickfiles.py in the nightly Selenium Staging Tests run.

## Summary of Changes
The test was initially failing due to a no-longer valid locator definition for the View button on the My Quick Files page.  After fixing that button I found 3 other buttons (Rename, Delete, and Move) that were also failing in subsequent test steps.  So I updated all 4 of the button locators.  Other buttons on this page have older locator definitions that still work at this point but are not ideal.  These and other updates to the quickfiles test will be handled in a separate ticket.


## Reviewer's Actions
`git fetch <remote> pull/<PR_number>/head:testFix/quickfiles`

Run this test using
`tests/test_quickfiles.py -s -v`

## Testing Changes Moving Forward
Another ticket will be created to handle additional upgrades to the quickfiles test. 


## Ticket
ENG-2838: SEL: Quickfiles test failing in nightly Selenium Staging Tests run https://openscience.atlassian.net/browse/ENG-2838
