### PR TITLE
[ENG-1911] Lint: black-isort

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,9 +1,20 @@
 repos:
-- repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v4.0.1
+- repo: https://github.com/psf/black
+  rev: 21.7b0 # Replace by any tag/version: https://github.com/psf/black/tags
   hooks:
-  - id: double-quote-string-fixer
-  - id: trailing-whitespace
+    - id: black
+      args:
+        - "--skip-string-normalization" # Prefer single quotes
+      language_version: python3 # Should be a command that runs python3.6+
+- repo: https://github.com/pycqa/isort
+  rev: 5.9.3
+  hooks:
+  - id: isort
+    args: ["--profile=black",
+           "--filter-files",
+           "--force-grid-wrap=2", #Pycharm profile
+           "--lines-after-imports=2"] #Pycharm profile
+    files: \.py$
 - repo: https://github.com/pycqa/flake8
   rev: 3.9.2
   hooks:
@@ -11,13 +22,12 @@ repos:
       args:
         # Match Black's default line length
         - "--max-line-length=88"
-        - "--max-complexity=18"
-- repo: https://github.com/pycqa/isort
-  rev: 5.9.3
+        # E501: Line too long
+        # W503: line break before binary operator
+        # E203: colons should not have any space before them
+      - "--ignore=E501,W503,E203"
+- repo: https://github.com/pre-commit/pre-commit-hooks
+  rev: v4.0.1
   hooks:
-  - id: isort
-    args: ["--profile=black",
-           "--filter-files",
-           "--force-grid-wrap=2",
-           "--lines-after-imports=2"]
-    files: \.py$
+  - id: double-quote-string-fixer
+  - id: trailing-whitespace

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,3 +8,16 @@ repos:
   rev: 3.9.2
   hooks:
   -   id: flake8
+      args:
+        # Match Black's default line length
+        - "--max-line-length=88"
+        - "--max-complexity=18"
+- repo: https://github.com/pycqa/isort
+  rev: 5.9.3
+  hooks:
+  - id: isort
+    args: ["--profile=black",
+           "--filter-files",
+           "--force-grid-wrap=2",
+           "--lines-after-imports=2"]
+    files: \.py$

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,19 +1,22 @@
 repos:
 - repo: https://github.com/psf/black
-  rev: 21.7b0 # Replace by any tag/version: https://github.com/psf/black/tags
+  rev: 21.7b0
   hooks:
     - id: black
       args:
-        - "--skip-string-normalization" # Prefer single quotes
-      language_version: python3 # Should be a command that runs python3.6+
+        # Prefer single quotes
+        - "--skip-string-normalization"
+      # Should be a command that runs python3.6+
+      language_version: python3
 - repo: https://github.com/pycqa/isort
   rev: 5.9.3
   hooks:
   - id: isort
     args: ["--profile=black",
            "--filter-files",
-           "--force-grid-wrap=2", #Pycharm profile
-           "--lines-after-imports=2"] #Pycharm profile
+           # Pycharm profile
+           "--force-grid-wrap=2",
+           "--lines-after-imports=2"]
     files: \.py$
 - repo: https://github.com/pycqa/flake8
   rev: 3.9.2

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,19 +1,10 @@
 repos:
-- repo: https://github.com/asottile/add-trailing-comma
-  rev: v0.7.0
-  hooks:
-  - id: add-trailing-comma
-    # TODO: Remove this line. For now, we only format the api/ directory
-    files: ^api/
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v1.4.0
+  rev: v4.0.1
   hooks:
   - id: double-quote-string-fixer
   - id: trailing-whitespace
-    exclude: website/static/vendor/*
-  - id: flake8
-    additional_dependencies: ["flake8==3.6.0", "flake8-mutable==1.2.0"]
-- repo: https://github.com/pre-commit/mirrors-jshint
-  rev: v2.9.6
+- repo: https://github.com/pycqa/flake8
+  rev: 3.9.2
   hooks:
-  - id: jshint
+  -   id: flake8

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[tool.black]
+line-length = 88
+skip-string-normalization = true

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 invoke==0.15.0
 selenium==3.141.0
 pytest==3.5.0
-flake8==3.9.1
+flake8==3.9.2
 flake8-quotes==3.2.0
 autopep8==1.3.3
 requests>=2.20.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,5 +8,7 @@ requests>=2.20.0
 pythosf==0.0.9
 environs==3.0.0
 faker==0.9.0
-pre-commit==1.18.3
+pre-commit==2.14.0
 ipdb==0.12.2
+black==21.7b0
+isort==5.9.3

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,11 +1,11 @@
 # E501: Line too long
-# E127: continuation line over-indented for visual indent
-# E128: continuation line under-indented for visual indent
-# E265: block comment should start with #
-# E301: expected 1 blank line, found 0
-# E302: expected 2 blank lines, found 0
-# E266: too many leading '#' for block comment
+# W503: line break before binary operator
+# E203: colons should not have any space before them
 [flake8]
-ignore = E501,E127,E128,E265,E301,E302,E266,E731,N803,N806,E701
-max-line-length = 100
-exclude = .git,tasks/*,settings/*,misc/*,helpers/*,staging/*,selenium/*
+max-line-length = 88
+ignore=E501,W503,E203
+[isort]
+profile = black
+filter_files = true
+force_grid_wrap = 2
+lines_after_imports = 2


### PR DESCRIPTION
<!-- Before you submit your Pull Request, please confirm that:

     - Any test that will create public data either has the `QAtest` tag or the `dont_run_on_production` marker
     - `core_functionality` is marked as such
     - Your tests will be able to run on *all* servers (all stagings, test)
 -->


## Purpose
Update our linting tools to use Black, iSort, and Flake8. But why though?
1. Reduce errors
2. Improve readability
3. Establish common programming guidelines
4. Improve overall quality of the test suite


## Summary of Changes

- Update existing Flake8 linting tool
- Remove outdated/unused pre-commit configs
- Add the latest version of Black to pre-commit hooks
- Add the latest version of iSort with `profile=black` for compatibility


## Reviewer's Actions
`git fetch <remote> pull/162/head:lint/black-isort`
Install the latest tools: `pip3 install -r requirements.txt`
Integrate pre-commit hooks `pre-commit install` (after staging YAML file changes)

Reformat the test suite by using the following commands. (Running them in either order should yield the same results)
1. `black . `
2. `isort .`

Test pre-commit hooks without git: `pre-commit run`

## Testing Changes Moving Forward
A follow-up pull request will include the repository-wide code formatting changes. 


## Ticket
https://openscience.atlassian.net/browse/ENG-1911
