### PR TITLE
[ENG-3426] - Add Preprints My Reviewing link to Navbar Test

### DIFF
--- a/components/navbars.py
+++ b/components/navbars.py
@@ -84,6 +84,7 @@ class PreprintsNavbar(EmberNavbar):
     )
 
     my_preprints_link = Locator(By.LINK_TEXT, 'My Preprints')
+    my_reviewing_link = Locator(By.LINK_TEXT, 'My Reviewing')
     add_a_preprint_link = Locator(By.LINK_TEXT, 'Add a Preprint')
     search_link = Locator(By.LINK_TEXT, 'Search')
     support_link = Locator(By.LINK_TEXT, 'Support')

--- a/pages/preprints.py
+++ b/pages/preprints.py
@@ -181,3 +181,8 @@ class PreprintDetailPage(GuidBasePage, BasePreprintPage):
     identity = Locator(By.ID, 'preprintTitle', settings.LONG_TIMEOUT)
     title = Locator(By.ID, 'preprintTitle', settings.LONG_TIMEOUT)
     view_page = Locator(By.ID, 'view-page')
+
+
+class ReviewsDashboardPage(OSFBasePage):
+    url = settings.OSF_HOME + '/reviews'
+    identity = Locator(By.CLASS_NAME, '_reviews-dashboard-header_jdu5ey')

--- a/tests/test_navbar.py
+++ b/tests/test_navbar.py
@@ -15,6 +15,7 @@ from pages.preprints import (
     PreprintDiscoverPage,
     PreprintLandingPage,
     PreprintSubmitPage,
+    ReviewsDashboardPage,
 )
 from pages.project import MyProjectsPage
 from pages.quickfiles import QuickfilesPage
@@ -201,6 +202,13 @@ class TestPreprintsNavbarLoggedIn(NavbarTestLoggedInMixin):
         page.navbar.my_preprints_link.click()
         # My Preprints link actually navigates to My Preprints section of My Projects page
         assert 'myprojects/#preprints' in driver.current_url
+
+    # In order to see the My Reviewing link in the Preprints Navbar the user has to be
+    # an admin for one of the Branded Preprint Providers.
+    @markers.dont_run_on_prod
+    def test_my_reviewing_link(self, page, driver):
+        page.navbar.my_reviewing_link.click()
+        ReviewsDashboardPage(driver, verify=True)
 
 
 @markers.smoke_test


### PR DESCRIPTION
<!-- Before you submit your Pull Request, please confirm that:

     - Any test that will create public data either has the `QAtest` tag or the `dont_run_on_production` marker
     - `core_functionality` is marked as such
     - Your tests will be able to run on *all* servers (all stagings, test)
 -->


## Purpose
To update the Navbar test and add the "My Reviewing" link that is visible on the Preprints navigation bar for all users that are moderators or administrators for a Branded Preprint Provider.


## Summary of Changes

- components/navbars.py - adding locator for the "My Reviewing" link in the Preprints navigation bar
- pages/preprints.py - adding new page class - ReviewsDashboardPage - for the Preprints Reviews Dashboard page.
- tests/test_navbar.py - adding test step to test the "My Reviewing" link. The test step has the pytest marker - @markers.dont_run_on_prod - so that it will be skipped in Production, since we do not have any test users in the Production environment that are moderators or admins for any Branded Preprint Providers.


## Reviewer's Actions
`git fetch <remote> pull/<PR_number>/head:testFix/navbar-myreviewing`

Run this test using
`tests/test_navbar.py -s -v`

## Testing Changes Moving Forward
N/A


## Ticket
ENG-3426: SEL: Navbar Test - Add "My Reviewing" link to Preprints Navbar Test
https://openscience.atlassian.net/browse/ENG-3426
