### PR TITLE
[ENG-3350] - Refactor Preprints Workflow Test

### DIFF
--- a/api/osf_api.py
+++ b/api/osf_api.py
@@ -344,3 +344,21 @@ def connect_provider_root_to_node(
         raw_body=json.dumps(raw_payload),
     )
     return addon
+
+
+def get_preprints_list_for_user(session, user=None):
+    """Return the list of Preprints for a given user"""
+    if not user:
+        user = current_user(session)
+    url = '/v2/users/{}/preprints/'.format(user.id)
+    return session.get(url)['data']
+
+
+def get_preprint_supplemental_material_guid(session, preprint_guid):
+    """Return the Supplemental Material Project guid for a given Preprint"""
+    url = '/v2/preprints/{}/relationships/node/'.format(preprint_guid)
+    data = session.get(url)['data']
+    if data:
+        return data['id']
+    else:
+        return None

--- a/tests/test_preprints.py
+++ b/tests/test_preprints.py
@@ -1,7 +1,9 @@
 import logging
 import re
+from datetime import datetime
 
 import pytest
+from selenium.common.exceptions import TimeoutException
 from selenium.webdriver.common.by import By
 from selenium.webdriver.common.keys import Keys
 from selenium.webdriver.support import expected_conditions as EC
@@ -39,99 +41,145 @@ class TestPreprintWorkflow:
     def test_create_preprint_from_landing(
         self, session, driver, landing_page, project_with_file
     ):
+        supplemental_guid = None
+        try:
+            # Create a date and time stamp before starting the creation of the preprint.
+            # This may be used later to find the guid for the preprint.
+            now = datetime.utcnow()
+            dtStamp = now.strftime('%Y-%m-%dT%H:%M:%S')
 
-        landing_page.add_preprint_button.click()
-        submit_page = PreprintSubmitPage(driver, verify=True)
+            landing_page.add_preprint_button.click()
+            submit_page = PreprintSubmitPage(driver, verify=True)
 
-        # Wait for select a service to show
-        WebDriverWait(driver, 10).until(
-            EC.visibility_of(submit_page.select_a_service_help_text)
-        )
-        submit_page.select_a_service_save_button.click()
-        submit_page.upload_from_existing_project_button.click()
-        submit_page.upload_project_selector.click()
-        submit_page.upload_project_help_text.here_then_gone()
-        submit_page.upload_project_selector_project.click()
+            # Wait for select a service to show
+            WebDriverWait(driver, 10).until(
+                EC.visibility_of(submit_page.select_a_service_help_text)
+            )
+            submit_page.select_a_service_save_button.click()
+            submit_page.upload_from_existing_project_button.click()
+            submit_page.upload_project_selector.click()
+            submit_page.upload_project_help_text.here_then_gone()
+            submit_page.upload_project_selector_project.click()
 
-        submit_page.upload_select_file.click()
-        submit_page.upload_file_save_continue.click()
+            submit_page.upload_select_file.click()
+            submit_page.upload_file_save_continue.click()
 
-        # Author Assertions section
-        # Note: We can't use the submit_page.save_author_assertions object here, because it is disabled and any time we use
-        # an object defined in pages/preprints.py it uses get_web_element() in the Locator class.  Within get_web_element() the
-        # element_to_be_clickable method is used, and this method will always fail for disabled objects.  So in this instance
-        # we have to get the button object using the driver.find_element method while it is disabled.  After the button becomes
-        # enabled (i.e. after required data has been provided) then we can use the submit_page.save_author_assertions object to
-        # check the disabled property.  See implementation below.
-        assert driver.find_element(
-            By.CSS_SELECTOR, '[data-test-author-assertions-continue]'
-        ).get_property('disabled')
-        assert submit_page.public_data_input.absent()
-        submit_page.public_available_button.click()
-        assert submit_page.public_data_input.present()
-        submit_page.public_data_input.click()
-        submit_page.public_data_input.send_keys_deliberately('https://osf.io/')
-        # Need to scroll down since the Preregistration radio buttons are obscured by the Dev mode warning in test environments
-        submit_page.scroll_into_view(submit_page.preregistration_no_button.element)
-        assert submit_page.preregistration_input.absent()
-        submit_page.preregistration_no_button.click()
-        assert submit_page.preregistration_input.present()
-        submit_page.preregistration_input.click()
-        submit_page.preregistration_input.send_keys_deliberately('QA Testing')
-        # Save button is now enabled so we can use the object as defined in pages/preprints.py
-        assert submit_page.save_author_assertions.is_enabled()
-        submit_page.save_author_assertions.click()
+            # Author Assertions section
+            # Note: We can't use the submit_page.save_author_assertions object here,
+            # because it is disabled and any time we use an object defined in
+            # pages/preprints.py it uses get_web_element() in the Locator class.
+            # Within get_web_element() the element_to_be_clickable method is used,
+            # and this method will always fail for disabled objects.  So in this
+            # instance we have to get the button object using the driver.find_element
+            # method while it is disabled.  After the button becomes enabled (i.e.
+            # after required data has been provided) then we can use the
+            # submit_page.save_author_assertions object to check the disabled
+            # property.  See implementation below.
+            assert driver.find_element(
+                By.CSS_SELECTOR, '[data-test-author-assertions-continue]'
+            ).get_property('disabled')
+            assert submit_page.public_data_input.absent()
+            submit_page.public_available_button.click()
+            assert submit_page.public_data_input.present()
+            submit_page.public_data_input.click()
+            submit_page.public_data_input.send_keys_deliberately('https://osf.io/')
+            # Need to scroll down since the Preregistration radio buttons are obscured
+            # by the Dev mode warning in test environments
+            submit_page.scroll_into_view(submit_page.preregistration_no_button.element)
+            assert submit_page.preregistration_input.absent()
+            submit_page.preregistration_no_button.click()
+            assert submit_page.preregistration_input.present()
+            submit_page.preregistration_input.click()
+            submit_page.preregistration_input.send_keys_deliberately('QA Testing')
+            # Save button is now enabled so we can use the object as defined in
+            # pages/preprints.py
+            assert submit_page.save_author_assertions.is_enabled()
+            submit_page.save_author_assertions.click()
 
-        submit_page.basics_license_dropdown.click()
-        # The order of the options in the license dropdown is not consistent across test environments. So we have to select
-        # by the actual text value instead of by relative position (i.e. 3rd option in listbox).
-        licenseSelect = Select(submit_page.basics_license_dropdown)
-        licenseSelect.select_by_visible_text('CC0 1.0 Universal')
-        # Need to scroll down since the Keyword/tags section is obscured by the Dev mode warning in the test environments
-        submit_page.scroll_into_view(submit_page.basics_tags_section.element)
-        submit_page.basics_tags_section.click()
-        submit_page.basics_tags_input.send_keys('selenium\r')
-        submit_page.basics_abstract_input.click()
-        submit_page.basics_abstract_input.send_keys('Center for Open Selenium')
-        submit_page.basics_save_button.click()
+            submit_page.basics_license_dropdown.click()
+            # The order of the options in the license dropdown is not consistent across
+            # test environments. So we have to select by the actual text value instead
+            # of by relative position (i.e. 3rd option in listbox).
+            licenseSelect = Select(submit_page.basics_license_dropdown)
+            licenseSelect.select_by_visible_text('CC0 1.0 Universal')
+            # Need to scroll down since the Keyword/tags section is obscured by the Dev
+            # mode warning in the test environments
+            submit_page.scroll_into_view(submit_page.basics_tags_section.element)
+            submit_page.basics_tags_section.click()
+            submit_page.basics_tags_input.send_keys('selenium\r')
+            submit_page.basics_abstract_input.click()
+            submit_page.basics_abstract_input.send_keys('Center for Open Selenium')
+            submit_page.basics_save_button.click()
 
-        # Wait for discipline help text
-        submit_page.first_discipline.click()
-        submit_page.discipline_save_button.click()
+            # Wait for discipline help text
+            submit_page.first_discipline.click()
+            submit_page.discipline_save_button.click()
 
-        # Wait for authors box to show
-        submit_page.authors_save_button.click()
+            # Wait for authors box to show
+            submit_page.authors_save_button.click()
 
-        # Conflict of Interest section:
-        assert driver.find_element(
-            By.CSS_SELECTOR, '[data-test-coi-continue]'
-        ).get_property('disabled')
-        assert submit_page.no_coi_text_box.absent()
-        submit_page.conflict_of_interest_no.click()
-        assert submit_page.no_coi_text_box.present()
-        assert submit_page.coi_save_button.is_enabled()
-        submit_page.coi_save_button.click()
+            # Conflict of Interest section:
+            assert driver.find_element(
+                By.CSS_SELECTOR, '[data-test-coi-continue]'
+            ).get_property('disabled')
+            assert submit_page.no_coi_text_box.absent()
+            submit_page.conflict_of_interest_no.click()
+            assert submit_page.no_coi_text_box.present()
+            assert submit_page.coi_save_button.is_enabled()
+            submit_page.coi_save_button.click()
 
-        # Wait for Supplemental materials to show
-        submit_page.supplemental_create_new_project.click()
-        submit_page.supplemental_save_button.click()
+            # Wait for Supplemental materials to show
+            submit_page.supplemental_create_new_project.click()
+            submit_page.supplemental_save_button.click()
 
-        submit_page.create_preprint_button.click()
-        submit_page.modal_create_preprint_button.click()
+            submit_page.create_preprint_button.click()
+            submit_page.modal_create_preprint_button.click()
 
-        preprint_detail = PreprintDetailPage(driver, verify=True)
-        WebDriverWait(driver, 10).until(EC.visibility_of(preprint_detail.title))
+            preprint_detail = PreprintDetailPage(driver, verify=True)
+            WebDriverWait(driver, 10).until(EC.visibility_of(preprint_detail.title))
 
-        assert preprint_detail.title.text == project_with_file.title
-        match = re.search(
-            r'Supplemental Materials\s+([a-z0-9]{4,8})\.osf\.io/([a-z0-9]{5})',
-            preprint_detail.view_page.text,
-        )
-        assert match is not None
+            assert preprint_detail.title.text == project_with_file.title
+            # Capture guid of supplemental materials project created during workflow
+            match = re.search(
+                r'Supplemental Materials\s+([a-z0-9]{4,8})\.osf\.io/([a-z0-9]{5})',
+                preprint_detail.view_page.text,
+            )
+            assert match is not None
+            supplemental_guid = match.group(2)
 
-        # Delete supplemental project created during workflow
-        supplemental_guid = match.group(2)
-        osf_api.delete_project(session, supplemental_guid, None)
+        finally:
+            # If there was an error above and we did not capture the guid for the
+            # supplemental materials project, then we need to get it if it exists.
+            if supplemental_guid is None:
+                # Get the list of preprints for the current user
+                preprints = osf_api.get_preprints_list_for_user(session)
+                for preprint in preprints:
+                    # Go through the list of preprints and if any of them has a creation
+                    # date and time after the date time stamp that we created before
+                    # starting this preprint then that is our preprint, so use its guid
+                    # to get the guid for the supplemental materials project.
+                    if preprint['attributes']['date_created'] > dtStamp:
+                        supplemental_guid = (
+                            osf_api.get_preprint_supplemental_material_guid(
+                                session, preprint['id']
+                            )
+                        )
+
+            # We need to always delete the supplemental materials project if it exists
+            if supplemental_guid is not None:
+                osf_api.delete_project(session, supplemental_guid, None)
+
+            # If we are still stuck on the Preprint Submit page then refresh it to see
+            # if we get an alert pop-up message about leaving the page.  If so then
+            # accept the alert so that we can get off this page and can proceed with
+            # the rest of the tests.
+            if submit_page.verify():
+                submit_page.reload()
+                try:
+                    WebDriverWait(driver, 3).until(EC.alert_is_present())
+                    driver.switch_to.alert.accept()
+                except TimeoutException:
+                    pass
 
 
 class TestPreprintSearch:

--- a/tests/test_preprints.py
+++ b/tests/test_preprints.py
@@ -164,6 +164,7 @@ class TestPreprintWorkflow:
                                 session, preprint['id']
                             )
                         )
+                        break
 
             # We need to always delete the supplemental materials project if it exists
             if supplemental_guid is not None:

--- a/tests/test_preprints.py
+++ b/tests/test_preprints.py
@@ -46,7 +46,7 @@ class TestPreprintWorkflow:
             # Create a date and time stamp before starting the creation of the preprint.
             # This may be used later to find the guid for the preprint.
             now = datetime.utcnow()
-            dtStamp = now.strftime('%Y-%m-%dT%H:%M:%S')
+            date_time_stamp = now.strftime('%Y-%m-%dT%H:%M:%S')
 
             landing_page.add_preprint_button.click()
             submit_page = PreprintSubmitPage(driver, verify=True)
@@ -100,8 +100,8 @@ class TestPreprintWorkflow:
             # The order of the options in the license dropdown is not consistent across
             # test environments. So we have to select by the actual text value instead
             # of by relative position (i.e. 3rd option in listbox).
-            licenseSelect = Select(submit_page.basics_license_dropdown)
-            licenseSelect.select_by_visible_text('CC0 1.0 Universal')
+            license_select = Select(submit_page.basics_license_dropdown)
+            license_select.select_by_visible_text('CC0 1.0 Universal')
             # Need to scroll down since the Keyword/tags section is obscured by the Dev
             # mode warning in the test environments
             submit_page.scroll_into_view(submit_page.basics_tags_section.element)
@@ -158,7 +158,7 @@ class TestPreprintWorkflow:
                     # date and time after the date time stamp that we created before
                     # starting this preprint then that is our preprint, so use its guid
                     # to get the guid for the supplemental materials project.
-                    if preprint['attributes']['date_created'] > dtStamp:
+                    if preprint['attributes']['date_created'] > date_time_stamp:
                         supplemental_guid = (
                             osf_api.get_preprint_supplemental_material_guid(
                                 session, preprint['id']


### PR DESCRIPTION
<!-- Before you submit your Pull Request, please confirm that:

     - Any test that will create public data either has the `QAtest` tag or the `dont_run_on_production` marker
     - `core_functionality` is marked as such
     - Your tests will be able to run on *all* servers (all stagings, test)
 -->


## Purpose
To refactor the Preprints Workflow test to prevent errors in subsequent test steps when the creation of a new preprint fails and to always delete any supplemental materials project that is created.


## Summary of Changes

- api/osf_api.py - add 2 new functions: "get_preprints_list_for_user" that returns a list of all of the preprints that a given user has created and "get_preprint_supplemental_material_guid" that returns the guid of the Supplemental Materials project if it exists.
- tests/test_preprints.py - In method: "test_create_preprint_from_landing" move all of the steps used to create a new preprint into a try clause and add a finally clause that contains steps to always delete any Supplemental Materials project and also to ensure that we are not stuck on the Preprint Submit page if there was an error.


## Reviewer's Actions
`git fetch <remote> pull/<PR_number>/head:testFix/preprints-refactor`

Run this test using
`tests/test_preprints.py -s -v`

## Testing Changes Moving Forward
N/A


## Ticket
ENG-3350: SEL: Preprints: Create Preprints Workflow (Refactor)
https://openscience.atlassian.net/browse/ENG-3350
