### PR TITLE
[ENG-2506] - Various fixes to Preprint test to prevent failures in staging environments

### DIFF
--- a/pages/preprints.py
+++ b/pages/preprints.py
@@ -76,7 +76,6 @@ class PreprintSubmitPage(BasePreprintPage):
     save_author_assertions = Locator(By.CSS_SELECTOR, '[data-test-author-assertions-continue]')
 
     basics_license_dropdown = Locator(By.CSS_SELECTOR, 'select[class="form-control"]', settings.LONG_TIMEOUT)
-    basics_universal_license = Locator(By.CSS_SELECTOR, 'select[class="form-control"] > option:nth-child(3)', settings.QUICK_TIMEOUT)
     basics_tags_section = Locator(By.CSS_SELECTOR, '#preprint-form-basics .tagsinput')
     basics_tags_input = Locator(By.CSS_SELECTOR, '#preprint-form-basics .tagsinput input')
     basics_abstract_input = Locator(By.NAME, 'basicsAbstract')


### PR DESCRIPTION
<!-- Before you submit your Pull Request, please confirm that:

     - Any test that will create public data either has the `QAtest` tag or the `dont_run_on_production` marker
     - `core_functionality` is marked as such
     - Your tests will be able to run on *all* servers (all stagings, test)
 -->


## Purpose
To fix various issues that were causing test failures in tests/test_preprints.py when the test was run in the staging environments.


## Summary of Changes
Added steps to test_create_preprint_from_landing in tests/test_preprints.py to scroll down the page so that certain elements will not be obscured by the Dev Mode warning message displayed at the bottom of the page in the test environments. This is especially necessary when running on smaller laptop screens. Also updated the way we select the license type from the dropdown listbox since there are inconsistencies in the order of the items in the list. We can no longer choose by index/position number and must choose by the actual text of the item in the list. Lastly, I updated the regular expression used to get the guid of the Supplemental Materials project so that the project can be deleted as cleanup. The previous version of the regular expression only worked in the test environment, so I updated it to work in all staging environments as well.

## Reviewer's Actions
`git fetch <remote> pull/<PR_number>/head:testFix/preprints2`

Run this test using
`tests/test_preprints.py -s -v`

## Testing Changes Moving Forward
N/A


## Ticket
ENG-2506: SEL: Preprint: Create preprint from landing
https://openscience.atlassian.net/browse/ENG-2506
