### PR TITLE
[ENG-3345] - Add additional providers check to Prod Preprints Detail Page test

### DIFF
--- a/tests/test_preprints.py
+++ b/tests/test_preprints.py
@@ -248,5 +248,8 @@ class TestBrandedProviders:
             assert search_results
             search_results[0].click()
             PreprintDetailPage(driver, verify=True)
-        else:
+        elif not provider['attributes']['additional_providers']:
+            # Some Preprint Providers may also display preprints from other sources not
+            # just OSF. So we do not want to assert that there are No Results when there
+            # may be results from non-OSF providers.
             assert discover_page.no_results


### PR DESCRIPTION
<!-- Before you submit your Pull Request, please confirm that:

     - Any test that will create public data either has the `QAtest` tag or the `dont_run_on_production` marker
     - `core_functionality` is marked as such
     - Your tests will be able to run on *all* servers (all stagings, test)
 -->


## Purpose
To fix an issue with a test failure in the nightly Production Smoke tests.


## Summary of Changes

- tests/test_preprints.py - adding a check of the "additional_providers" value from the OSF api for Branded Preprint Providers that do not have any OSF Preprints (i.e. total count from api = 0).  Since some Preprint Providers may also show preprints from other sources (non-OSF) on their Discover pages, we do not want to assert that there are "No Results" if the provider has additional providers.


## Reviewer's Actions
`git fetch <remote> pull/<PR_number>/head:testFix/preprints_additionak_providers`

Run this test using
`tests/test_preprints.py -s -v`

## Testing Changes Moving Forward
N/A


## Ticket
ENG-3345: SEL: Preprints Test - Production Failure - TestBrandedProviders::test_detail_page[livedata]
https://openscience.atlassian.net/browse/ENG-3345
