### PR TITLE
[ENG-3379] - Fix User test failures when run in Production

### DIFF
--- a/pages/user.py
+++ b/pages/user.py
@@ -29,7 +29,7 @@ class UserProfilePage(GuidBasePage):
     edit_profile_link = Locator(By.CSS_SELECTOR, '#edit-profile-settings')
 
     # TODO: Seperate out by component if it becomes necessary
-    loading_indicator = Locator(By.CSS_SELECTOR, '.ball-pulse')
+    loading_indicator = Locator(By.CSS_SELECTOR, '.ball-pulse', settings.LONG_TIMEOUT)
 
     # Group Locators
     public_projects = GroupLocator(By.CSS_SELECTOR, '#publicProjects .list-group-item')

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -4,7 +4,6 @@ from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.support.ui import WebDriverWait
 
 import markers
-import settings
 from api import osf_api
 from pages import user
 
@@ -27,14 +26,13 @@ class ProfilePageMixin:
     def profile_page(self, driver):
         raise NotImplementedError()
 
+    @markers.smoke_test
     @markers.core_functionality
     def test_nothings_public(self, profile_page):
-        """Confirm there the user has no public projects."""
+        """Confirm that the user has no public projects."""
+        profile_page.loading_indicator.here_then_gone()
         assert profile_page.no_public_projects_text.present()
         assert profile_page.no_public_components_text.present()
-
-        if settings.PRODUCTION:
-            assert profile_page.no_public_quickfiles.present()
 
     @markers.dont_run_on_prod
     def test_public_lists(self, quickfile, public_project, profile_page):


### PR DESCRIPTION
<!-- Before you submit your Pull Request, please confirm that:

     - Any test that will create public data either has the `QAtest` tag or the `dont_run_on_production` marker
     - `core_functionality` is marked as such
     - Your tests will be able to run on *all* servers (all stagings, test)
 -->


## Purpose
To fix some issues in the User test that caused failures when run in the Production environment.


## Summary of Changes

- pages/user.py - add settings.LONG_TIMEOUT to the loading_indicator locator definition on the User Profile Page. This is necessary because some of the sections on the User Profile page in Production can take several seconds to load.
- tests/test_user.py - add a wait (here_then_gone) on the User Profile page loading indicator to the test_nothings_public  mixin.  And deleted step to verify no public quick files when run in Production, since the section does not appear when the user has no quick files.  Also added smoke_test marker to the mixin so that it will be run in the nightly Production test run.


## Reviewer's Actions
`git fetch <remote> pull/<PR_number>/head:testFix/user`

Run this test using
`tests/test_user.py -s -v`

## Testing Changes Moving Forward
N/A


## Ticket
ENG-3379: SEL: User Test - Fix Production Failures in test_nothings_public in ProfilePageMixin
https://openscience.atlassian.net/browse/ENG-3379
