### PR TITLE
[ENG-2510] - Fix issue with failing Project Change Title test

### DIFF
--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -29,6 +29,12 @@ class TestProjectDetailPage:
 
         new_title = fake.sentence(nb_words=4)
         assert project_page.title.text != new_title
+        # In some cases (especially with Chrome) the test steps are executed faster than the web page is
+        # really ready for them.  In this particular case the test clicks the title of the project which
+        # is supposed to then produce an input box in which you can change the title.  If the click is
+        # performed before the page is ready, then there is no input box and the test fails.  So we need
+        # to provide a little extra time.  We can do this by waiting on the log widget to load.
+        project_page.log_widget.loading_indicator.here_then_gone()
         project_page.title.click()
         project_page.title_input.clear()
         project_page.title_input.send_keys(new_title)
@@ -122,8 +128,7 @@ class TestForksPage:
         assert len(forks_page.listed_forks) == 1
 
         # Clean-up leftover fork
-        href = forks_page.fork_link.get_attribute('href')
-        fork_guid = href[20:]
+        fork_guid = forks_page.fork_link.get_attribute('data-test-node-title')
         osf_api.delete_project(session, fork_guid, None)
 
 


### PR DESCRIPTION
<!-- Before you submit your Pull Request, please confirm that:

     - Any test that will create public data either has the `QAtest` tag or the `dont_run_on_production` marker
     - `core_functionality` is marked as such
     - Your tests will be able to run on *all* servers (all stagings, test)
 -->


## Purpose
To fix a test step in test_project.py that is periodically failing in the nightly Selenium test runs in the Test environment.


## Summary of Changes
The test: test_change_title in tests/test_project.py sometimes fails in the nightly Selenium Staging test run.  The test opens the project page for an existing project and immediately clicks the title of the project.  This is supposed to produce an input box which you can then use to change the title.  The issue with the test failing is that sometimes the click of the title is performed before the page is ready and the title input box is not produced.  I was able to recreate the issue when running locally on my machine and using the Chrome browser.  To fix the issue we need to add a little more time before clicking the title to allow the project page to finish loading.  This can be accomplished by adding a here_then_gone method call for the log widget loading indicator.  NOTE: I first attempted to add a Webdriverwait statement to wait for the title element to be clickable, but this did not work since the title was already clickable when the test was clicking it before and failing.  The problem isn't that the title isn't clickable, it's that the test is clicking the title before the click actually does anything useful (i.e. producing the input box).  

Also while running test_project.py in all of the test environments I noticed that the cleanup steps in test_create_fork which are supposed to delete the newly created fork project were not working in the staging environments.  Upon further investigation I discovered that it was only coded to work in the test environment.  So I have modified the steps to work in all testing environments (test, staging 1, staging 2, and staging 3).


## Reviewer's Actions
`git fetch <remote> pull/<PR_number>/head:testFix/project`

Run this test using
`tests/test_project.py -s -v`

## Testing Changes Moving Forward
N?A


## Ticket
ENG-2510: SEL: Project: Change Title
https://openscience.atlassian.net/browse/ENG-2510
