### PR TITLE
[ENG-3348] - Refactor Project Files Drag and Drop Test

### DIFF
--- a/pages/project.py
+++ b/pages/project.py
@@ -115,6 +115,11 @@ class FilesPage(GuidBasePage):
         By.CSS_SELECTOR, '#folderRow .fangorn-toolbar-icon'
     )
     delete_modal = Locator(By.CSS_SELECTOR, 'span.btn:nth-child(1)')
+    replace_modal = Locator(By.CSS_SELECTOR, '#tb-tbody > div.tb-modal-shade > div')
+    replace_modal_close_button = Locator(
+        By.CSS_SELECTOR,
+        '#tb-tbody > div.tb-modal-shade > div > div.modal-header > button.close',
+    )
 
 
 """Note that the class FilesPage in pages/project.py is used for test_project_files.py.


### PR DESCRIPTION
<!-- Before you submit your Pull Request, please confirm that:

     - Any test that will create public data either has the `QAtest` tag or the `dont_run_on_production` marker
     - `core_functionality` is marked as such
     - Your tests will be able to run on *all* servers (all stagings, test)
 -->


## Purpose
To make the test_dragon_drop test in test_project_files.py more efficient and reduce unneeded and repetitive steps that could lead to errors.


## Summary of Changes

- pages/project.py - add definitions for replace_modal and replace_modal_close_button elements used to interact with the modal window that can sometimes open when a duplicate copy action is attempted.
- tests/test_project_files.py - rearranged order of code and removed unneeded and repetitive steps to make the code more efficient and less error-prone.


## Reviewer's Actions
`git fetch <remote> pull/<PR_number>/head:testFix/project-files-drag-drop`

Run this test using
`tests/test_project_files.py -s -v`

## Testing Changes Moving Forward
N/A


## Ticket
ENG-3348: SEL: Project Files Drag & Drop (Refactor)
https://openscience.atlassian.net/browse/ENG-3348
