### PR TITLE
[ENG-2832] - Updating locator for first noteworthy project in dashboard test

### DIFF
--- a/pages/dashboard.py
+++ b/pages/dashboard.py
@@ -30,7 +30,7 @@ class DashboardPage(BaseDashboardPage):
     create_project_button = Locator(By.CSS_SELECTOR, '[data-test-create-project-modal-button]', settings.LONG_TIMEOUT)
     view_meetings_button = Locator(By.XPATH, '//a[text()="View meetings"]')
     view_preprints_button = Locator(By.XPATH, '//a[text()="View preprints"]')
-    first_popular_project_entry = Locator(By.CSS_SELECTOR, '._NoteworthyProject__item_ko80g1', settings.LONG_TIMEOUT)
+    first_noteworthy_project = Locator(By.CSS_SELECTOR, '[data-test-noteworthy-project]', settings.LONG_TIMEOUT)
     institutions_carousel_left_arrow = Locator(By.CSS_SELECTOR, '._InstitutionCarousel__control_16pdz4.carousel-control._left_16pdz4')
     institutions_carousel_right_arrow = Locator(By.CSS_SELECTOR, '._InstitutionCarousel__control_16pdz4.carousel-control._right_16pdz4')
 

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -66,10 +66,16 @@ class TestDashboardPage:
         page_institution_names = [i.get_property('name') for i in page_institutions]
         assert set(page_institution_names) == set(api_institution_names)
 
+    # There is some setup involved (not a waffle flag) with getting projects to display in the New and noteworthy
+    # section. Currently this only works in the Stage 1 and Stage 3 environments.
     @pytest.mark.skipif(settings.STAGE2 or settings.TEST, reason='No new and noteworthy node on stage2 or test')
+    @markers.smoke_test
     @markers.core_functionality
     def test_new_and_noteworthy(self, dashboard_page):
-        assert dashboard_page.first_popular_project_entry.present()
+        assert dashboard_page.first_noteworthy_project.present()
+
+    # TODO: Maybe add a test to verify Most popular section if/when we ever figure out how a project becomes
+    # Most Popular
 
     def test_meetings_link(self, driver, dashboard_page):
         dashboard_page.view_meetings_button.click()


### PR DESCRIPTION
<!-- Before you submit your Pull Request, please confirm that:

     - Any test that will create public data either has the `QAtest` tag or the `dont_run_on_production` marker
     - `core_functionality` is marked as such
     - Your tests will be able to run on *all* servers (all stagings, test)
 -->


## Purpose
To make the locator for the first project in the New and noteworthy section on the Dashboard page more accurate.


## Summary of Changes
Updated the locator name and definition of the element that represents the first project in the New and noteworthy section of the Dashboard page. The previous locator actually referenced a class that was not unique and the name of the element was also confusing, as it could also mean the first project listed under the "Most popular" section on the Dashboard page.  Also added some comments to explain why test_new_and_noteworthy is skipped in the Stage 2 and Test environments.


## Reviewer's Actions
`git fetch <remote> pull/<PR_number>/head:testFix/dashboard`

Run this test using
`tests/test_dashboard.py -s -v`

## Testing Changes Moving Forward
N/A


## Ticket
ENG-2832: SEL: Dashboard - test step: test_new_and_noteworthy is failing in Stage 3 https://openscience.atlassian.net/browse/ENG-2832
