### PR TITLE
[ENG-2862] My Registrations Page

### DIFF
--- a/components/navbars.py
+++ b/components/navbars.py
@@ -151,7 +151,8 @@ class RegistriesNavbar(EmberNavbar):
         By.CSS_SELECTOR, 'a[data-analytics-name="Settings"]'
     )
 
-    add_new_link = Locator(By.CSS_SELECTOR, 'a[data-test-add-new-button]')
+    add_new_link = Locator(By.CSS_SELECTOR, 'a[data-test-add-new-button][href="/registries/osf/new"]')
+    my_registrations_link = Locator(By.CSS_SELECTOR, 'a[data-test-add-new-button][href="/registries/my-registrations"]')
 
     def verify(self):
         return self.current_service.text == 'REGISTRIES'

--- a/pages/registrations.py
+++ b/pages/registrations.py
@@ -8,3 +8,11 @@ from pages.base import OSFBasePage
 class MyRegistrationsPage(OSFBasePage):
     url = settings.OSF_HOME + '/registries/my-registrations/'
     identity = Locator(By.CSS_SELECTOR, 'div[data-analytics-scope="My Registrations page"]')
+
+    drafts_tab = Locator(By.CSS_SELECTOR, '[data-test-my-registrations-nav="drafts"]')
+    no_drafts_message = Locator(By.CSS_SELECTOR, 'p[data-test-draft-list-no-drafts]')
+    create_a_registration_button_drafts = Locator(By.CSS_SELECTOR, 'a[data-test-my-reg-drafts-add-new-button]')
+
+    submissions_tab = Locator(By.CSS_SELECTOR, '[data-test-my-registrations-nav="submitted"]')
+    no_submissions_message = Locator(By.CSS_SELECTOR, 'p[data-test-draft-list-no-registrations]')
+    create_a_registration_button_submitted = Locator(By.CSS_SELECTOR, 'a[data-test-my-reg-registrations-add-new-button]')

--- a/pages/registrations.py
+++ b/pages/registrations.py
@@ -12,7 +12,9 @@ class MyRegistrationsPage(OSFBasePage):
     drafts_tab = Locator(By.CSS_SELECTOR, '[data-test-my-registrations-nav="drafts"]')
     no_drafts_message = Locator(By.CSS_SELECTOR, 'p[data-test-draft-list-no-drafts]')
     create_a_registration_button_drafts = Locator(By.CSS_SELECTOR, 'a[data-test-my-reg-drafts-add-new-button]')
+    draft_registration_title = Locator(By.CSS_SELECTOR, 'a[data-analytics-name="view_registration"]')
 
     submissions_tab = Locator(By.CSS_SELECTOR, '[data-test-my-registrations-nav="submitted"]')
     no_submissions_message = Locator(By.CSS_SELECTOR, 'p[data-test-draft-list-no-registrations]')
     create_a_registration_button_submitted = Locator(By.CSS_SELECTOR, 'a[data-test-my-reg-registrations-add-new-button]')
+    public_registration_title = Locator(By.CSS_SELECTOR, 'a[data-test-node-title]')

--- a/pages/registrations.py
+++ b/pages/registrations.py
@@ -1,0 +1,10 @@
+import settings
+
+from selenium.webdriver.common.by import By
+from base.locators import Locator
+from pages.base import OSFBasePage
+
+
+class MyRegistrationsPage(OSFBasePage):
+    url = settings.OSF_HOME + '/registries/my-registrations/'
+    identity = Locator(By.CSS_SELECTOR, 'div[data-analytics-scope="My Registrations page"]')

--- a/pages/registries.py
+++ b/pages/registries.py
@@ -62,4 +62,8 @@ class RegistrationDetailPage(GuidBasePage):
 
 class RegistrationAddNewPage(BaseRegistriesPage):
     url = settings.OSF_HOME + '/registries/osf/new'
-    identity = Locator(By.CLASS_NAME, 'Application__page', settings.LONG_TIMEOUT)
+    identity = Locator(By.CSS_SELECTOR, 'form[data-test-new-registration-form]', settings.LONG_TIMEOUT)
+
+
+class RegistrationDraftPage(BaseRegistriesPage):
+    identity = Locator(By.CSS_SELECTOR, 'nav[data-test-side-nav]', settings.LONG_TIMEOUT)

--- a/tests/test_my_registrations.py
+++ b/tests/test_my_registrations.py
@@ -1,6 +1,6 @@
 import pytest
 from pages.registrations import MyRegistrationsPage
-from pages.registries import RegistrationAddNewPage
+from pages.registries import RegistrationAddNewPage, RegistrationDraftPage, RegistrationDetailPage
 
 
 class TestMyRegistrationsPageEmpty:
@@ -23,3 +23,23 @@ class TestMyRegistrationsPageEmpty:
         assert "You don't have any submitted registrations." in registrations_page.no_submissions_message.text
         registrations_page.create_a_registration_button_submitted.click()
         RegistrationAddNewPage(driver, verify=True)
+
+
+class TestMyRegistrationsUserTwo:
+    """User two has a public registration and a registration in the draft state for test purposes.
+    """
+    @pytest.fixture()
+    def registrations_page(self, driver, must_be_logged_in_as_user_two):
+        my_registrations_page = MyRegistrationsPage(driver)
+        my_registrations_page.goto()
+        return my_registrations_page
+
+    def test_drafts_tab(self, driver, registrations_page):
+        registrations_page.drafts_tab.click()
+        registrations_page.draft_registration_title.click()
+        RegistrationDraftPage(driver, verify=True)
+
+    def test_submissions_tab(self, driver, registrations_page):
+        registrations_page.submissions_tab.click()
+        registrations_page.public_registration_title.click()
+        RegistrationDetailPage(driver, verify=True)

--- a/tests/test_my_registrations.py
+++ b/tests/test_my_registrations.py
@@ -1,8 +1,10 @@
 import pytest
+import markers
 from pages.registrations import MyRegistrationsPage
 from pages.registries import RegistrationAddNewPage, RegistrationDraftPage, RegistrationDetailPage
 
 
+@markers.smoke_test
 class TestMyRegistrationsPageEmpty:
     """This test covers the My Registrations page: https://{home}/registries/my-registrations
     """
@@ -25,6 +27,7 @@ class TestMyRegistrationsPageEmpty:
         RegistrationAddNewPage(driver, verify=True)
 
 
+@markers.smoke_test
 class TestMyRegistrationsUserTwo:
     """User two has a public registration and a registration in the draft state for test purposes.
     """

--- a/tests/test_my_registrations.py
+++ b/tests/test_my_registrations.py
@@ -1,0 +1,25 @@
+import pytest
+from pages.registrations import MyRegistrationsPage
+from pages.registries import RegistrationAddNewPage
+
+
+class TestMyRegistrationsPageEmpty:
+    """This test covers the My Registrations page: https://{home}/registries/my-registrations
+    """
+    @pytest.fixture()
+    def registrations_page(self, driver, must_be_logged_in):
+        my_registrations_page = MyRegistrationsPage(driver)
+        my_registrations_page.goto()
+        return my_registrations_page
+
+    def test_no_drafts(self, driver, registrations_page):
+        registrations_page.drafts_tab.click()
+        assert "You don't have any draft registrations." in registrations_page.no_drafts_message.text
+        registrations_page.create_a_registration_button_drafts.click()
+        RegistrationAddNewPage(driver, verify=True)
+
+    def test_no_registrations(self, driver, registrations_page):
+        registrations_page.submissions_tab.click()
+        assert "You don't have any submitted registrations." in registrations_page.no_submissions_message.text
+        registrations_page.create_a_registration_button_submitted.click()
+        RegistrationAddNewPage(driver, verify=True)

--- a/tests/test_navbar.py
+++ b/tests/test_navbar.py
@@ -29,6 +29,8 @@ from pages.user import (
     ProfileInformationPage,
     UserProfilePage,
 )
+from pages.institutions import InstitutionsLandingPage
+from pages.registrations import MyRegistrationsPage
 
 
 class NavbarTestLoggedOutMixin:
@@ -241,6 +243,10 @@ class TestRegistriesNavbarLoggedIn(NavbarTestLoggedInMixin):
     def test_add_new_link(self, page, driver):
         page.navbar.add_new_link.click()
         RegistrationAddNewPage(driver, verify=True)
+
+    def test_my_registrations_link(self, page, driver):
+        page.navbar.my_registrations_link.click()
+        MyRegistrationsPage(driver, verify=True)
 
 
 @markers.smoke_test


### PR DESCRIPTION
<!-- Before you submit your Pull Request, please confirm that:

     - Any test that will create public data either has the `QAtest` tag or the `dont_run_on_production` marker
     - `core_functionality` is marked as such
     - Your tests will be able to run on *all* servers (all stagings, test)
 -->


## Purpose
Write selenium tests for the newly created My Registrations page. 

1. User A will test the My Registrations page before there are drafts and submissions. 
2. User B will test the My Registrations page with a public registration and a registration in the draft state. 


## Summary of Changes
- Add page to existing navbars test
- Test Drafts registrations tab
- Test Public registrations tab
- Test page as a user with no registrations



## Reviewer's Actions
`git fetch <remote> pull/153/head:feature/my-registrations-page`

Run this test using
`tests/test_my_registrations.py -s -v`

## Testing Changes Moving Forward
N/A


## Ticket

https://openscience.atlassian.net/browse/ENG-2862
