### PR TITLE
[ENG-3425] - Update Navbar links to fix Nightly Staging Test Failures

### DIFF
--- a/components/navbars.py
+++ b/components/navbars.py
@@ -83,37 +83,18 @@ class PreprintsNavbar(EmberNavbar):
         By.CSS_SELECTOR, 'ul.dropdown-menu.service-dropdown > li:nth-child(5) > a'
     )
 
-    my_preprints_link = Locator(
-        By.CSS_SELECTOR, '#secondary-navigation > ul > li:first-child > a'
-    )
-    add_a_preprint_link = Locator(
-        By.CSS_SELECTOR, '#secondary-navigation > ul > li:nth-last-child(5) > a'
-    )
-    search_link = Locator(
-        By.CSS_SELECTOR, '#secondary-navigation > ul > li:nth-last-child(4) > a'
-    )
-    support_link = Locator(
-        By.CSS_SELECTOR, '#secondary-navigation > ul > li:nth-last-child(3) > a'
-    )
-    donate_link = Locator(
-        By.CSS_SELECTOR, '#secondary-navigation > ul > li.navbar-donate-button'
-    )
-    sign_up_button = Locator(By.CSS_SELECTOR, 'a.btn-success:nth-child(1)')
-    sign_in_button = Locator(By.CSS_SELECTOR, '.btn-top-login')
+    my_preprints_link = Locator(By.LINK_TEXT, 'My Preprints')
+    add_a_preprint_link = Locator(By.LINK_TEXT, 'Add a Preprint')
+    search_link = Locator(By.LINK_TEXT, 'Search')
+    support_link = Locator(By.LINK_TEXT, 'Support')
+    donate_link = Locator(By.LINK_TEXT, 'Donate')
+    sign_up_button = Locator(By.LINK_TEXT, 'Sign Up')
+    sign_in_button = Locator(By.LINK_TEXT, 'Sign In')
 
-    user_dropdown_profile = Locator(
-        By.CSS_SELECTOR, 'ul.dropdown-menu-right > li:nth-child(1)'
-    )
-    user_dropdown_support = Locator(
-        By.CSS_SELECTOR, 'ul.dropdown-menu-right > li:nth-child(2)'
-    )
-    user_dropdown_settings = Locator(
-        By.CSS_SELECTOR, 'ul.dropdown-menu-right > li:nth-child(3)'
-    )
-    logout_link = Locator(
-        By.CSS_SELECTOR,
-        '#secondary-navigation > ul > li.dropdown.open > ul > li:nth-child(4) > a',
-    )
+    user_dropdown_profile = Locator(By.LINK_TEXT, 'My Profile')
+    user_dropdown_support = Locator(By.LINK_TEXT, 'OSF Support')
+    user_dropdown_settings = Locator(By.LINK_TEXT, 'Settings')
+    logout_link = Locator(By.LINK_TEXT, 'Log Out')
 
     def verify(self):
         return self.current_service.text == 'PREPRINTS'

--- a/components/navbars.py
+++ b/components/navbars.py
@@ -22,7 +22,9 @@ class HomeNavbar(BaseElement):
     support_link = Locator(By.ID, 'navbar-support')
     donate_link = Locator(By.ID, 'navbar-donate')
 
-    user_dropdown = Locator(By.CSS_SELECTOR, 'ul.navbar-nav > li:nth-child(6) > a')
+    user_dropdown = Locator(
+        By.CSS_SELECTOR, 'ul.navbar-nav > li.secondary-nav-dropdown'
+    )
     user_dropdown_profile = Locator(
         By.CSS_SELECTOR, 'ul.dropdown-menu-right > li:nth-child(1)'
     )
@@ -82,7 +84,7 @@ class PreprintsNavbar(EmberNavbar):
     )
 
     my_preprints_link = Locator(
-        By.CSS_SELECTOR, '#secondary-navigation > ul > li:nth-last-child(6) > a'
+        By.CSS_SELECTOR, '#secondary-navigation > ul > li:first-child > a'
     )
     add_a_preprint_link = Locator(
         By.CSS_SELECTOR, '#secondary-navigation > ul > li:nth-last-child(5) > a'
@@ -151,8 +153,13 @@ class RegistriesNavbar(EmberNavbar):
         By.CSS_SELECTOR, 'a[data-analytics-name="Settings"]'
     )
 
-    add_new_link = Locator(By.CSS_SELECTOR, 'a[data-test-add-new-button][href="/registries/osf/new"]')
-    my_registrations_link = Locator(By.CSS_SELECTOR, 'a[data-test-add-new-button][href="/registries/my-registrations"]')
+    add_new_link = Locator(
+        By.CSS_SELECTOR, 'a[data-test-add-new-button][href="/registries/osf/new"]'
+    )
+    my_registrations_link = Locator(
+        By.CSS_SELECTOR,
+        'a[data-test-add-new-button][href="/registries/my-registrations"]',
+    )
 
     def verify(self):
         return self.current_service.text == 'REGISTRIES'


### PR DESCRIPTION
<!-- Before you submit your Pull Request, please confirm that:

     - Any test that will create public data either has the `QAtest` tag or the `dont_run_on_production` marker
     - `core_functionality` is marked as such
     - Your tests will be able to run on *all* servers (all stagings, test)
 -->


## Purpose
To fix Navbar Test failures in the nightly Staging Test runs.


## Summary of Changes

- components/navbars.py - Fix user_dropdown link to use a more specific locator definition, since the old locator assumes that there are only 6 links in the Navbar and so it fails when there are 7 or more links.  Also update the specific Preprints navbar link locators to use "LINK_TEXT" so that their position in the navbar no longer matters.  Lastly the "add_new_link" and "my_registrations_link" locator definitions in the RegistriesNavbar class were not properly linted before for some reason.


## Reviewer's Actions
`git fetch <remote> pull/<PR_number>/head:testFix/navbar`

Run this test using
`tests/test_navbar.py -s -v`

## Testing Changes Moving Forward
N/A


## Ticket
ENG-3425: SEL: Navbar Test -  Preprints Navbar Tests Failing in Nightly Staging Tests
https://openscience.atlassian.net/browse/ENG-3425
