### PR TITLE
[ENG-3500] - Add smoke_test marker to Collections test

### DIFF
--- a/tests/test_collections.py
+++ b/tests/test_collections.py
@@ -12,6 +12,7 @@ from pages.collections import (
 from pages.project import ProjectPage
 
 
+@markers.smoke_test
 class TestCollectionDiscoverPages:
     """This test will load the Discover page for each Collection Provider that exists in
     an environment.


### PR DESCRIPTION
<!-- Before you submit your Pull Request, please confirm that:

     - Any test that will create public data either has the `QAtest` tag or the `dont_run_on_production` marker
     - `core_functionality` is marked as such
     - Your tests will be able to run on *all* servers (all stagings, test)
 -->


## Purpose
Adding smoke_test marker to test class for Collections Discover pages to ensure that these pages get tested nightly in the Production Smoke test run.


## Summary of Changes

- tests/test_collections.py - add @markers.smoke_test to TestCollectionDiscoverPages class


## Reviewer's Actions
`git fetch <remote> pull/<PR_number>/head:testFix/collections`

Run this test using
`tests/test_collections.py -s -v -m smoke_test`

## Testing Changes Moving Forward
N/A


## Ticket
ENG-3500: SEL: Collections Test - Add smoke_test marker
https://openscience.atlassian.net/browse/ENG-3500
