### PR TITLE
[ENG-2022] - Preprints - Add steps to verify Author Assertions and Conflict of Interest sections

### DIFF
--- a/pages/preprints.py
+++ b/pages/preprints.py
@@ -86,7 +86,9 @@ class PreprintSubmitPage(BasePreprintPage):
 
     authors_save_button = Locator(By.CSS_SELECTOR, '#preprint-form-authors .btn-primary', settings.QUICK_TIMEOUT)
 
-    conflict_of_interest = Locator(By.ID, 'coiNo', settings.QUICK_TIMEOUT)
+    conflict_of_interest_yes = Locator(By.ID, 'coiYes', settings.QUICK_TIMEOUT)
+    conflict_of_interest_no = Locator(By.ID, 'coiNo', settings.QUICK_TIMEOUT)
+    no_coi_text_box = Locator(By.CSS_SELECTOR, '[data-test-has-no-coi]', settings.QUICK_TIMEOUT)
     coi_save_button = Locator(By.CSS_SELECTOR, '[data-test-coi-continue]')
 
     supplemental_create_new_project = Locator(By.CSS_SELECTOR, 'div[class="start"] > div[class="row"] > div:nth-child(2)', settings.QUICK_TIMEOUT)


### PR DESCRIPTION
<!-- Before you submit your Pull Request, please confirm that:

     - Any test that will create public data either has the `QAtest` tag or the `dont_run_on_production` marker
     - `core_functionality` is marked as such
     - Your tests will be able to run on *all* servers (all stagings, test)
 -->


## Purpose
To add verification steps to Author Assertions and Conflict of Interest sections of Submit Preprints page to enhance the current Preprints test. 


## Summary of Changes

- pages/preprints.py - renaming existing conflict of interest "No' checkbox and adding other elements in the Conflict of Interest section
- tests/test_preprints.py - adding verification steps (assert statements) to verify the enabling of Save buttons in the Author Assertions and Conflict of Interest sections and the absence and then appearance of certain fields in the sections based on the user's selection of radio buttons in each section. 


## Reviewer's Actions
`git fetch <remote> pull/<PR_number>/head:testFix/preprints2022`

Run this test using
`tests/test_preprints.py -s -v`

## Testing Changes Moving Forward
N/A


## Ticket
ENG-2022 - SEL: Verify Author Assertions
https://openscience.atlassian.net/browse/ENG-2022
