### PR TITLE
fix: avoid error where a str is not an element

### DIFF
--- a/pages/base.py
+++ b/pages/base.py
@@ -94,19 +94,19 @@ class OSFBasePage(BasePage):
     def __init__(self, driver, verify=False):
         super().__init__(driver, verify)
 
-    @property
-    def error_heading(self):
+    def find_error_heading_element(self):
         try:
             error_head = self.driver.find_element(By.CSS_SELECTOR, 'h2#error')
         except NoSuchElementException:
             return None
         else:
-            return error_head.text
+            return error_head
 
     def error_handling(self):
         # If we've got an error message here from osf, grab it
-        if self.error_heading:
-            raise HttpError(self.error_heading.get_attribute('data-http-status-code'))
+        error_heading = self.find_error_heading_element()
+        if error_heading:
+            raise HttpError(error_heading.get_attribute('data-http-status-code'))
 
     def is_logged_in(self):
         return self.navbar.is_logged_in()


### PR DESCRIPTION
<!-- Before you submit your Pull Request, please confirm that:

     - Any test that will create public data either has the `QAtest` tag or the `dont_run_on_production` marker
     - `core_functionality` is marked as such
     - Your tests will be able to run on *all* servers (all stagings, test)
 -->


## Purpose
fix an error in `OsfBasePage`'s error handling


## Summary of Changes
update `OsfBasePage.error_handling()` to do what its comments claim


## Reviewer's Actions
`git fetch <remote> pull/<PR_number>/head:<branch_name>`

Run this test using
`tests/<name_of_test>.py -s -v`

## Testing Changes Moving Forward



## Ticket

https://openscience.atlassian.net/browse/ENG-
