### PR TITLE
[ENG-2840] - Upgrade Quick Files Test

### DIFF
--- a/pages/quickfiles.py
+++ b/pages/quickfiles.py
@@ -22,11 +22,12 @@ class QuickfilesPage(BaseQuickfilesPage, GuidBasePage):
     def __init__(self, driver, verify=False, guid=user.id):
         super().__init__(driver, verify, guid)
 
-    # TODO: Add download buttons back in when you have a way to distingish them
     identity = Locator(By.ID, 'quickfiles-dropzone')
     loading_indicator = Locator(By.CSS_SELECTOR, '.ball-scale')
     upload_button = Locator(By.CSS_SELECTOR, 'button[data-analytics-name="Upload"]')
     share_button = Locator(By.CSS_SELECTOR, '[data-test-share-dialog-button]')
+    download_button = Locator(By.CSS_SELECTOR, '[data-test-download-button]')
+    download_as_zip_button = Locator(By.CSS_SELECTOR, '[data-test-download-zip-button]')
     view_button = Locator(By.CSS_SELECTOR, '[data-test-view-button]')
     help_button = Locator(By.CSS_SELECTOR, '[data-test-info-button]')
     filter_button = Locator(By.CSS_SELECTOR, '[data-test-filter-button]')

--- a/pages/quickfiles.py
+++ b/pages/quickfiles.py
@@ -41,4 +41,12 @@ class QuickfilesPage(BaseQuickfilesPage, GuidBasePage):
 
 
 class QuickfileDetailPage(BaseQuickfilesPage, GuidBasePage):
-    identity = Locator(By.CSS_SELECTOR, '._TitleBar_1628nl')
+    identity = Locator(By.CSS_SELECTOR, 'div[data-analytics-scope="File detail"]')
+
+    delete_button = Locator(By.CSS_SELECTOR, '[data-test-delete-button]')
+    download_button = Locator(By.CSS_SELECTOR, '[data-test-download-button]')
+    share_button = Locator(By.CSS_SELECTOR, '[data-test-share-button]')
+    view_button = Locator(By.CSS_SELECTOR, 'button[data-analytics-name="View"]')
+    edit_button = Locator(By.CSS_SELECTOR, 'button[data-analytics-name="Edit"]')
+    revisions_button = Locator(By.CSS_SELECTOR, '[data-test-revisions-tab]')
+    filter_button = Locator(By.CSS_SELECTOR, '[data-test-filter-button]')

--- a/pages/quickfiles.py
+++ b/pages/quickfiles.py
@@ -23,20 +23,20 @@ class QuickfilesPage(BaseQuickfilesPage, GuidBasePage):
         super().__init__(driver, verify, guid)
 
     # TODO: Add download buttons back in when you have a way to distingish them
-    identity = Locator(By.CSS_SELECTOR, '#quickfiles-dropzone')
+    identity = Locator(By.ID, 'quickfiles-dropzone')
     loading_indicator = Locator(By.CSS_SELECTOR, '.ball-scale')
-    upload_button = Locator(By.CSS_SELECTOR, '.dz-upload-button')
-    share_button = Locator(By.CSS_SELECTOR, '.btn .fa-share-alt')
+    upload_button = Locator(By.CSS_SELECTOR, 'button[data-analytics-name="Upload"]')
+    share_button = Locator(By.CSS_SELECTOR, '[data-test-share-dialog-button]')
     view_button = Locator(By.CSS_SELECTOR, '[data-test-view-button]')
-    help_button = Locator(By.CSS_SELECTOR, '.btn .fa-info')
-    filter_button = Locator(By.CSS_SELECTOR, '.btn .fa-search')
+    help_button = Locator(By.CSS_SELECTOR, '[data-test-info-button]')
+    filter_button = Locator(By.CSS_SELECTOR, '[data-test-filter-button]')
     rename_button = Locator(By.CSS_SELECTOR, '[data-test-rename-file-button]')
     delete_button = Locator(By.CSS_SELECTOR, '[data-test-delete-file-button]')
     move_button = Locator(By.CSS_SELECTOR, '[data-test-move-button]')
 
     # Group Locators
     files = GroupLocator(By.CSS_SELECTOR, '._file-browser-item_1v8xgw')
-    file_titles = GroupLocator(By.CSS_SELECTOR, '._file-browser-item_1v8xgw a')
+    file_titles = GroupLocator(By.CSS_SELECTOR, '[data-test-file-item-link]')
 
 
 class QuickfileDetailPage(BaseQuickfilesPage, GuidBasePage):

--- a/pages/quickfiles.py
+++ b/pages/quickfiles.py
@@ -4,6 +4,7 @@ from api import osf_api
 from selenium.webdriver.common.by import By
 
 from components.navbars import EmberNavbar
+from components.dashboard import EmberCreateProjectModal, EmberProjectCreatedModal
 from pages.base import OSFBasePage, GuidBasePage
 from base.locators import Locator, ComponentLocator, GroupLocator
 
@@ -35,9 +36,27 @@ class QuickfilesPage(BaseQuickfilesPage, GuidBasePage):
     delete_button = Locator(By.CSS_SELECTOR, '[data-test-delete-file-button]')
     move_button = Locator(By.CSS_SELECTOR, '[data-test-move-button]')
 
+    filter_input = Locator(By.CSS_SELECTOR, '[data-test-filter-input]')
+    filter_close_button = Locator(By.CSS_SELECTOR, '[data-test-close-filter]')
+    generic_modal = Locator(By.CSS_SELECTOR, '.modal-title')
+    help_modal_close_button = Locator(By.CSS_SELECTOR, '[data-test-close-current-modal]')
+    share_popover = Locator(By.CSS_SELECTOR, '[data-test-file-share-copyable-text]')
+    move_create_new_project_button = Locator(By.CSS_SELECTOR, '[data-test-ps-new-project-button]')
+    move_existing_project_button = Locator(By.CSS_SELECTOR, '[data-test-ps-existing-project-button]')
+    move_modal_close_button = Locator(By.CSS_SELECTOR, '[data-test-move-to-project-modal-close-button]')
+    confirm_delete_button = Locator(By.CSS_SELECTOR, '[data-test-delete-file-confirm-button]')
+    flash_message = Locator(By.CSS_SELECTOR, '.flash-message')
+    rename_input = Locator(By.CSS_SELECTOR, '[data-test-rename-field="rename"]')
+    rename_save_button = Locator(By.CSS_SELECTOR, '[data-test-save-rename]')
+    rename_close_button = Locator(By.CSS_SELECTOR, '[data-test-close-rename]')
+
     # Group Locators
     files = GroupLocator(By.CSS_SELECTOR, '._file-browser-item_1v8xgw')
     file_titles = GroupLocator(By.CSS_SELECTOR, '[data-test-file-item-link]')
+
+    # Components
+    create_project_modal = ComponentLocator(EmberCreateProjectModal)
+    project_created_modal = ComponentLocator(EmberProjectCreatedModal)
 
 
 class QuickfileDetailPage(BaseQuickfilesPage, GuidBasePage):

--- a/tests/test_quickfiles.py
+++ b/tests/test_quickfiles.py
@@ -23,7 +23,16 @@ class TestQuickfilesLoggedIn:
     def test_quickfile_exists(self, driver, my_quickfiles):
         my_quickfiles.loading_indicator.here_then_gone()
         my_quickfiles.file_titles[0].click()
-        QuickfileDetailPage(driver, verify=True)
+        quickfileDetail = QuickfileDetailPage(driver, verify=True)
+
+        # verify expected buttons on Quickfiles Detail page
+        assert quickfileDetail.delete_button.present()
+        assert quickfileDetail.download_button.present()
+        assert quickfileDetail.share_button.present()
+        assert quickfileDetail.view_button.present()
+        assert quickfileDetail.edit_button.present()
+        assert quickfileDetail.revisions_button.present()
+        assert quickfileDetail.filter_button.present()
 
     def test_expected_buttons(self, my_quickfiles):
         # Check expected buttons when file is not selected
@@ -68,7 +77,16 @@ class AnothersQuickfilesMixin:
     def test_quickfile_exists(self, driver, anothers_quickfiles):
         anothers_quickfiles.loading_indicator.here_then_gone()
         anothers_quickfiles.file_titles[0].click()
-        QuickfileDetailPage(driver, verify=True)
+        quickfileDetail = QuickfileDetailPage(driver, verify=True)
+
+        # verify expected buttons on Quickfiles Detail page
+        assert quickfileDetail.delete_button.absent()
+        assert quickfileDetail.download_button.present()
+        assert quickfileDetail.share_button.present()
+        assert quickfileDetail.view_button.present()
+        assert quickfileDetail.edit_button.absent()
+        assert quickfileDetail.revisions_button.present()
+        assert quickfileDetail.filter_button.present()
 
     def test_expected_buttons(self, anothers_quickfiles):
         # Check expected buttons when file is not selected

--- a/tests/test_quickfiles.py
+++ b/tests/test_quickfiles.py
@@ -1,8 +1,13 @@
 import pytest
 import markers
+import re
 from api import osf_api
 
 from pages.quickfiles import QuickfilesPage, QuickfileDetailPage
+from pages.project import ProjectPage
+from selenium.webdriver.support import expected_conditions as EC
+from selenium.webdriver.common.by import By
+from selenium.webdriver.common.keys import Keys
 
 
 @pytest.fixture()
@@ -63,6 +68,95 @@ class TestQuickfilesLoggedIn:
         assert my_quickfiles.help_button.present()
 
         assert my_quickfiles.download_as_zip_button.absent()
+
+    def test_help_button(self, my_quickfiles):
+        my_quickfiles.loading_indicator.here_then_gone()
+        # click the Help button and verify modal window opens
+        my_quickfiles.help_button.click()
+        assert my_quickfiles.generic_modal.present()
+        assert my_quickfiles.generic_modal.text == 'How to use the file browser'
+        my_quickfiles.help_modal_close_button.click()
+
+    def test_share_quickfile(self, my_quickfiles):
+        my_quickfiles.loading_indicator.here_then_gone()
+        my_quickfiles.files[0].click()
+        # click the Share button and verify that popover box appears
+        my_quickfiles.share_button.click()
+        assert my_quickfiles.share_popover.present()
+
+    def test_view_quickfile(self, driver, my_quickfiles):
+        my_quickfiles.loading_indicator.here_then_gone()
+        my_quickfiles.files[0].click()
+        # click the View button and verify that you are navigated to Quickfiles Detail page
+        my_quickfiles.view_button.click()
+        QuickfileDetailPage(driver, verify=True)
+
+    def test_filter_quickfile(self, my_quickfiles):
+        my_quickfiles.loading_indicator.here_then_gone()
+        my_quickfiles.filter_button.click()
+        assert my_quickfiles.filter_input.present()
+        my_quickfiles.filter_input.click()
+        # enter a value in the filter input box that wll filter out the file from the list
+        my_quickfiles.filter_input.send_keys_deliberately('XXXXXX')
+        assert EC.invisibility_of_element_located((By.CSS_SELECTOR, '[data-test-file-icon-and-name]'))
+        # clear the filter input box and verify that the file is visible again
+        for _ in range(5):
+            my_quickfiles.filter_input.send_keys_deliberately(Keys.BACKSPACE)
+        assert EC.visibility_of_element_located((By.CSS_SELECTOR, '[data-test-file-icon-and-name]'))
+        my_quickfiles.filter_close_button.click()
+
+    def test_move_quickfile_to_new_project(self, driver, session, my_quickfiles):
+        my_quickfiles.loading_indicator.here_then_gone()
+        file_name = driver.find_element(By.CSS_SELECTOR, '[data-test-file-icon-and-name]').text
+        my_quickfiles.files[0].click()
+        my_quickfiles.move_button.click()
+        # verify move modal
+        assert my_quickfiles.generic_modal.present()
+        assert my_quickfiles.generic_modal.text == 'Move file to project'
+        assert my_quickfiles.move_create_new_project_button.present()
+        assert my_quickfiles.move_existing_project_button.present()
+        my_quickfiles.move_create_new_project_button.click()
+        new_project_tile = 'OSF Selenium Test Quickfile Move'
+        my_quickfiles.create_project_modal.title_input.send_keys(new_project_tile)
+        my_quickfiles.create_project_modal.create_project_button.click()
+        my_quickfiles.project_created_modal.go_to_project_href_link.click()
+        project_page = ProjectPage(driver, verify=True)
+        assert project_page.title.text == new_project_tile
+        # Capture guid for project so we can delete it later
+        match = re.search(r'osf\.io/([a-z0-9]{5})', driver.current_url)
+        project_guid = match.group(1)
+        # Verify that Quick File is listed in Project Files Widget
+        project_page.file_widget.loading_indicator.here_then_gone()
+        assert project_page.file_widget.component_and_file_titles[3].text == file_name
+        # Go back to My Quick Files page and verify that file is no longer listed there
+        my_quickfiles.goto()
+        my_quickfiles.loading_indicator.here_then_gone()
+        assert len(my_quickfiles.files) == 0
+        # Cleanup - delete the new project
+        osf_api.delete_project(session, project_guid, None)
+
+    def test_delete_quickfile(self, my_quickfiles):
+        my_quickfiles.loading_indicator.here_then_gone()
+        my_quickfiles.files[0].click()
+        my_quickfiles.delete_button.click()
+        my_quickfiles.confirm_delete_button.click()
+        my_quickfiles.flash_message.here_then_gone()
+        assert len(my_quickfiles.files) == 0
+
+    def test_rename_quickfile(self, driver, my_quickfiles):
+        my_quickfiles.loading_indicator.here_then_gone()
+        original_name = driver.find_element(By.CSS_SELECTOR, '[data-test-file-icon-and-name]').text
+        my_quickfiles.files[0].click()
+        my_quickfiles.rename_button.click()
+        assert my_quickfiles.rename_input.present()
+        my_quickfiles.rename_input.click()
+        my_quickfiles.rename_input.clear()
+        new_name = 'osf_selenium_test_renamed_quickfile.txt'
+        assert original_name != new_name
+        my_quickfiles.rename_input.send_keys_deliberately(new_name)
+        my_quickfiles.rename_save_button.click()
+        my_quickfiles.flash_message.here_then_gone()
+        assert driver.find_element(By.CSS_SELECTOR, '[data-test-file-icon-and-name]').text == new_name
 
 
 @markers.dont_run_on_prod

--- a/tests/test_quickfiles.py
+++ b/tests/test_quickfiles.py
@@ -30,10 +30,10 @@ class TestQuickfilesLoggedIn:
         assert my_quickfiles.upload_button.present()
         assert my_quickfiles.filter_button.present()
         assert my_quickfiles.help_button.present()
-        # assert my_quickfiles.download_as_zip_button.present()
+        assert my_quickfiles.download_as_zip_button.present()
 
         assert my_quickfiles.share_button.absent()
-        # assert my_quickfiles.download_button.absent()
+        assert my_quickfiles.download_button.absent()
         assert my_quickfiles.view_button.absent()
         assert my_quickfiles.move_button.absent()
         assert my_quickfiles.delete_button.absent()
@@ -45,7 +45,7 @@ class TestQuickfilesLoggedIn:
         # Check expected buttons when file is selected
         assert my_quickfiles.upload_button.present()
         assert my_quickfiles.share_button.present()
-        # assert my_quickfiles.download_button.present()
+        assert my_quickfiles.download_button.present()
         assert my_quickfiles.view_button.present()
         assert my_quickfiles.move_button.present()
         assert my_quickfiles.delete_button.present()
@@ -53,7 +53,7 @@ class TestQuickfilesLoggedIn:
         assert my_quickfiles.filter_button.present()
         assert my_quickfiles.help_button.present()
 
-        # assert my_quickfiles.download_as_zip_button.absent()
+        assert my_quickfiles.download_as_zip_button.absent()
 
 
 @markers.dont_run_on_prod
@@ -74,11 +74,11 @@ class AnothersQuickfilesMixin:
         # Check expected buttons when file is not selected
         assert anothers_quickfiles.filter_button.present()
         assert anothers_quickfiles.help_button.present()
-        # assert anothers_quickfiles.download_as_zip_button.present()
+        assert anothers_quickfiles.download_as_zip_button.present()
 
         assert anothers_quickfiles.upload_button.absent()
         assert anothers_quickfiles.share_button.absent()
-        # assert anothers_quickfiles.download_button.absent()
+        assert anothers_quickfiles.download_button.absent()
         assert anothers_quickfiles.view_button.absent()
         assert anothers_quickfiles.move_button.absent()
         assert anothers_quickfiles.delete_button.absent()
@@ -91,7 +91,7 @@ class AnothersQuickfilesMixin:
         assert anothers_quickfiles.filter_button.present()
         assert anothers_quickfiles.help_button.present()
         assert anothers_quickfiles.share_button.present()
-        # assert anothers_quickfiles.download_button.present()
+        assert anothers_quickfiles.download_button.present()
         assert anothers_quickfiles.view_button.present()
 
         assert anothers_quickfiles.upload_button.absent()
@@ -99,7 +99,7 @@ class AnothersQuickfilesMixin:
         assert anothers_quickfiles.delete_button.absent()
         assert anothers_quickfiles.rename_button.absent()
 
-        # assert anothers_quickfiles.download_as_zip_button.absent()
+        assert anothers_quickfiles.download_as_zip_button.absent()
 
 
 @markers.dont_run_on_prod


### PR DESCRIPTION
<!-- Before you submit your Pull Request, please confirm that:

     - Any test that will create public data either has the `QAtest` tag or the `dont_run_on_production` marker
     - `core_functionality` is marked as such
     - Your tests will be able to run on *all* servers (all stagings, test)
 -->


## Purpose
To upgrade and enhance the Quick Files test to make it more robust and useful.


## Summary of Changes

- Update several of the locators of elements on the Quick Files page (pages/quickfiles.py) so that they are using more relevant values and not the names of font awesome icons.
- Add “Download” and “Download as zip” buttons to pages/quickfiles.py in the QuickfilesPage class.   Also uncomment the associated assert statements for these buttons in tests/test_quickfiles.py.
- Add buttons to QuickfileDetailPage class in pages/quickfiles and associated assert statements to tests/test_quickfiles.py. 
- Create additional Quick Files tests: test_help_button, test_share_quickfile, test_view_quickfile, test_filter_quickfile, test_move_quickfile_to_new_project, test_delete_quickfile, and test_rename_quickfile. 


## Reviewer's Actions
`git fetch <remote> pull/<PR_number>/head:testFix/quickfiles`

Run this test using
`tests/test_quickfiles.py -s -v`

## Testing Changes Moving Forward
N/A


## Ticket
ENG-2840: SEL: Quickfiles Test - Audit test and apply upgrades
https://openscience.atlassian.net/browse/ENG-2840
