### PR TITLE
[ENG-826] - Expand the Scope of the Landing Page Test

### DIFF
--- a/pages/landing.py
+++ b/pages/landing.py
@@ -3,6 +3,7 @@ from selenium.webdriver.common.by import By
 import settings
 from base.locators import (
     ComponentLocator,
+    GroupLocator,
     Locator,
 )
 from components.generic import SignUpForm
@@ -13,18 +14,50 @@ from pages.base import OSFBasePage
 class LandingPage(OSFBasePage):
     identity = Locator(By.CSS_SELECTOR, '._heroHeader_1qc5dv', settings.LONG_TIMEOUT)
 
+    get_started_button = Locator(By.CSS_SELECTOR, '[data-test-get-started-button]')
+    search_input = Locator(By.CSS_SELECTOR, '[data-test-search-input]')
+    learn_more_button = Locator(By.CSS_SELECTOR, '[data-test-learn-more-button]')
+    testimonial_1_button = Locator(
+        By.CSS_SELECTOR, '[data-analytics-name="Go to slide 1"]'
+    )
+    testimonial_2_button = Locator(
+        By.CSS_SELECTOR, '[data-analytics-name="Go to slide 2"]'
+    )
+    testimonial_3_button = Locator(
+        By.CSS_SELECTOR, '[data-analytics-name="Go to slide 3"]'
+    )
+    testimonial_1_slide = Locator(By.CSS_SELECTOR, '[data-test-testimonials-slide-1]')
+    testimonial_2_slide = Locator(By.CSS_SELECTOR, '[data-test-testimonials-slide-2]')
+    testimonial_3_slide = Locator(By.CSS_SELECTOR, '[data-test-testimonials-slide-3]')
+    previous_testimonial_arrow = Locator(By.CSS_SELECTOR, '[data-test-previous-arrow]')
+    next_testimonial_arrow = Locator(By.CSS_SELECTOR, '[data-test-next-arrow]')
+    testimonial_view_research_links = GroupLocator(
+        By.CSS_SELECTOR, '[data-analytics-name="View research"]'
+    )
+
     # Components
     navbar = ComponentLocator(EmberNavbar)
     sign_up_form = ComponentLocator(SignUpForm)
-
-
-class LegacyLandingPage(OSFBasePage):
-    waffle_override = {'ember_home_page': LandingPage}
-
-    identity = Locator(By.CSS_SELECTOR, '._heroHeader_1qc5dv')
 
 
 class RegisteredReportsLandingPage(OSFBasePage):
     url = settings.OSF_HOME + '/rr/'
 
     identity = Locator(By.CSS_SELECTOR, '.reg-landing-page-logo')
+
+    create_registered_report_button = Locator(
+        By.CSS_SELECTOR,
+        'body > div.watermarked > div > div > div.row.hidden-xs > table > tbody > tr:nth-child(1) > td > a > div',
+    )
+    cos_rr_link = Locator(
+        By.CSS_SELECTOR,
+        'body > div.watermarked > div > div > div:nth-child(8) > a:nth-child(1)',
+    )
+    osf_registries_link = Locator(
+        By.CSS_SELECTOR,
+        'body > div.watermarked > div > div > div:nth-child(8) > a:nth-child(2)',
+    )
+    cos_prereg_link = Locator(
+        By.CSS_SELECTOR,
+        'body > div.watermarked > div > div > div:nth-child(8) > a:nth-child(3)',
+    )

--- a/tests/test_landing.py
+++ b/tests/test_landing.py
@@ -1,35 +1,164 @@
 import pytest
+from selenium.webdriver.common.keys import Keys
 
 import markers
+import settings
 from pages.landing import (
     LandingPage,
     RegisteredReportsLandingPage,
 )
+from pages.register import RegisterPage
+from pages.registries import RegistriesDiscoverPage
+from pages.search import SearchPage
+from pages.user import UserProfilePage
 
 
 @pytest.fixture()
 def landing_page(driver):
     landing_page = LandingPage(driver)
-    landing_page.goto()
+    landing_page.goto_with_reload()
     return landing_page
 
 
 @markers.smoke_test
 class TestHomeLandingPage:
-    @pytest.fixture()
-    def page(self, landing_page):
-        return landing_page
+    def test_get_started(self, driver, landing_page):
+        landing_page.get_started_button.click()
+        RegisterPage(driver, verify=True)
 
-    @markers.core_functionality
-    def test_landing_page(self, driver):
-        LandingPage(driver, verify=True)
+    def test_search(self, driver, landing_page):
+        landing_page.search_input.send_keys('*')
+        landing_page.search_input.send_keys(Keys.ENTER)
+        search_page = SearchPage(driver, verify=True)
+        search_page.loading_indicator.here_then_gone()
+        assert search_page.search_results
 
-    # TO DO: Come back later and add other tests for elements on OSF Home page - see ENG-826
+    def test_learn_nore(self, driver, landing_page):
+        landing_page.learn_more_button.click()
+        assert driver.current_url == 'https://www.cos.io/products/osf'
+
+    def test_testimonials_by_buttons(self, driver, landing_page):
+        landing_page.scroll_into_view(landing_page.testimonial_3_button.element)
+        # Verify that Testimonial 1 slide is initially visible
+        assert landing_page.testimonial_1_slide.present()
+        assert landing_page.testimonial_2_slide.absent()
+        assert landing_page.testimonial_3_slide.absent()
+        # Click the button above the testimonial carousel to go to Testimonial 3
+        landing_page.testimonial_3_button.click()
+        assert landing_page.testimonial_3_slide.present()
+        assert landing_page.testimonial_1_slide.absent()
+        assert landing_page.testimonial_2_slide.absent()
+        # Click the button above the testimonial carousel to go to Testimonial 2
+        landing_page.testimonial_2_button.click()
+        assert landing_page.testimonial_2_slide.present()
+        assert landing_page.testimonial_1_slide.absent()
+        assert landing_page.testimonial_3_slide.absent()
+        # Click the button above the testimonial carousel to go to Testimonial 1
+        landing_page.testimonial_1_button.click()
+        assert landing_page.testimonial_1_slide.present()
+        assert landing_page.testimonial_2_slide.absent()
+        assert landing_page.testimonial_3_slide.absent()
+
+    def test_testimonials_by_arrows(self, driver, landing_page):
+        landing_page.scroll_into_view(landing_page.previous_testimonial_arrow.element)
+        # Verify that Testimonial 1 slide is initially visible
+        assert landing_page.testimonial_1_slide.present()
+        assert landing_page.testimonial_2_slide.absent()
+        assert landing_page.testimonial_3_slide.absent()
+        # Click the previous arrow to the left of the slide to go to Testimonial 3
+        landing_page.previous_testimonial_arrow.click()
+        assert landing_page.testimonial_3_slide.present()
+        assert landing_page.testimonial_1_slide.absent()
+        assert landing_page.testimonial_2_slide.absent()
+        # Click the previous arrow again to go to Testimonial 2
+        landing_page.previous_testimonial_arrow.click()
+        assert landing_page.testimonial_2_slide.present()
+        assert landing_page.testimonial_1_slide.absent()
+        assert landing_page.testimonial_3_slide.absent()
+        # Click the previous arrow again to go to Testimonial 1
+        landing_page.previous_testimonial_arrow.click()
+        assert landing_page.testimonial_1_slide.present()
+        assert landing_page.testimonial_2_slide.absent()
+        assert landing_page.testimonial_3_slide.absent()
+        # Next click the next arrow to the right of the slide to go to Testimonial 2
+        landing_page.next_testimonial_arrow.click()
+        assert landing_page.testimonial_2_slide.present()
+        assert landing_page.testimonial_1_slide.absent()
+        assert landing_page.testimonial_3_slide.absent()
+        # Click the next arrow again to go to Testimonial 3
+        landing_page.next_testimonial_arrow.click()
+        assert landing_page.testimonial_3_slide.present()
+        assert landing_page.testimonial_1_slide.absent()
+        assert landing_page.testimonial_2_slide.absent()
+
+    @pytest.mark.skipif(
+        not settings.PRODUCTION,
+        reason='User Guids only exist in Production',
+    )
+    def test_testimonial_1_view_research_link(self, driver, landing_page):
+        landing_page.scroll_into_view(landing_page.testimonial_view_research_links[0])
+        # Verify that Testimonial 1 slide is initially visible
+        assert landing_page.testimonial_1_slide.present()
+        # Click the "See her research" link and verify that you are navigated to the User
+        # Profile page for Patricia Ayala (guid=wx9bf)
+        landing_page.testimonial_view_research_links[0].click()
+        UserProfilePage(driver, verify=True)
+        assert 'wx9bf' in driver.current_url
+
+    @pytest.mark.skipif(
+        not settings.PRODUCTION,
+        reason='User Guids only exist in Production',
+    )
+    def test_testimonial_2_view_research_link(self, driver, landing_page):
+        landing_page.scroll_into_view(landing_page.testimonial_view_research_links[0])
+        assert landing_page.testimonial_1_slide.present()
+        # Click the next arrow to the right of the slide to go to Testimonial 2
+        landing_page.next_testimonial_arrow.click()
+        assert landing_page.testimonial_2_slide.present()
+        # Click the "See her research" link and verify that you are navigated to the User
+        # Profile page for Maya Mathur (guid=e9tg8)
+        landing_page.testimonial_view_research_links[1].click()
+        UserProfilePage(driver, verify=True)
+        assert 'e9tg8' in driver.current_url
+
+    @pytest.mark.skipif(
+        not settings.PRODUCTION,
+        reason='User Guids only exist in Production',
+    )
+    def test_testimonial_3_view_research_link(self, driver, landing_page):
+        landing_page.scroll_into_view(landing_page.testimonial_view_research_links[0])
+        assert landing_page.testimonial_1_slide.present()
+        # Click the button above the testimonial carousel to go to Testimonial 3
+        landing_page.testimonial_3_button.click()
+        assert landing_page.testimonial_3_slide.present()
+        # Click the "See his research" link and verify that you are navigated to the User
+        # Profile page for Philip Cohen (guid=2u4tf)
+        landing_page.testimonial_view_research_links[2].click()
+        UserProfilePage(driver, verify=True)
+        assert '2u4tf' in driver.current_url
+
+
+@pytest.fixture()
+def rr_landing_page(driver):
+    rr_landing_page = RegisteredReportsLandingPage(driver)
+    rr_landing_page.goto_with_reload()
+    return rr_landing_page
 
 
 @markers.smoke_test
 class TestRegisteredReportsLandingPage:
-    @markers.core_functionality
-    def test_landing_page(self, driver):
-        landing_page = RegisteredReportsLandingPage(driver)
-        landing_page.goto()
+    def test_create_registered_report_button(self, driver, rr_landing_page):
+        rr_landing_page.create_registered_report_button.click()
+        RegisterPage(driver, verify=True)
+
+    def test_cos_rr_link(self, driver, rr_landing_page):
+        rr_landing_page.cos_rr_link.click()
+        assert 'https://www.cos.io/initiatives/registered-reports' in driver.current_url
+
+    def test_osf_registries_link(self, driver, rr_landing_page):
+        rr_landing_page.osf_registries_link.click()
+        RegistriesDiscoverPage(driver, verify=True)
+
+    def test_cos_prereg_link(self, driver, rr_landing_page):
+        rr_landing_page.cos_prereg_link.click()
+        assert 'https://www.cos.io/initiatives/prereg' in driver.current_url


### PR DESCRIPTION
<!-- Before you submit your Pull Request, please confirm that:

     - Any test that will create public data either has the `QAtest` tag or the `dont_run_on_production` marker
     - `core_functionality` is marked as such
     - Your tests will be able to run on *all* servers (all stagings, test)
 -->


## Purpose
To expand the scope of the landing page test to make it more comprehensive.


## Summary of Changes

- pages/landing.py - add necessary elements to LandingPage class and RegisteredReportsLandingPage class.
- tests/test_landing.py - add tests of major elements on the OSF Home landing page and the Registered Reports landing page.


## Reviewer's Actions
`git fetch <remote> pull/<PR_number>/head:testFix/landing`

Run this test using
`tests/test_landing.py -s -v`

## Testing Changes Moving Forward
N/A


## Ticket
ENG-826: SEL: Write test for Logged Out Home Page 
https://openscience.atlassian.net/browse/ENG-826
