### PR TITLE
[ENG-3303] - Update Project Files Download Test to verify downloaded files

### DIFF
--- a/tests/test_project_files.py
+++ b/tests/test_project_files.py
@@ -429,6 +429,14 @@ class TestFilesPage:
         )
 
         try:
+            # If running on local machine, first check if the download file already
+            # exists in the Downloads folder. If so then delete the old copy before
+            # attempting to download a new one.
+            if settings.DRIVER != 'Remote':
+                file_path = os.path.expanduser('~/Downloads/' + file_name)
+                if os.path.exists(file_path):
+                    os.remove(file_path)
+
             files_page = FilesPage(driver, guid=node_id)
             files_page.goto()
 
@@ -463,15 +471,12 @@ class TestFilesPage:
                 )
                 assert file_create_date.date() == current_date.date()
             else:
-                file_path = os.path.expanduser('~/Downloads/' + file_name)
                 # First verify the downloaded file exists
                 assert os.path.exists(file_path)
                 # Next verify the file was downloaded today
                 status = os.stat(file_path)
                 file_create_date = datetime.datetime.fromtimestamp(status.st_ctime)
                 assert file_create_date.date() == current_date.date()
-                # Cleanup - Delete the downloaded file after we have verified it
-                os.remove(file_path)
 
         finally:
             osf_api.delete_addon_files(session, provider, current_browser, guid=node_id)

--- a/tests/test_project_files.py
+++ b/tests/test_project_files.py
@@ -474,9 +474,9 @@ class TestFilesPage:
                 # First verify the downloaded file exists
                 assert os.path.exists(file_path)
                 # Next verify the file was downloaded today
-                file_ctime = os.path.getctime(file_path)
-                file_create_date = datetime.datetime.fromtimestamp(file_ctime)
-                assert file_create_date.date() == current_date.date()
+                file_mtime = os.path.getmtime(file_path)
+                file_mod_date = datetime.datetime.fromtimestamp(file_mtime)
+                assert file_mod_date.date() == current_date.date()
 
         finally:
             osf_api.delete_addon_files(session, provider, current_browser, guid=node_id)

--- a/tests/test_project_files.py
+++ b/tests/test_project_files.py
@@ -1,3 +1,5 @@
+import datetime
+import os
 import time
 
 import pytest
@@ -407,7 +409,6 @@ class TestFilesPage:
         finally:
             osf_api.delete_addon_files(session, provider, current_browser, guid=node_id)
 
-    @pytest.mark.skipif(settings.DRIVER == 'remote', reason='File_Detector Class only ')
     @pytest.mark.parametrize('provider', ['s3', 'dropbox', 'box', 'owncloud'])
     def test_download_file(self, driver, default_project, session, provider):
         current_browser = driver.desired_capabilities.get('browserName')
@@ -444,13 +445,40 @@ class TestFilesPage:
                 not in driver.find_element_by_xpath('/html/body').text
             )
 
+            # Positive Test: Verify that file is actually downloaded to user's machine
+            current_date = datetime.datetime.now()
+            if settings.DRIVER == 'Remote':
+                # First verify the downloaded file exists on the virtual remote machine
+                assert driver.execute_script(
+                    'browserstack_executor: {"action": "fileExists", "arguments": {"fileName": "%s"}}'
+                    % (file_name)
+                )
+                # Next get the file properties and then verify that the file creation date is today
+                file_props = driver.execute_script(
+                    'browserstack_executor: {"action": "getFileProperties", "arguments": {"fileName": "%s"}}'
+                    % (file_name)
+                )
+                file_create_date = datetime.datetime.fromtimestamp(
+                    file_props['created_time']
+                )
+                assert file_create_date.date() == current_date.date()
+            else:
+                file_path = os.path.expanduser('~/Downloads/' + file_name)
+                # First verify the downloaded file exists
+                assert os.path.exists(file_path)
+                # Next verify the file was downloaded today
+                status = os.stat(file_path)
+                file_create_date = datetime.datetime.fromtimestamp(status.st_ctime)
+                assert file_create_date.date() == current_date.date()
+                # Cleanup - Delete the downloaded file after we have verified it
+                os.remove(file_path)
+
         finally:
             osf_api.delete_addon_files(session, provider, current_browser, guid=node_id)
 
 
 """
 TODO:
-- improve downloads test to check for positive result
 - write an uploads test
 
 Addons this test does not cover, and reasons:

--- a/tests/test_project_files.py
+++ b/tests/test_project_files.py
@@ -474,8 +474,8 @@ class TestFilesPage:
                 # First verify the downloaded file exists
                 assert os.path.exists(file_path)
                 # Next verify the file was downloaded today
-                status = os.stat(file_path)
-                file_create_date = datetime.datetime.fromtimestamp(status.st_ctime)
+                file_ctime = os.path.getctime(file_path)
+                file_create_date = datetime.datetime.fromtimestamp(file_ctime)
                 assert file_create_date.date() == current_date.date()
 
         finally:

--- a/utils.py
+++ b/utils.py
@@ -21,6 +21,12 @@ def launch_driver(driver_name=settings.DRIVER, desired_capabilities=None):
         command_executor = 'http://{}:{}@hub.browserstack.com:80/wd/hub'.format(
             settings.BSTACK_USER, settings.BSTACK_KEY
         )
+
+        # NOTE: BrowserStack does support the use of Chrome Options, but we are not
+        # currently using any of them. Below are several steps to setup preferences
+        # that are specific to Firefox.  Currently when running Chrome or Edge in
+        # BrowserStack we are running with the default base install options.
+
         # DeprecationWarning: Please use FirefoxOptions to set browser profile
         from selenium.webdriver import FirefoxProfile
 

--- a/utils.py
+++ b/utils.py
@@ -26,17 +26,20 @@ def launch_driver(driver_name=settings.DRIVER, desired_capabilities=None):
 
         ffp = FirefoxProfile()
         # Set the default download location [0=Desktop, 1=Downloads, 2=Specified location]
-        ffp.set_preference('browser.download.folderList', 2)
-        # Specify the download directory
-        ffp.set_preference('browser.download.dir', 'Users/Public/Downloads')
+        ffp.set_preference('browser.download.folderList', 1)
+
         # Disable the OS-level pop-up modal
         ffp.set_preference('browser.download.manager.showWhenStarting', False)
         ffp.set_preference('browser.helperApps.alwaysAsk.force', False)
+        ffp.set_preference('browser.download.manager.alertOnEXEOpen', False)
+        ffp.set_preference('browser.download.manager.closeWhenDone', True)
+        ffp.set_preference('browser.download.manager.showAlertOnComplete', False)
+        ffp.set_preference('browser.download.manager.useWindow', False)
         # Specify the file types supported by the download
         ffp.set_preference(
             'browser.helperApps.neverAsk.saveToDisk',
             'text/plain, application/octet-stream, application/binary, text/csv, application/csv, '
-            'application/excel, text/comma-separated-values, text/xml, application/xml',
+            'application/excel, text/comma-separated-values, text/xml, application/xml, binary/octet-stream',
         )
         driver = driver_cls(
             command_executor=command_executor,
@@ -71,7 +74,7 @@ def launch_driver(driver_name=settings.DRIVER, desired_capabilities=None):
         ffp.set_preference(
             'browser.helperApps.neverAsk.saveToDisk',
             'text/plain, application/octet-stream, application/binary, text/csv, application/csv, '
-            'application/excel, text/comma-separated-values, text/xml, application/xml',
+            'application/excel, text/comma-separated-values, text/xml, application/xml, binary/octet-stream',
         )
         driver = driver_cls(firefox_profile=ffp)
     else:


### PR DESCRIPTION
<!-- Before you submit your Pull Request, please confirm that:

     - Any test that will create public data either has the `QAtest` tag or the `dont_run_on_production` marker
     - `core_functionality` is marked as such
     - Your tests will be able to run on *all* servers (all stagings, test)
 -->


## Purpose
To improve the existing download file test in test_project_files.py to actually verify that the file download was successful.


## Summary of Changes

- tests/test_project_files.py - adding positive test to existing test_download_file method to actually verify that the downloaded file exists on the user's machine and that the file's creation date is the current test run date.  This download file verification will work on both local machines and when run remotely on BrowserStack.
- utils.py - updating Firefox preferences to use settings required to allow BrowserStack file verification possible. Also adding "binary/octet-stream" to the Firefox preference "browser.helperApps.neverAsk.saveToDisk" so that downloading from the Amazon s3 add-on no longer produces a pop-up modal asking the user if they want to save the downloaded file to disk.


## Reviewer's Actions
`git fetch <remote> pull/<PR_number>/head:testFix/project_files`

Run this test using
`tests/test_project_files.py -s -v`

## Testing Changes Moving Forward
N/A


## Ticket
ENG-3303: SEL: Project Files Test - Improve Downloads Test to actually verify downloaded file
https://openscience.atlassian.net/browse/ENG-3303
