### PR TITLE
[ENG-3494] - Add New Collections Test

### DIFF
--- a/api/osf_api.py
+++ b/api/osf_api.py
@@ -272,6 +272,17 @@ def get_providers_list(session=None, type='preprints'):
     return session.get(url)['data']
 
 
+def get_provider(session=None, type='registrations', provider_id='osf'):
+    """Return the data for an individual provider. The default type is registrations but
+    it can also be used for a preprints or collections provider.  The default provider_id
+    is 'osf'
+    """
+    if not session:
+        session = get_default_session()
+    url = '/v2/providers/' + type + '/' + provider_id
+    return session.get(url)['data']
+
+
 def get_provider_submission_status(provider):
     """Return the boolean attribute `allow_submissions` from the dictionary object (provider)"""
     return provider['attributes']['allow_submissions']
@@ -362,3 +373,25 @@ def get_preprint_supplemental_material_guid(session, preprint_guid):
         return data['id']
     else:
         return None
+
+
+def update_node_public_attribute(session, node_id, status=False):
+    """Update the public attribute on a given node. This will make a project Private
+    if status=False (default) or make the project Public if status=True.
+    """
+    url = '/v2/nodes/{}/'.format(node_id)
+    raw_payload = {
+        'data': {
+            'type': 'nodes',
+            'id': node_id,
+            'attributes': {
+                'public': status,
+            },
+        },
+    }
+    status = session.patch(
+        url=url,
+        item_type='nodes',
+        item_id=node_id,
+        raw_body=json.dumps(raw_payload),
+    )

--- a/components/navbars.py
+++ b/components/navbars.py
@@ -155,3 +155,7 @@ class MeetingsNavbar(EmberNavbar):
 class InstitutionsNavbar(EmberNavbar):
     def verify(self):
         return self.current_service.text == 'INSTITUTIONS'
+
+
+class CollectionsNavbar(EmberNavbar):
+    title = Locator(By.CSS_SELECTOR, '.navbar-title')

--- a/pages/collections.py
+++ b/pages/collections.py
@@ -1,0 +1,86 @@
+from urllib.parse import urljoin
+
+from selenium.webdriver.common.by import By
+
+import settings
+from base.locators import (
+    ComponentLocator,
+    Locator,
+)
+from components.navbars import CollectionsNavbar
+from pages.base import OSFBasePage
+
+
+class BaseCollectionPage(OSFBasePage):
+    """The base page from which all collection pages inherit."""
+
+    base_url = settings.OSF_HOME + '/collections/'
+    url_addition = ''
+    navbar = ComponentLocator(CollectionsNavbar)
+
+    def __init__(self, driver, verify=False, provider=None):
+        self.provider = provider
+        if provider:
+            self.provider_id = provider['id']
+            self.provider_name = provider['attributes']['name']
+
+        super().__init__(driver, verify)
+
+    @property
+    def url(self):
+        """Set the URL based on the provider domain."""
+        return urljoin(self.base_url, self.provider_id) + '/' + self.url_addition
+
+    def verify(self):
+        """Return true if you are on the expected page.
+        Checks both the general page identity and the branding.
+        """
+        if self.provider:
+            return super().verify() and self.provider_name in self.navbar.title.text
+        return super().verify()
+
+
+class CollectionDiscoverPage(BaseCollectionPage):
+    url_addition = 'discover'
+
+    identity = Locator(By.CSS_SELECTOR, 'div[data-test-provider-branding]')
+    loading_indicator = Locator(By.CSS_SELECTOR, '.ball-scale')
+
+
+class CollectionSubmitPage(BaseCollectionPage):
+    url_addition = 'submit'
+
+    identity = Locator(By.CSS_SELECTOR, 'div[data-test-collections-submit-sections]')
+    project_selector = Locator(
+        By.CSS_SELECTOR, 'span[class="ember-power-select-placeholder"]'
+    )
+    project_help_text = Locator(
+        By.CSS_SELECTOR, '.ember-power-select-option--search-message'
+    )
+    project_selector_project = Locator(By.CSS_SELECTOR, '.ember-power-select-option')
+    license_dropdown_trigger = Locator(By.CLASS_NAME, 'ember-basic-dropdown-trigger')
+    first_license_option = Locator(
+        By.CSS_SELECTOR, '.ember-power-select-options > li:nth-child(1)'
+    )
+    description_textbox = Locator(By.CSS_SELECTOR, 'textarea[name="description"]')
+    tags_input = Locator(By.CLASS_NAME, 'emberTagInput-input')
+    project_metadata_save = Locator(
+        By.CSS_SELECTOR, '[data-test-project-metadata-save-button]'
+    )
+    project_contributors_continue = Locator(
+        By.CSS_SELECTOR, '[data-test-submit-section-continue]'
+    )
+    type_dropdown_trigger = Locator(By.CLASS_NAME, 'ember-basic-dropdown-trigger')
+    first_type_option = Locator(
+        By.CSS_SELECTOR, '.ember-power-select-options > li:nth-child(1)'
+    )
+    collection_metadata_continue = Locator(
+        By.CSS_SELECTOR, '[data-test-submit-section-continue]'
+    )
+    add_to_collection_button = Locator(
+        By.CSS_SELECTOR, '[data-test-collections-submit-submit-button]'
+    )
+    modal_add_to_collection_button = Locator(
+        By.CSS_SELECTOR,
+        '[data-test-collection-submission-confirmation-modal-add-button]',
+    )

--- a/pages/project.py
+++ b/pages/project.py
@@ -34,6 +34,11 @@ class ProjectPage(GuidBasePage):
     make_private_link = Locator(By.XPATH, '//a[contains(text(), "Make Private")]')
     confirm_privacy_change_link = Locator(By.XPATH, '//a[text()="Confirm"]')
     cancel_privacy_change_link = Locator(By.XPATH, '//a[text()="Cancel"]')
+    collections_container = Locator(By.CLASS_NAME, 'collections-container')
+    collections_link = Locator(
+        By.CSS_SELECTOR,
+        'div.collections-container > div > div > div:nth-child(1) > a:nth-child(1)',
+    )
 
     # Components
     file_widget = ComponentLocator(FileWidget)

--- a/tests/test_collections.py
+++ b/tests/test_collections.py
@@ -1,0 +1,107 @@
+import pytest
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support import expected_conditions as EC
+from selenium.webdriver.support.ui import WebDriverWait
+
+import markers
+from api import osf_api
+from pages.collections import (
+    CollectionDiscoverPage,
+    CollectionSubmitPage,
+)
+from pages.project import ProjectPage
+
+
+class TestCollectionDiscoverPages:
+    """This test will load the Discover page for each Collection Provider that exists in
+    an environment.
+    """
+
+    def providers():
+        """Return all collection providers."""
+        return osf_api.get_providers_list(type='collections')
+
+    @pytest.fixture(params=providers(), ids=[prov['id'] for prov in providers()])
+    def provider(self, request):
+        return request.param
+
+    def test_discover_page(self, session, driver, provider):
+        discover_page = CollectionDiscoverPage(driver, provider=provider)
+        discover_page.goto()
+        discover_page.loading_indicator.here_then_gone()
+        assert CollectionDiscoverPage(driver, verify=True)
+
+
+@markers.dont_run_on_prod
+class TestCollectionSubmission:
+    """This tests the process of submitting a project to a Collection via the Collection
+    Submit page for a given provider.  We will be using a specific test collection
+    reserved for Selenium testing in each of the testing environments and therefore we
+    will not be running this test in the Production environment.
+    """
+
+    @pytest.fixture
+    def provider(self, driver):
+        return osf_api.get_provider(type='collections', provider_id='selenium')
+
+    def test_add_to_collection(
+        self,
+        driver,
+        session,
+        provider,
+        project_with_file,
+        must_be_logged_in,
+    ):
+        try:
+            submit_page = CollectionSubmitPage(driver, provider=provider)
+            submit_page.goto()
+            assert CollectionSubmitPage(driver, verify=True)
+            # Select the dummmy project from the listbox in the Select a project section
+            submit_page.project_selector.click()
+            submit_page.project_help_text.here_then_gone()
+            submit_page.project_selector_project.click()
+            # Project metadata section - select a license, enter description, and add tag
+            submit_page.scroll_into_view(submit_page.project_metadata_save.element)
+            submit_page.license_dropdown_trigger.click()
+            submit_page.first_license_option.click()
+            submit_page.description_textbox.click()
+            submit_page.description_textbox.send_keys_deliberately(
+                'QA Selenium Testing'
+            )
+            submit_page.tags_input.click()
+            submit_page.tags_input.send_keys('selenium\r')
+            submit_page.project_metadata_save.click()
+            # Project contributors section - just click Continue button
+            WebDriverWait(driver, 5).until(
+                EC.visibility_of_element_located(
+                    (By.CSS_SELECTOR, '[data-test-project-contributors-list-item-name]')
+                )
+            )
+            submit_page.scroll_into_view(
+                submit_page.project_contributors_continue.element
+            )
+            submit_page.project_contributors_continue.click()
+            # Collection metadata section - select from Type listbox and click Continue
+            submit_page.type_dropdown_trigger.click()
+            submit_page.first_type_option.click()
+            submit_page.collection_metadata_continue.click()
+            # Finally click the Add to collection button at the bottom of the form and on
+            # the confirmation modal to complete the submission
+            submit_page.add_to_collection_button.click()
+            submit_page.modal_add_to_collection_button.click()
+            # After submitting we will end up on the Project page - verify this and verify
+            # there is a new section on Project page indicating the project is part of a
+            # collection with a link to the collection.
+            project_page = ProjectPage(driver, verify=True, guid=project_with_file.id)
+            assert project_page.collections_container.present()
+            assert provider['id'] in project_page.collections_link.get_attribute('href')
+            # Also verify Project is now Public.
+            assert project_page.make_private_link.present()
+        finally:
+            # Need to make project Private to get it to disappear from Collection Discover
+            # page.  The project itself will be deleted through the project_with_file
+            # fixture code.  However, if we don't also make the project private, then
+            # there will be an entry on the Collection Discover page with a dead link.
+            osf_api.update_node_public_attribute(
+                session, project_with_file.id, status=False
+            )


### PR DESCRIPTION
<!-- Before you submit your Pull Request, please confirm that:

     - Any test that will create public data either has the `QAtest` tag or the `dont_run_on_production` marker
     - `core_functionality` is marked as such
     - Your tests will be able to run on *all* servers (all stagings, test)
 -->


## Purpose
To add a new Selenium test that tests the functionality of OSF Collections.


## Summary of Changes

- api/osf_api.py - add 2 new functions: 'get_provider' which returns the information for a given provider from the osf api (can be used for Collections, Registrations, or Preprints providers); and 'update_node_public_attribute' which updates the 'Public' attribute for a given node/project thus enabling us to make a project Public or Private. 
- components/navbars.py - add new class 'CollectionsNavbar" that is specific to OSF Collections
- pages/collections.py - new file with page definitions for OSF Collections associated pages: CollectionDiscoverPage and CollectionSubmitPage
- pages/project.py - add 2 new elements: 'collections_container' and 'collections_link' that only display on Project pages that have been added to a Collection.
- tests/test_collections.py - new test file that tests the functionality of OSF Collections including: TestCollectionDiscoverPages and TestCollectionSubmission


## Reviewer's Actions
`git fetch <remote> pull/<PR_number>/head:newTest/collections`

Run this test using
`tests/test_collections.py -s -v`

## Testing Changes Moving Forward
N/A


## Ticket
ENG-3494 - SEL: Create New Collections Test
https://openscience.atlassian.net/browse/ENG-3494
