### PR TITLE
[ENG-2915] - Registries Test - Fixing registries search to work in all environments.

### DIFF
--- a/pages/registries.py
+++ b/pages/registries.py
@@ -26,6 +26,7 @@ class RegistriesDiscoverPage(BaseRegistriesPage):
     url = settings.OSF_HOME + '/registries/discover'
 
     identity = Locator(By.CSS_SELECTOR, 'div[data-analytics-scope="Registries Discover page"]')
+    search_box = Locator(By.ID, 'search')
     loading_indicator = Locator(By.CSS_SELECTOR, '.ball-scale', settings.LONG_TIMEOUT)
     osf_filter = Locator(By.CSS_SELECTOR, '[data-test-source-filter-id$="OSF Registries"]')
 


### PR DESCRIPTION
<!-- Before you submit your Pull Request, please confirm that:

     - Any test that will create public data either has the `QAtest` tag or the `dont_run_on_production` marker
     - `core_functionality` is marked as such
     - Your tests will be able to run on *all* servers (all stagings, test)
 -->


## Purpose
To fix test_registries.py test so that it will run successfully in all environments.


## Summary of Changes

- Delete checking of 'OSF Registries" filter checkbox in test_detail_page test step. Attempts to check the filter checkbox resulted in inconsistent results across environments. In stage 1 and stage 3 environments the checkbox is disabled as OSF Registries is the only available provider in those environments.  In stage 2 there were scrolling issues in Firefox since the Dev warning banner at the bottom of the page would often obscure the checkbox. 
- Add steps to search registries using the "affiliations" metadata field.  By entering keyword "affiliations:" followed by the environment name (i.e. "affiliations:stage3") the returned search results on the Registries Discover page are filtered correctly for the test environment. This gets around the issues we have with all test environments sharing the same SHARE server.  This works because in all of the test environments the COS Institution is setup with the environment in its name (ex: "Center for Open Science [Stage2]").
- Add locator for search_box to RegistriesDiscoverPage in pages/registries.py to accompany search addition above.
- Also added @markers.smoke_test to the test_detail_page test step since the test runs successfully in Production anyway and there is no reason not to add it to the nightly smoke test runs.


## Reviewer's Actions
`git fetch <remote> pull/<PR_number>/head:testFix/registries`

Run this test using
`tests/test_registries.py -s -v`

## Testing Changes Moving Forward
N/A


## Ticket
ENG-2915: SEL: Registries - TestRegistriesDiscoverPage::test_detail_page Fails in Staging environments
https://openscience.atlassian.net/browse/ENG-2915
