### PR TITLE
Update project page locator due to a11y changes

### DIFF
--- a/pages/project.py
+++ b/pages/project.py
@@ -11,7 +11,7 @@ from base.locators import Locator, ComponentLocator, GroupLocator
 
 class ProjectPage(GuidBasePage):
 
-    identity = Locator(By.CSS_SELECTOR, '#overview > nav#projectSubnav')
+    identity = Locator(By.ID, 'projectScope')
     title = Locator(By.ID, 'nodeTitleEditable', settings.LONG_TIMEOUT)
     title_input = Locator(By.CSS_SELECTOR, '.form-inline input')
     title_edit_submit_button = Locator(By.CSS_SELECTOR, '.editable-submit')


### PR DESCRIPTION
<!-- Before you submit your Pull Request, please confirm that:

     - Any test that will create public data either has the `QAtest` tag or the `dont_run_on_production` marker
     - `core_functionality` is marked as such
     - Your tests will be able to run on *all* servers (all stagings, test)
 -->


## Purpose
To update the project overview page identity locator to accommodate upcoming accessibility changes. 


## Summary of Changes

- pages/project.py - change the identity locator for the Project Overview page since the "overview" id is going away. This "overview" id is actually used on multiple different elements on this page and therefore violates an accessibility rule.  Also the use of the "nav#projectSubnav" was not unique anyway, since it refers to the Project sub-navigation bar that appears on all of the Legacy Project pages (i.e. Files, Wiki, Contributors, Settings, etc.)


## Reviewer's Actions
`git fetch <remote> pull/<PR_number>/head:testFix/project`

Run this test using
`tests/test_project.py -s -v`

## Testing Changes Moving Forward
N/A


## Ticket
N/A
