### PR TITLE
[ENG-2884] - Update meetings test to run in Production

### DIFF
--- a/pages/meetings.py
+++ b/pages/meetings.py
@@ -35,7 +35,7 @@ class MeetingDetailPage(BaseMeetingsPage):
     # test url functionality
     url = settings.OSF_HOME + '/view/'
 
-    identity = Locator(By.CSS_SELECTOR, 'button[data-test-meeting-toggle-panel-button]')
+    identity = Locator(By.CSS_SELECTOR, 'div._toggle-button-and-homepage-link-container_1h8tly')
     meeting_title = Locator(By.CSS_SELECTOR, 'h1[data-test-meeting-name]')
     entry_download_button = Locator(By.CSS_SELECTOR,
                                     'li.list-group-item:nth-child(2) > div:nth-child(5) > button:nth-child(1)')

--- a/tests/test_meetings.py
+++ b/tests/test_meetings.py
@@ -10,10 +10,12 @@ from selenium.webdriver.support.wait import WebDriverWait
 @pytest.fixture
 def meetings_page(driver):
     meetings_page = MeetingsPage(driver)
-    meetings_page.goto()
+    meetings_page.goto_with_reload()
     return meetings_page
 
 
+@markers.smoke_test
+@markers.core_functionality
 class TestMeetingsPage:
 
     def test_meetings_landing(self, meetings_page, driver):
@@ -56,7 +58,6 @@ class TestMeetingsPage:
         sorted_top_result = meetings_page.top_meeting_link.text
         assert default_top_result != sorted_top_result
 
-    @markers.core_functionality
     def test_meetings_list(self, meetings_page, driver):
         search_bar = driver.find_element_by_css_selector('div[data-test-meetings-list-search]')
         driver.execute_script('arguments[0].scrollIntoView();', search_bar)
@@ -67,6 +68,8 @@ class TestMeetingsPage:
         assert meeting_name.strip() == meeting_detail.meeting_title.text.strip()
 
 
+@markers.smoke_test
+@markers.core_functionality
 class TestMeetingDetailPage:
 
     @pytest.fixture
@@ -77,7 +80,6 @@ class TestMeetingDetailPage:
         meetings_page.top_meeting_link.click()
         return MeetingDetailPage(driver, verify=True)
 
-    @markers.core_functionality
     def test_meeting_detail(self, meeting_detail_page, driver):
 
         assert meeting_detail_page.entry_download_button.present()


### PR DESCRIPTION
<!-- Before you submit your Pull Request, please confirm that:

     - Any test that will create public data either has the `QAtest` tag or the `dont_run_on_production` marker
     - `core_functionality` is marked as such
     - Your tests will be able to run on *all* servers (all stagings, test)
 -->


## Purpose
To expand the selenium testing coverage in the nightly Production Smoke Test run to include the existing meetings tests.


## Summary of Changes

- pages/meetings.py - update identity locator for Meeting Detail page since the button element that was being used is not consistently present on every Meeting Detail page in Production.
- tests/test_meetings.py - add @markers.smoke_test marker to tests so the nightly Production Smoke Test run will include these meetings tests.  Also changed meetings_page.goto() method to goto_with_reload() after testing using BrowserStack resulted in several random failures due to initial page loads timing out.


## Reviewer's Actions
`git fetch <remote> pull/<PR_number>/head:testFix/meetings`

Run this test using
`tests/test_meetings.py -s -v`

## Testing Changes Moving Forward
NA


## Ticket
ENG-2884: SEL: Meetings: Production Compatibility
https://openscience.atlassian.net/browse/ENG-2884
