### PR TITLE
[ENG-2863] - Improvements to Navbar test to reduce failures in nightly test runs

### DIFF
--- a/pages/base.py
+++ b/pages/base.py
@@ -38,6 +38,22 @@ class BasePage(BaseElement):
         else:
             self.check_page()
 
+    def goto_with_reload(self):
+        """An extension of the goto method above to be used in instances where the first attempt
+        to load a page takes too long or hangs.  This can often happen while running remotely using
+        BrowserStack.  If the first attempt at goto fails then we want to refresh the page and try
+        to load the page again.  This method serves as a workaround solution to issues that we are
+        having while running the nightly Selenium test suites in BrowserStack.  It does not replace
+        the existing goto method that is called by most of the Selenium tests.  This method will
+        only be called by tests that experience page loading timeout issues in BrowserStack.
+        (ex: test_navbar.py)
+        """
+        try:
+            self.goto()
+        except PageException:
+            self.reload()
+            self.goto()
+
     def check_page(self):
         if not self.verify():
             # handle any specific kind of error before go to page exception

--- a/pages/institutions.py
+++ b/pages/institutions.py
@@ -10,14 +10,13 @@ class InstitutionsLandingPage(OSFBasePage):
     url = settings.OSF_HOME + '/institutions/'
 
     #TODO fix insitution typo
-    identity = Locator(By.CSS_SELECTOR, 'div[data-test-insitutions-header]')
+    identity = Locator(By.CSS_SELECTOR, 'div[data-test-insitutions-header]', settings.VERY_LONG_TIMEOUT)
 
     search_bar = Locator(By.CSS_SELECTOR, '.ember-text-field')
 
     # Group Locators
     institution_list = GroupLocator(By.CSS_SELECTOR, 'span[data-test-institution-name]')
 
-    #TODO: add institutional navbar
     navbar = ComponentLocator(InstitutionsNavbar)
 
 class InstitutionBrandedPage(OSFBasePage):

--- a/pages/meetings.py
+++ b/pages/meetings.py
@@ -15,7 +15,7 @@ class BaseMeetingsPage(OSFBasePage):
 class MeetingsPage(BaseMeetingsPage):
     url = settings.OSF_HOME + '/meetings/'
 
-    identity = Locator(By.CSS_SELECTOR, 'img[alt="Logo for OSF meeting"]', settings.LONG_TIMEOUT)
+    identity = Locator(By.CSS_SELECTOR, 'img[alt="Logo for OSF meeting"]', settings.VERY_LONG_TIMEOUT)
     register_button = Locator(By.CSS_SELECTOR, 'button[data-test-register-button]', settings.LONG_TIMEOUT)
     register_text = Locator(By.CSS_SELECTOR, 'div[data-test-register-panel-text]')
     upload_button = Locator(By.CSS_SELECTOR, 'button[data-test-upload-button]', settings.LONG_TIMEOUT)

--- a/tests/test_navbar.py
+++ b/tests/test_navbar.py
@@ -109,7 +109,7 @@ class TestOSFHomeNavbarLoggedOut(NavbarTestLoggedOutMixin):
     @pytest.fixture()
     def page(self, driver):
         page = LandingPage(driver)
-        page.goto()
+        page.goto_with_reload()
         return page
 
     def test_my_projects_link_not_present(self, page):
@@ -131,7 +131,7 @@ class TestOSFHomeNavbarLoggedIn(NavbarTestLoggedInMixin):
     @pytest.fixture()
     def page(self, driver, must_be_logged_in):
         page = DashboardPage(driver)
-        page.goto()
+        page.goto_with_reload()
         return page
 
     def test_my_projects_link(self, page, driver):
@@ -150,7 +150,7 @@ class TestPreprintsNavbarLoggedOut(NavbarTestLoggedOutMixin):
     @pytest.fixture()
     def page(self, driver):
         page = PreprintLandingPage(driver)
-        page.goto()
+        page.goto_with_reload()
         return page
 
     def test_search_link(self, page, driver):
@@ -176,7 +176,7 @@ class TestPreprintsNavbarLoggedIn(NavbarTestLoggedInMixin):
     @pytest.fixture()
     def page(self, driver):
         page = PreprintLandingPage(driver)
-        page.goto()
+        page.goto_with_reload()
         return page
 
     def test_add_a_preprint_link(self, page, driver):
@@ -196,7 +196,7 @@ class TestRegistriesNavbarLoggedOut(NavbarTestLoggedOutMixin):
     @pytest.fixture()
     def page(self, driver):
         page = RegistriesLandingPage(driver)
-        page.goto()
+        page.goto_with_reload()
         return page
 
     def test_help_link(self, page, driver):
@@ -224,7 +224,7 @@ class TestRegistriesNavbarLoggedIn(NavbarTestLoggedInMixin):
     @pytest.fixture()
     def page(self, driver):
         page = RegistriesLandingPage(driver)
-        page.goto()
+        page.goto_with_reload()
         return page
 
     def test_add_new_link(self, page, driver):
@@ -239,7 +239,7 @@ class TestMeetingsNavbarLoggedOut(NavbarTestLoggedOutMixin):
     @pytest.fixture()
     def page(self, driver):
         page = MeetingsPage(driver)
-        page.goto()
+        page.goto_with_reload()
         return page
 
     def test_search_link(self, driver, page):
@@ -263,7 +263,7 @@ class TestMeetingsNavbarLoggedIn(NavbarTestLoggedInMixin):
     @pytest.fixture()
     def page(self, driver):
         page = MeetingsPage(driver)
-        page.goto()
+        page.goto_with_reload()
         return page
 
     def test_my_projects_link(self, page, driver):
@@ -282,7 +282,7 @@ class TestInstitutionsNavbarLoggedOut(NavbarTestLoggedOutMixin):
     @pytest.fixture()
     def page(self, driver):
         page = InstitutionsLandingPage(driver)
-        page.goto()
+        page.goto_with_reload()
         return page
 
     def test_search_link(self, driver, page):
@@ -302,7 +302,7 @@ class TestInstitutionsNavbarLoggedIn(NavbarTestLoggedInMixin):
     @pytest.fixture()
     def page(self, driver):
         page = InstitutionsLandingPage(driver)
-        page.goto()
+        page.goto_with_reload()
         return page
 
     def test_my_projects_link(self, page, driver):


### PR DESCRIPTION
<!-- Before you submit your Pull Request, please confirm that:

     - Any test that will create public data either has the `QAtest` tag or the `dont_run_on_production` marker
     - `core_functionality` is marked as such
     - Your tests will be able to run on *all* servers (all stagings, test)
 -->


## Purpose
To reduce the number of navbar test steps that fail on the first attempt and therefore have to be rerun again.


## Summary of Changes
In the nightly Selenium test runs in the Production and Test environments, we have noticed that a number of the navbar test steps in tests/test_navbar.py have been failing on their first attempt.  The nightly tests are setup to rerun failed test steps up to 2 more times, so in most cases the failed navbar test steps do pass on their second or third attempts.  However, we would like to minimize these failures.  The fixes to help reduce test failures are as follows:

1. Increase the wait times to load for the meetings and institutions landing pages in pages/meetings.py and pages/institutions.py.  These two pages account for the largest number of test failures due to page timeouts.  Both of these pages wait times have been increased by using the VERY_LONG_TIMEOUT setting in their respective identity locators.  Currently the VERY_LONG_TIMEOUT is set to 60 seconds.
2. Add a new method to pages/base.py called goto_with_reload().  This new method will first call the existing goto() method to attempt to load a page.  If the page load fails with a PageException then the browser page will be refreshed and a second attempt at loading the page will be made, again by calling the existing goto() method.  We then replace the calls to the old goto() method In tests/test_navbar.py with calls to goto_with_reload() for each of the landing page fixtures used in the test. 


## Reviewer's Actions
`git fetch <remote> pull/<PR_number>/head:testFix/navbar`

Run this test using
`tests/test_navbar.py -s -v`

## Testing Changes Moving Forward
Monitor nightly test runs to make sure the number of navbar test steps failing on first attempt is reduced.


## Ticket
ENG-2863: SEL: Some Navbar Tests are Failing Due to Timeouts in Production Nightly Smoke Test Run https://openscience.atlassian.net/browse/ENG-2863
