### PR TITLE
[ENG-2930] - Add Smoke Test marker to additional tests to expand Production test coverage

### DIFF
--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -80,10 +80,12 @@ class TestDashboardPage:
     # TODO: Maybe add a test to verify Most popular section if/when we ever figure out how a project becomes
     # Most Popular
 
+    @markers.smoke_test
     def test_meetings_link(self, driver, dashboard_page):
         dashboard_page.view_meetings_button.click()
         assert MeetingsPage(driver).verify()
 
+    @markers.smoke_test
     def test_preprints_link(self, driver, dashboard_page):
         dashboard_page.view_preprints_button.click()
         assert PreprintLandingPage(driver).verify()

--- a/tests/test_institutions.py
+++ b/tests/test_institutions.py
@@ -11,6 +11,7 @@ from pages.institutions import (
 )
 
 
+@markers.smoke_test
 class TestInstitutionsPage:
     @pytest.fixture()
     def landing_page(self, driver):

--- a/tests/test_landing.py
+++ b/tests/test_landing.py
@@ -14,6 +14,7 @@ def landing_page(driver):
     return landing_page
 
 
+@markers.smoke_test
 class TestHomeLandingPage:
     @pytest.fixture()
     def page(self, landing_page):
@@ -26,6 +27,7 @@ class TestHomeLandingPage:
     # TO DO: Come back later and add other tests for elements on OSF Home page - see ENG-826
 
 
+@markers.smoke_test
 class TestRegisteredReportsLandingPage:
     @markers.core_functionality
     def test_landing_page(self, driver):

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -53,6 +53,7 @@ class TestProjectDetailPage:
         project_page.verify()  # Wait for the page to reload
         assert project_page.title.text == new_title
 
+    @markers.smoke_test
     @markers.core_functionality
     def test_log_widget_loads(self, project_page):
         project_page.log_widget.loading_indicator.here_then_gone()
@@ -76,6 +77,7 @@ class TestProjectDetailPage:
         project_page.goto()
         login(driver)
 
+    @markers.smoke_test
     @markers.core_functionality
     def test_file_widget_loads(self, project_page_with_file):
         # Check the uploaded file shows up in the files widget
@@ -118,6 +120,7 @@ class TestProjectDetailAsNonContributor:
 
 
 class TestProjectDetailLoggedOut:
+    @markers.smoke_test
     @markers.core_functionality
     def test_is_private(self, driver, default_project_page):
         # Verify that a logged out user cannot see the project

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -87,6 +87,7 @@ class TestUserSettings:
         profile_settings_page.goto()
         return profile_settings_page
 
+    @markers.smoke_test
     @markers.core_functionality
     def test_user_settings_loads(self, settings_page):
         """Confirm the given user settings page loads."""


### PR DESCRIPTION
<!-- Before you submit your Pull Request, please confirm that:

     - Any test that will create public data either has the `QAtest` tag or the `dont_run_on_production` marker
     - `core_functionality` is marked as such
     - Your tests will be able to run on *all* servers (all stagings, test)
 -->


## Purpose
To expand the nightly Production Smoke Test run to include more testing.


## Summary of Changes
Adding @markers.smoke_test to test steps (or classes where appropriate) so that the following tests will be included in the nightly Production test run:

- test_dashboard.py - test_meetings_link
- test_dashboard.py - test_preprints_link
- test_institutions.py - test_select_institution
- test_institutions.py - test_filter_by_institution
- test_landing.py - TestHomeLandingPage::test_landing_page
- test_landing.py - TestRegisteredReportsLandingPage::test_landing_page
- test_project.py - test_log_widget_loads
- test_project.py - test_file_widget_loads
- test_project.py - TestProjectDetailLoggedOut::test_is_private
- test_user.py - test_user_settings_loads[ProfileInformationPage]
- test_user.py - test_user_settings_loads[AccountSettingsPage]
- test_user.py - test_user_settings_loads[ConfigureAddonsPage
- test_user.py - test_user_settings_loads[NotificationsPage]
- test_user.py - test_user_settings_loads[DeveloperAppsPage]
- test_user.py - test_user_settings_loads[PersonalAccessTokenPage]


## Reviewer's Actions
`git fetch <remote> pull/<PR_number>/head:testFix/smoke-tests`

Run this test using
`tests/test_dashboard.py -s -v`
`tests/test_institutions.py -s -v`
`tests/test_landing.py -s -v`
`tests/test_project.py -s -v`
`tests/test_user.py -s -v`
or 
'pytest tests/ -m "smoke_test" -s -v --collect-only' to see list of tests with smoke_test marker

## Testing Changes Moving Forward
N/A


## Ticket
ENG-2930: SEL: Add smoke_test marker to additional tests to expand Production test coverage
https://openscience.atlassian.net/browse/ENG-2930
