### PR TITLE
[ENG-2858] Remove old Travis references

### DIFF
--- a/.github/workflows/production_smoke_tests.yml
+++ b/.github/workflows/production_smoke_tests.yml
@@ -86,4 +86,4 @@ jobs:
           PREFERRED_NODE: ra4bf
           TEST_BUILD: ${{ matrix.browser }}
         run: |
-          invoke test_travis_on_prod
+          invoke test_selenium_on_prod

--- a/.github/workflows/selenium_staging_tests.yml
+++ b/.github/workflows/selenium_staging_tests.yml
@@ -91,9 +91,9 @@ jobs:
         env:
           TEST_BUILD: ${{ matrix.browser }}
         run: |
-          invoke test_travis_part_one
+          invoke test_selenium_part_one
       - name: run staging tests, part two
         env:
           TEST_BUILD: ${{ matrix.browser }}
         run: |
-          invoke test_travis_part_two
+          invoke test_selenium_part_two

--- a/.github/workflows/selenium_staging_tests.yml
+++ b/.github/workflows/selenium_staging_tests.yml
@@ -87,13 +87,8 @@ jobs:
         with:
           path: ${{ env.pythonLocation }}
           key: ${{ env.GHA_DISTRO }}-${{ env.pythonLocation }}-${{ hashFiles('requirements.txt') }}
-      - name: run staging tests, part one
+      - name: run staging tests
         env:
           TEST_BUILD: ${{ matrix.browser }}
         run: |
-          invoke test_selenium_part_one
-      - name: run staging tests, part two
-        env:
-          TEST_BUILD: ${{ matrix.browser }}
-        run: |
-          invoke test_selenium_part_two
+          invoke test_selenium_with_retries

--- a/README.md
+++ b/README.md
@@ -3,7 +3,9 @@
 This is the UI test automation for the OSF. It uses Selenium WebDriver and Pytest to create end-to-end OSF tests.
 
 
-[![Build Status](https://travis-ci.org/cos-qa/osf-selenium-tests.svg?branch=master)](https://travis-ci.org/cos-qa/osf-selenium-tests)
+![production_smoke_tests](https://github.com/cos-qa/osf-selenium-tests/actions/workflows/production_smoke_tests.yml/badge.svg)
+![develop_staging_tests](https://github.com/cos-qa/osf-selenium-tests/actions/workflows/selenium_staging_tests.yml/badge.svg)
+
 
 
 ## Setting up

--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -18,7 +18,7 @@ logging.getLogger('invoke').setLevel(logging.CRITICAL)
 HERE = os.path.abspath(os.path.join(os.path.dirname(os.path.abspath(__file__)), '..'))
 BIN_PATH = os.path.dirname(sys.executable)
 bin_prefix = lambda cmd: os.path.join(BIN_PATH, cmd)
-MAX_TRAVIS_RETRIES = int(os.getenv('MAX_TRAVIS_RETRIES', 3))
+MAX_RETRIES = int(os.getenv('MAX_RETRIES', 3))
 
 
 @task(aliases=['flake8'])
@@ -75,33 +75,33 @@ def test_module(ctx, module=None, params=None):
 
 
 @task
-def test_travis_on_prod(ctx):
+def test_selenium_on_prod(ctx):
     """
     Runs targeted prod smoke tests on the latest Chrome
     """
     flake(ctx)
     print('>>> Testing modules in "{}" in Chrome'.format('tests'))
-    test_travis_with_retries(
+    test_selenium_with_retries(
         ctx, 'Master', _get_test_file_list(), module=['-m', 'smoke_test']
     )
 
 
 @task
-def test_travis_part_one(ctx):
+def test_selenium_part_one(ctx):
     """Run first group of tests on the browser defined by TEST_BUILD."""
     all_test_files = _get_test_file_list()
     midpoint = len(all_test_files) // 2
     file_list = all_test_files[:midpoint]
-    test_travis_with_retries(ctx, 'part one', file_list)
+    test_selenium_with_retries(ctx, 'part one', file_list)
 
 
 @task
-def test_travis_part_two(ctx):
+def test_selenium_part_two(ctx):
     """Run second group of tests on the browser defined by TEST_BUILD."""
     all_test_files = _get_test_file_list()
     midpoint = len(all_test_files) // 2
     file_list = all_test_files[midpoint:]
-    test_travis_with_retries(ctx, 'part two', file_list)
+    test_selenium_with_retries(ctx, 'part two', file_list)
 
 
 def _get_test_file_list():
@@ -111,7 +111,7 @@ def _get_test_file_list():
 
 
 @task
-def test_travis_with_retries(ctx, partition_name, file_list, module=None):
+def test_selenium_with_retries(ctx, partition_name, file_list, module=None):
     """Run group of tests on the browser defined by TEST_BUILD."""
     flake(ctx)
 
@@ -128,7 +128,7 @@ def test_travis_with_retries(ctx, partition_name, file_list, module=None):
 
     file_list = ['--last-failed', '--last-failed-no-failures', 'none'] + file_list
 
-    for i in range(1, MAX_TRAVIS_RETRIES + 1):
+    for i in range(1, MAX_RETRIES + 1):
         print(
             '>>> Retesting {} failures, iteration {}, in "/test/" '
             'in {}'.format(partition_name, i, os.environ['TEST_BUILD'])

--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -81,9 +81,7 @@ def test_selenium_on_prod(ctx):
     """
     flake(ctx)
     print('>>> Testing modules in "{}" in Chrome'.format('tests'))
-    test_selenium_with_retries(
-        ctx, 'Master', _get_test_file_list(), module=['-m', 'smoke_test']
-    )
+    test_selenium_with_retries(ctx, 'Master', module=['-m', 'smoke_test'])
 
 
 def _get_test_file_list():
@@ -93,9 +91,10 @@ def _get_test_file_list():
 
 
 @task
-def test_selenium_with_retries(ctx, file_list, module=None):
+def test_selenium_with_retries(ctx, module=None):
     """Run group of tests on the browser defined by TEST_BUILD."""
     flake(ctx)
+    file_list = _get_test_file_list()
 
     print('>>> Testing modules in "/tests/" in {}'.format(os.environ['TEST_BUILD']))
     print('>>> File list is: {}'.format(file_list))

--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -86,24 +86,6 @@ def test_selenium_on_prod(ctx):
     )
 
 
-@task
-def test_selenium_part_one(ctx):
-    """Run first group of tests on the browser defined by TEST_BUILD."""
-    all_test_files = _get_test_file_list()
-    midpoint = len(all_test_files) // 2
-    file_list = all_test_files[:midpoint]
-    test_selenium_with_retries(ctx, 'part one', file_list)
-
-
-@task
-def test_selenium_part_two(ctx):
-    """Run second group of tests on the browser defined by TEST_BUILD."""
-    all_test_files = _get_test_file_list()
-    midpoint = len(all_test_files) // 2
-    file_list = all_test_files[midpoint:]
-    test_selenium_with_retries(ctx, 'part two', file_list)
-
-
 def _get_test_file_list():
     all_test_files = glob.glob('tests/test_*.py')
     all_test_files.sort()
@@ -111,16 +93,12 @@ def _get_test_file_list():
 
 
 @task
-def test_selenium_with_retries(ctx, partition_name, file_list, module=None):
+def test_selenium_with_retries(ctx, file_list, module=None):
     """Run group of tests on the browser defined by TEST_BUILD."""
     flake(ctx)
 
-    print(
-        '>>> Testing {} modules in "/tests/" in {}'.format(
-            partition_name, os.environ['TEST_BUILD']
-        )
-    )
-    print('>>> File list for {} is: {}'.format(partition_name, file_list))
+    print('>>> Testing modules in "/tests/" in {}'.format(os.environ['TEST_BUILD']))
+    print('>>> File list is: {}'.format(file_list))
     retcode = test_module_wo_exit(ctx, params=file_list, module=module)
 
     if retcode != 1:
@@ -130,8 +108,8 @@ def test_selenium_with_retries(ctx, partition_name, file_list, module=None):
 
     for i in range(1, MAX_RETRIES + 1):
         print(
-            '>>> Retesting {} failures, iteration {}, in "/test/" '
-            'in {}'.format(partition_name, i, os.environ['TEST_BUILD'])
+            '>>> Retesting failures, iteration {}, in "/test/" '
+            'in {}'.format(i, os.environ['TEST_BUILD'])
         )
         retcode = test_module_wo_exit(ctx, params=file_list, module=module)
 


### PR DESCRIPTION
<!-- Before you submit your Pull Request, please confirm that:

     - Any test that will create public data either has the `QAtest` tag or the `dont_run_on_production` marker
     - `core_functionality` is marked as such
     - Your tests will be able to run on *all* servers (all stagings, test)
 -->


## Purpose
Remove old references to Travis CI in our code base. 


## Summary of Changes
- Update github actions workflows
- Update init file
- Update README status badges for `Master` and `Develop`
- Combine 2 test partitions into a singular test run


## Reviewer's Actions
N/A

Run this test using
N/A

## Testing Changes Moving Forward
N/A


## Ticket

https://openscience.atlassian.net/browse/ENG-2858
