### PR TITLE
[ENG-3353] - Enable use of MS Edge with Selenium tests

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,8 +4,8 @@
 
 ##### Timeouts #####
 
-## Helpful for local development. Configure the wait times of timeouts to your needs. All values given in seconds. 
-## Note: Official timeout settings for the suite set in settings.py - go there if you need to add a new type or length 
+## Helpful for local development. Configure the wait times of timeouts to your needs. All values given in seconds.
+## Note: Official timeout settings for the suite set in settings.py - go there if you need to add a new type or length
 ## of timeout to the suite, to be used in scheduled remote runs of the tests.
 
 # QUICK_TIMEOUT=4
@@ -18,9 +18,10 @@
 
 ## Which browser/software stack to run the tests under.
 
-## DRIVER: which browser to test in.  Valid options are 'Chrome', 'Firefox', 'Remote'
+## DRIVER: which browser to test in.  Valid options are 'Chrome', 'Firefox', 'Edge', Remote'
 ##   'Chrome' requires that chromedriver is available in $PATH
 ##   'Firefox' requires that geckodriver is available in $PATH
+##   'Edge' requires that msedgedriver is available in $PATH
 ##   'Remote' will run the tests via BrowserStack
 ##
 ## HEADLESS: Should selenium hide the browser gui as the tests are being run?

--- a/utils.py
+++ b/utils.py
@@ -83,6 +83,22 @@ def launch_driver(driver_name=settings.DRIVER, desired_capabilities=None):
             'application/excel, text/comma-separated-values, text/xml, application/xml, binary/octet-stream',
         )
         driver = driver_cls(firefox_profile=ffp)
+    elif driver_name == 'Edge' and not settings.HEADLESS:
+        # Is the following only for Windows machines? - It doesn't work on Mac
+        # from msedge.selenium_tools import Edge, EdgeOptions
+
+        # options = EdgeOptions()
+        # options.use_chromium = True
+        # driver = Edge(options=options)
+
+        # The following works on Mac - does it also work on a Windows machine?
+        # Mac requires 'desired_capabilities' parameter even if it is empty. It does not
+        # recognize the 'options' parameter
+        from msedge.selenium_tools import Edge
+
+        desired_capabilities = {'ms:edgeChromium': True}
+        driver = Edge(desired_capabilities=desired_capabilities)
+
     else:
         driver = driver_cls()
 

--- a/utils.py
+++ b/utils.py
@@ -84,18 +84,10 @@ def launch_driver(driver_name=settings.DRIVER, desired_capabilities=None):
         )
         driver = driver_cls(firefox_profile=ffp)
     elif driver_name == 'Edge' and not settings.HEADLESS:
-        # Is the following only for Windows machines? - It doesn't work on Mac
-        # from msedge.selenium_tools import Edge, EdgeOptions
-
-        # options = EdgeOptions()
-        # options.use_chromium = True
-        # driver = Edge(options=options)
-
-        # The following works on Mac - does it also work on a Windows machine?
-        # Mac requires 'desired_capabilities' parameter even if it is empty. It does not
-        # recognize the 'options' parameter
         from msedge.selenium_tools import Edge
 
+        # Need to set the flag so that we use the newer Chromium based version of Edge
+        # instead of older IE based version of Edge
         desired_capabilities = {'ms:edgeChromium': True}
         driver = Edge(desired_capabilities=desired_capabilities)
 


### PR DESCRIPTION
<!-- Before you submit your Pull Request, please confirm that:

     - Any test that will create public data either has the `QAtest` tag or the `dont_run_on_production` marker
     - `core_functionality` is marked as such
     - Your tests will be able to run on *all* servers (all stagings, test)
 -->


## Purpose
To expand the capability of our Selenium test suite to run tests using the Edge browser on local machines.


## Summary of Changes

- .env.example - updating example documentation to include Edge as a browser option
- utils.py - adding Edge specific elif clause to launch_driver method, including flag to tell Selenium to use the Chromium version of the MS Edge driver.


## Reviewer's Actions
`git fetch <remote> pull/<PR_number>/head:feature/edge`

Run this test using
- run any test in our test suite after following the instructions to install MS Edge Driver and MS Edge Selenium Tools here: https://www.notion.so/cos/Selenium-Setup-Guide-8aaae9ff126a4311aa09daeacae24a1a#26974ad5bd4a48fe854320bfb20a42bc  and also setting DRIVER=Edge in your .env file.

## Testing Changes Moving Forward
N/A


## Ticket
ENG-3353: SEL: Add MS Edge to test suite
https://openscience.atlassian.net/browse/ENG-3353
