### PR TITLE
[ENG-1667] - Add steps to verify project list on custom domain institution page

### DIFF
--- a/pages/institutions.py
+++ b/pages/institutions.py
@@ -22,3 +22,8 @@ class InstitutionsLandingPage(OSFBasePage):
 class InstitutionBrandedPage(OSFBasePage):
 
     identity = Locator(By.CSS_SELECTOR, '#fileBrowser > div.db-header.row > div.db-buttonRow.col-xs-12.col-sm-4.col-lg-3 > div > input')
+
+    empty_collection_indicator = Locator(By.CLASS_NAME, 'db-non-load-template')
+
+    # Group Locators
+    project_list = GroupLocator(By.CSS_SELECTOR, '#tb-tbody > div > div > div.tb-row')

--- a/tests/test_institutions.py
+++ b/tests/test_institutions.py
@@ -1,6 +1,11 @@
 import pytest
 import markers
 import settings
+
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support.ui import WebDriverWait
+from selenium.webdriver.support import expected_conditions as EC
+
 from pages.institutions import InstitutionsLandingPage, InstitutionBrandedPage
 
 class TestInstitutionsPage:
@@ -29,5 +34,11 @@ class TestCustomDomains:
         """
         #TODO: Add check for institution name
         driver.get(domain)
-        InstitutionBrandedPage(driver, verify=True)
+        institution_page = InstitutionBrandedPage(driver, verify=True)
         assert domain in driver.current_url
+        # first check if the collection is empty - this may often be the case in the test environments
+        if institution_page.empty_collection_indicator.absent():
+            # wait for projects table to start loading and verify that there are some projects listed
+            WebDriverWait(driver, 60).until(EC.presence_of_element_located((By.CSS_SELECTOR, '#tb-tbody > div > div > div.tb-row')))
+            # projects are loaded in batches in varying sizes - anywhere from 4 to 15 at a time
+            assert len(institution_page.project_list) >= 4


### PR DESCRIPTION
<!-- Before you submit your Pull Request, please confirm that:

     - Any test that will create public data either has the `QAtest` tag or the `dont_run_on_production` marker
     - `core_functionality` is marked as such
     - Your tests will be able to run on *all* servers (all stagings, test)
 -->


## Purpose
Add steps to institutions test to verify that projects load in the table on the branded institution page for institutions with custom domains.


## Summary of Changes

- pages/institutions.py - added locators for elements: empty_collection_indicator and project_list.
- tests/test_institutions.py - added steps to the TestCustomDomains class to first check if there is an empty collection indicator. This should only be present in the testing environments.  If the collection does have projects, then wait for the project list to start loading and then verify that there are projects listed in the table.


## Reviewer's Actions
`git fetch <remote> pull/<PR_number>/head:testFix/institutions`

Run this test using
`tests/test_institution.py -s -v`

## Testing Changes Moving Forward
N/A


## Ticket
ENG-1667: SEL: Institutions - projects page on custom domains takes too long to load
https://openscience.atlassian.net/browse/ENG-1667
