### PR TITLE
[ENG-1015] - Update Preprints search to work in all environments

### DIFF
--- a/pages/preprints.py
+++ b/pages/preprints.py
@@ -164,6 +164,11 @@ class PreprintDiscoverPage(BasePreprintPage):
 
     identity = Locator(By.ID, 'share-logo')
     loading_indicator = Locator(By.CSS_SELECTOR, '.ball-scale')
+    search_box = Locator(By.ID, 'searchBox')
+    sort_button = Locator(By.ID, 'sortBy')
+    sort_option_newest_to_oldest = Locator(
+        By.CSS_SELECTOR, '#sortByOptionList > li:nth-child(3) > button'
+    )
 
     # Group Locators
     search_results = GroupLocator(By.CSS_SELECTOR, '.search-result h4 > a')


### PR DESCRIPTION
<!-- Before you submit your Pull Request, please confirm that:

     - Any test that will create public data either has the `QAtest` tag or the `dont_run_on_production` marker
     - `core_functionality` is marked as such
     - Your tests will be able to run on *all* servers (all stagings, test)
 -->


## Purpose
To expand the Preprints test to be able to verify the Preprints Detail page in all testing environments.


## Summary of Changes

- pages/preprints.py - adding necessary elements to the Preprints Discover page class.
- tests/test_preprints.py - adding new class - TestPreprintSearch - with new test - test_preprint_detail_page - that uses the Share searching functionality to search Preprints by the "identifiers" metadata field.  Entering "identifiers:" + environment url in the search input box ensures that the search results in each test environment are only for that environment.  This is necessary since the Share testing server is shared between all testing environments.  Also moved the existing test - test_search_results_exist - under the new class - TestPreprintSearch - since it also involves verifying search results on the Preprint Discover page.


## Reviewer's Actions
`git fetch <remote> pull/<PR_number>/head:testFix/preprints`

Run this test using
`tests/test_preprints.py -s -v`

## Testing Changes Moving Forward
N/A


## Ticket
ENG-1015: SEL: Preprints: stay on current server when clicking search result
https://openscience.atlassian.net/browse/ENG-1015
