### PR TITLE
[ENG-3307] - Update Project Files test to run on Edge in BrowserStack

### DIFF
--- a/tests/test_project_files.py
+++ b/tests/test_project_files.py
@@ -97,10 +97,6 @@ def find_toolbar_button_by_name(driver, button_name):
 
 @markers.dont_run_on_prod
 @pytest.mark.usefixtures('must_be_logged_in')
-@pytest.mark.skipif(
-    settings.BUILD == 'edge',
-    reason='Our actions prompt edge to ask "Would you like to navigate away from this page?"',
-)
 class TestFilesPage:
     """We want to wrap all of our tests with try/finally so we can delete leftover files after failures.
     Decorators did not work here because we would need to pull out node_id from each test.
@@ -332,7 +328,7 @@ class TestFilesPage:
 
             action_chains = ActionChains(driver)
             action_chains.reset_actions()
-            if 'chrome' in current_browser:
+            if 'chrome' or 'edge' in current_browser:
                 # The sleeps in the following code block are needed for
                 # Chrome's virtual keyboard to work properly
                 if modifier_key == 'alt':


### PR DESCRIPTION
<!-- Before you submit your Pull Request, please confirm that:

     - Any test that will create public data either has the `QAtest` tag or the `dont_run_on_production` marker
     - `core_functionality` is marked as such
     - Your tests will be able to run on *all* servers (all stagings, test)
 -->


## Purpose
To expand the coverage of the Project Files test to also run with the Edge browser in BrowserStack. 


## Summary of Changes

- tests/test_project_files.py - deleted the 'skipif' pytest marker that was skipping all of the test steps when running in BrowserStack with the Edge browser.  Also adding Edge to an if statement that was previously specific only to Chrome, since both Chrome and Edge are now based on Chromium and use the same underlying code base.


## Reviewer's Actions
`git fetch <remote> pull/<PR_number>/head:testFix/project_files_Edge`

Run this test using
`tests/test_project_files.py -s -v`

## Testing Changes Moving Forward
NA


## Ticket
ENG-3307: SEL: Project Files Test - Enhancement - running test with Edge Browser on BrowserStack
https://openscience.atlassian.net/browse/ENG-3307
