### PR TITLE
[WIP][FEATURE-1477] FE Intercept

### DIFF
--- a/pages/dashboard.py
+++ b/pages/dashboard.py
@@ -47,6 +47,11 @@ class DashboardPage(BaseDashboardPage):
         By.CSS_SELECTOR, '.carousel-control.right'
     )
 
+    # First in search results
+    search_string = 'African and European Birbs'
+    result_first_match = Locator(By.CSS_SELECTOR, 'div[data-test-dashboard-item]')
+   
+
     # Group Locators
     institution_carousel_logos = GroupLocator(By.CSS_SELECTOR, '.carousel-inner img')
 
@@ -97,3 +102,4 @@ class LegacyDashboardPage(BaseDashboardPage):
     create_project_modal = ComponentLocator(components.CreateProjectModal)
     project_created_modal = ComponentLocator(components.ProjectCreatedModal)
     project_list = ComponentLocator(components.ProjectList)
+

--- a/pages/files.py
+++ b/pages/files.py
@@ -1,0 +1,55 @@
+from selenium.common.exceptions import NoSuchElementException
+from selenium.webdriver.common.by import By
+
+import settings
+from base.locators import (
+    ComponentLocator,
+    GroupLocator,
+    Locator,
+)
+from components.navbars import RegistriesNavbar
+from pages.base import (
+    GuidBasePage,
+    OSFBasePage,
+)
+
+class BaseFilesPage(OSFBasePage):
+
+    # Components
+    navbar = ComponentLocator(RegistriesNavbar)
+
+
+class FilesListPage(BaseFilesPage):
+    provider = 'osfstorage'
+    guid = '4nrqw'
+    url = settings.OSF_HOME + '/' + guid + '/' + 'files' + '/' + provider  + '/'
+
+    # file name link
+    file_link = Locator(By.CSS_SELECTOR, '[data-test-file-name]')
+
+    # file actions menu trigger
+    file_actions_menu = Locator(By.CSS_SELECTOR, '[data-test-file-download-share-trigger]')
+
+    # download file
+    download_file_action = Locator(By.CSS_SELECTOR, '[data-test-download-button]')
+
+    # delete file
+    delete_file_action = Locator(By.CSS_SELECTOR, '[]')
+
+    # embed file
+    embed_file_action = Locator(By.CSS_SELECTOR, '[data-test-embed-button]')
+
+    # embed JS
+    embed_js_action = Locator(By.CSS_SELECTOR, '[data-test-copy-js]')
+
+    # embed HTML
+    embed_html_action = Locator(By.CSS_SELECTOR, '[data-test-copy-htnml]')
+
+    # share file
+    share_file_action = Locator(By.CSS_SELECTOR, '[data-test-social-sharing-button]')
+
+    # rename file
+    rename_file_action = Locator(By.CSS_SELECTOR, '[]')
+
+    # move file
+    move_file_action = Locator(By.CSS_SELECTOR, '[]')

--- a/pages/login.py
+++ b/pages/login.py
@@ -135,6 +135,21 @@ def login(driver, user=settings.USER_ONE, password=settings.USER_ONE_PASSWORD):
     login_page.goto()
     login_page.submit_login(user, password)
 
+def login_admin(driver, user=settings.USER_ONE, password=settings.USER_ONE_PASSWORD):
+    login_page = LoginPage(driver)
+    login_page.goto()
+    login_page.submit_login(user, password)
+
+def login_read_write(driver, user=settings.USER_TWO, password=settings.USER_TWO_PASSWORD):
+    login_page = LoginPage(driver)
+    login_page.goto()
+    login_page.submit_login(user, password)
+
+def login_read_only(driver, user=settings.USER_THREE, password=settings.USER_THREE_PASSWORD):
+    login_page = LoginPage(driver)
+    login_page.goto()
+    login_page.submit_login(user, password)
+
 
 def safe_login(driver, user=settings.USER_ONE, password=settings.USER_ONE_PASSWORD):
     """Raise a LoginError if login fails."""

--- a/pages/project.py
+++ b/pages/project.py
@@ -34,6 +34,7 @@ class ProjectPage(GuidBasePage):
     make_private_link = Locator(By.XPATH, '//a[contains(text(), "Make Private")]')
     confirm_privacy_change_link = Locator(By.XPATH, '//a[text()="Confirm"]')
     cancel_privacy_change_link = Locator(By.XPATH, '//a[text()="Cancel"]')
+    project_files_tab =  Locator(By.ID, 'projectNavFiles')
 
     # Components
     file_widget = ComponentLocator(FileWidget)

--- a/pages/registries.py
+++ b/pages/registries.py
@@ -100,7 +100,7 @@ class RegistrationDraftPage(BaseRegistriesPage):
 
     add_contributor_search_button = Locator(By.XPATH, '//form[1]//div[4]//button[1]')
 
-    add_first_contributor_result = Locator(By.XPATH, '//form[1]//div["data-test-user-search-results"][4]//div[2]//div[3]//div[1]//span[4]//button[1]')
+    add_first_contributor_result = GroupLocator(By.XPATH, '//form[1]//div["data-test-user-search-results"][4]//div[2]//div[3]//div[1]//span[4]//button[1]')
 
     remove_contributor_button_first_el = Locator(By.XPATH, 'button[data-test-start-registration-button]') # for use with method to first clear all contributors
 
@@ -143,6 +143,8 @@ class RegistrationDraftPage(BaseRegistriesPage):
     demo_back_button = Locator(By.XPATH, '//button[text()="Submit"]//following-sibling::button[text()="Back"]')
 
     register_draft_button = Locator(By.XPATH, '//button[text()="Register"]')
+
+    submit_draft_button = Locator(By.XPATH, '//button[text()="Submit"]')
 
 class MyRegistrationsPage(BaseRegistriesPage):
     identity = Locator(By.CSS_SELECTOR, '[]')

--- a/pages/registries.py
+++ b/pages/registries.py
@@ -64,6 +64,85 @@ class RegistrationAddNewPage(BaseRegistriesPage):
     url = settings.OSF_HOME + '/registries/osf/new'
     identity = Locator(By.CSS_SELECTOR, 'form[data-test-new-registration-form]', settings.LONG_TIMEOUT)
 
+    # validate add new page
+    add_new_main_wormhole = Locator(By.ID, 'div[ember-basic-dropdown-wormhole]', settings.LONG_TIMEOUT)
+    dropdown_wormhole = Locator(By.XPATH, '//div[@id=‘ember-basic-dropdown-wormhole’]', settings.LONG_TIMEOUT) # this one works
+
+    # has project
+    has_project_button = Locator(By.XPATH, '//body//main[1]//div[2]//div[1]/div[1]//form[1]//div[1]//fieldset[1]//div[1]')
+    # has_project_button = Locator(By.CSS_SELECTOR, 'form > div > fieldset > div:nth-child(2)')
+
+    # no project
+    no_project_button  = Locator(By.XPATH, '//div[@id="ember44"]//form[@class="_registrationForm_1p1l4a"]//div[1]//fieldset[1]//div[2]//input[1]')
+    # has_project_button = Locator(By.CSS_SELECTOR, 'form > div > fieldset > div:nth-child(2)')
+
+    # project_selection
+    project_selection_dropdown = Locator(By.XPATH, '//body//main[1]//div[2]//div[1]/div[1]//form[1]//label[1]//div[1]//span[1]')
+    first_project_selection = Locator(By.XPATH, '//body//div[3]//div[1]//ul[1]//li[1]')
+    second_project_selection =  Locator(By.XPATH, '//body//div[3]//div[1]//ul[1]//li[2]')
+
+    # select schema type
+    schema_type_dropdown = Locator(By.XPATH, '//body//main[1]//div[2]//div[1]/div[1]//form[1]//label[2]//div[1]//span[1]')
+    preregistration_schema_selection = Locator(By.XPATH, '//body//div[3]//div[1]//ul[1]//li[4]')
+    add_new_submit_button = Locator(By.CSS_SELECTOR, 'button[data-test-start-registration-button]')
+
 
 class RegistrationDraftPage(BaseRegistriesPage):
     identity = Locator(By.CSS_SELECTOR, 'nav[data-test-side-nav]', settings.LONG_TIMEOUT)
+
+    registration_title_input = Locator(By.XPATH, '//input["ember-text-field"][1]')
+
+    registration_description_input = Locator(By.XPATH, '//form[1]//textarea[1]')
+
+    add_contributor_plus_button = Locator(By.XPATH, '//form[1]//div[3]//button[1]')
+
+    add_contributor_search_box = Locator(By.XPATH, '//form[1]//div[4]//input[1]')
+
+    add_contributor_search_button = Locator(By.XPATH, '//form[1]//div[4]//button[1]')
+
+    add_first_contributor_result = Locator(By.XPATH, '//form[1]//div["data-test-user-search-results"][4]//div[2]//div[3]//div[1]//span[4]//button[1]')
+
+    remove_contributor_button_first_el = Locator(By.XPATH, 'button[data-test-start-registration-button]') # for use with method to first clear all contributors
+
+    category_power_select = Locator(By.XPATH, '//form[1]//div[6]//div[1]')
+
+    # TODO fill in other dropdown tags for data, other, software, analysis, procedure, and hypothesis
+    category_analysis_dropdown_select = Locator(By.XPATH, '//ul[@class="ember-power-select-options"]//li[@class="ember-power-select-option"]//span[text()="Analysis"]//parent::span//parent::li')
+
+    license_power_select = Locator(By.XPATH, '//form[1]//div[8]//div[1]//div[1]//div[@role="button"]')
+
+    # CC-By Attribution 4.0 International
+    license_cc_international_select = Locator(By.XPATH, '//ul[@class="ember-power-select-options"]//li[@class="ember-power-select-option"]//span[text()="CC-By Attribution 4.0 International"]')
+
+    subject_engineering_checkbox = Locator(By.XPATH, '//label[text()="Engineering"]')
+
+    tags_input = Locator(By.XPATH, '//li[@class="emberTagInput-new"]//input[@aria-label="Add a tag to enhance discoverability"]')
+
+    draft_registration_next_button = Locator(By.XPATH, '//button[text()="Next"]')
+
+    # no_data_collected_radio_button = Locator(By.XPATH, '//main//fieldset//div[1]//div[1]//div[1]//div[1]//input[1]')
+    no_data_collected_radio_button = Locator(By.XPATH, '//input[@value="No, data collection has not begun"]')
+
+    # data_collected_radio_button = Locator(By.XPATH, '//main//fieldset//div[1]//div[1]//div[1]//div[2]//input[1]')
+    data_collected_radio_button = Locator(By.XPATH, '//input[@value="Yes, data collection is underway or complete"]')
+
+    # data_looked_at_radio_button = Locator(By.XPATH, '//main//fieldset[2]//div[1]//div[1]//div[1]//div[1]//input[1]')
+    data_looked_at_radio_button = Locator(By.XPATH, '//input[@value="Yes"]')
+
+    # data_not_looked_at_radio_button = Locator(By.XPATH, '//main//fieldset[2]//div[1]//div[1]//div[1]//div[2]//input[1]')
+    data_not_looked_at_radio_button = Locator(By.XPATH, '//input[@value="No"]')
+
+    comments_textarea = Locator(By.XPATH, '//textarea[1]')
+
+    draft_review_button = Locator(By.XPATH, '//button[text()="Review"]')
+
+    make_registration_public_radio = Locator(By.XPATH, '//input[@value="immediate"]')
+
+    make_registration_embargo_radio = Locator(By.XPATH, '//input[@value="//input[@value="embargo"]')
+
+    demo_back_button = Locator(By.XPATH, '//button[text()="Submit"]//following-sibling::button[text()="Back"]')
+
+    register_draft_button = Locator(By.XPATH, '//button[text()="Register"]')
+
+class MyRegistrationsPage(BaseRegistriesPage):
+    identity = Locator(By.CSS_SELECTOR, '[]')

--- a/pages/registries.py
+++ b/pages/registries.py
@@ -147,4 +147,5 @@ class RegistrationDraftPage(BaseRegistriesPage):
     submit_draft_button = Locator(By.XPATH, '//button[text()="Submit"]')
 
 class MyRegistrationsPage(BaseRegistriesPage):
+    url = settings.OSF_HOME + '/registries/osf/new'
     identity = Locator(By.CSS_SELECTOR, '[]')

--- a/pages/search.py
+++ b/pages/search.py
@@ -12,7 +12,8 @@ class SearchPage(OSFBasePage):
     url = settings.OSF_HOME + '/search/'
 
     identity = Locator(By.ID, 'searchPageFullBar')
-    search_bar = Locator(By.ID, 'searchPageFullBar')
+    # search_bar = Locator(By.ID, 'searchPageFullBar')
+    search_bar = Locator(By.XPATH, '//input[@placeholder="Search your projects"]')
     loading_indicator = Locator(By.CSS_SELECTOR, '.ball-scale')
 
     # Group Locators

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ pre-commit==2.14.0
 ipdb==0.12.2
 black==21.7b0
 isort==5.9.3
+numpy==1.21.5

--- a/scripts/require.js
+++ b/scripts/require.js
@@ -1,0 +1,2145 @@
+/** vim: et:ts=4:sw=4:sts=4
+ * @license RequireJS 2.3.6 Copyright jQuery Foundation and other contributors.
+ * Released under MIT license, https://github.com/requirejs/requirejs/blob/master/LICENSE
+ */
+//Not using strict: uneven strict support in browsers, #392, and causes
+//problems with requirejs.exec()/transpiler plugins that may not be strict.
+/*jslint regexp: true, nomen: true, sloppy: true */
+/*global window, navigator, document, importScripts, setTimeout, opera */
+
+var requirejs, require, define;
+(function (global, setTimeout) {
+    var req, s, head, baseElement, dataMain, src,
+        interactiveScript, currentlyAddingScript, mainScript, subPath,
+        version = '2.3.6',
+        commentRegExp = /\/\*[\s\S]*?\*\/|([^:"'=]|^)\/\/.*$/mg,
+        cjsRequireRegExp = /[^.]\s*require\s*\(\s*["']([^'"\s]+)["']\s*\)/g,
+        jsSuffixRegExp = /\.js$/,
+        currDirRegExp = /^\.\//,
+        op = Object.prototype,
+        ostring = op.toString,
+        hasOwn = op.hasOwnProperty,
+        isBrowser = !!(typeof window !== 'undefined' && typeof navigator !== 'undefined' && window.document),
+        isWebWorker = !isBrowser && typeof importScripts !== 'undefined',
+        //PS3 indicates loaded and complete, but need to wait for complete
+        //specifically. Sequence is 'loading', 'loaded', execution,
+        // then 'complete'. The UA check is unfortunate, but not sure how
+        //to feature test w/o causing perf issues.
+        readyRegExp = isBrowser && navigator.platform === 'PLAYSTATION 3' ?
+                      /^complete$/ : /^(complete|loaded)$/,
+        defContextName = '_',
+        //Oh the tragedy, detecting opera. See the usage of isOpera for reason.
+        isOpera = typeof opera !== 'undefined' && opera.toString() === '[object Opera]',
+        contexts = {},
+        cfg = {},
+        globalDefQueue = [],
+        useInteractive = false;
+
+    //Could match something like ')//comment', do not lose the prefix to comment.
+    function commentReplace(match, singlePrefix) {
+        return singlePrefix || '';
+    }
+
+    function isFunction(it) {
+        return ostring.call(it) === '[object Function]';
+    }
+
+    function isArray(it) {
+        return ostring.call(it) === '[object Array]';
+    }
+
+    /**
+     * Helper function for iterating over an array. If the func returns
+     * a true value, it will break out of the loop.
+     */
+    function each(ary, func) {
+        if (ary) {
+            var i;
+            for (i = 0; i < ary.length; i += 1) {
+                if (ary[i] && func(ary[i], i, ary)) {
+                    break;
+                }
+            }
+        }
+    }
+
+    /**
+     * Helper function for iterating over an array backwards. If the func
+     * returns a true value, it will break out of the loop.
+     */
+    function eachReverse(ary, func) {
+        if (ary) {
+            var i;
+            for (i = ary.length - 1; i > -1; i -= 1) {
+                if (ary[i] && func(ary[i], i, ary)) {
+                    break;
+                }
+            }
+        }
+    }
+
+    function hasProp(obj, prop) {
+        return hasOwn.call(obj, prop);
+    }
+
+    function getOwn(obj, prop) {
+        return hasProp(obj, prop) && obj[prop];
+    }
+
+    /**
+     * Cycles over properties in an object and calls a function for each
+     * property value. If the function returns a truthy value, then the
+     * iteration is stopped.
+     */
+    function eachProp(obj, func) {
+        var prop;
+        for (prop in obj) {
+            if (hasProp(obj, prop)) {
+                if (func(obj[prop], prop)) {
+                    break;
+                }
+            }
+        }
+    }
+
+    /**
+     * Simple function to mix in properties from source into target,
+     * but only if target does not already have a property of the same name.
+     */
+    function mixin(target, source, force, deepStringMixin) {
+        if (source) {
+            eachProp(source, function (value, prop) {
+                if (force || !hasProp(target, prop)) {
+                    if (deepStringMixin && typeof value === 'object' && value &&
+                        !isArray(value) && !isFunction(value) &&
+                        !(value instanceof RegExp)) {
+
+                        if (!target[prop]) {
+                            target[prop] = {};
+                        }
+                        mixin(target[prop], value, force, deepStringMixin);
+                    } else {
+                        target[prop] = value;
+                    }
+                }
+            });
+        }
+        return target;
+    }
+
+    //Similar to Function.prototype.bind, but the 'this' object is specified
+    //first, since it is easier to read/figure out what 'this' will be.
+    function bind(obj, fn) {
+        return function () {
+            return fn.apply(obj, arguments);
+        };
+    }
+
+    function scripts() {
+        return document.getElementsByTagName('script');
+    }
+
+    function defaultOnError(err) {
+        throw err;
+    }
+
+    //Allow getting a global that is expressed in
+    //dot notation, like 'a.b.c'.
+    function getGlobal(value) {
+        if (!value) {
+            return value;
+        }
+        var g = global;
+        each(value.split('.'), function (part) {
+            g = g[part];
+        });
+        return g;
+    }
+
+    /**
+     * Constructs an error with a pointer to an URL with more information.
+     * @param {String} id the error ID that maps to an ID on a web page.
+     * @param {String} message human readable error.
+     * @param {Error} [err] the original error, if there is one.
+     *
+     * @returns {Error}
+     */
+    function makeError(id, msg, err, requireModules) {
+        var e = new Error(msg + '\nhttps://requirejs.org/docs/errors.html#' + id);
+        e.requireType = id;
+        e.requireModules = requireModules;
+        if (err) {
+            e.originalError = err;
+        }
+        return e;
+    }
+
+    if (typeof define !== 'undefined') {
+        //If a define is already in play via another AMD loader,
+        //do not overwrite.
+        return;
+    }
+
+    if (typeof requirejs !== 'undefined') {
+        if (isFunction(requirejs)) {
+            //Do not overwrite an existing requirejs instance.
+            return;
+        }
+        cfg = requirejs;
+        requirejs = undefined;
+    }
+
+    //Allow for a require config object
+    if (typeof require !== 'undefined' && !isFunction(require)) {
+        //assume it is a config object.
+        cfg = require;
+        require = undefined;
+    }
+
+    function newContext(contextName) {
+        var inCheckLoaded, Module, context, handlers,
+            checkLoadedTimeoutId,
+            config = {
+                //Defaults. Do not set a default for map
+                //config to speed up normalize(), which
+                //will run faster if there is no default.
+                waitSeconds: 7,
+                baseUrl: './',
+                paths: {},
+                bundles: {},
+                pkgs: {},
+                shim: {},
+                config: {}
+            },
+            registry = {},
+            //registry of just enabled modules, to speed
+            //cycle breaking code when lots of modules
+            //are registered, but not activated.
+            enabledRegistry = {},
+            undefEvents = {},
+            defQueue = [],
+            defined = {},
+            urlFetched = {},
+            bundlesMap = {},
+            requireCounter = 1,
+            unnormalizedCounter = 1;
+
+        /**
+         * Trims the . and .. from an array of path segments.
+         * It will keep a leading path segment if a .. will become
+         * the first path segment, to help with module name lookups,
+         * which act like paths, but can be remapped. But the end result,
+         * all paths that use this function should look normalized.
+         * NOTE: this method MODIFIES the input array.
+         * @param {Array} ary the array of path segments.
+         */
+        function trimDots(ary) {
+            var i, part;
+            for (i = 0; i < ary.length; i++) {
+                part = ary[i];
+                if (part === '.') {
+                    ary.splice(i, 1);
+                    i -= 1;
+                } else if (part === '..') {
+                    // If at the start, or previous value is still ..,
+                    // keep them so that when converted to a path it may
+                    // still work when converted to a path, even though
+                    // as an ID it is less than ideal. In larger point
+                    // releases, may be better to just kick out an error.
+                    if (i === 0 || (i === 1 && ary[2] === '..') || ary[i - 1] === '..') {
+                        continue;
+                    } else if (i > 0) {
+                        ary.splice(i - 1, 2);
+                        i -= 2;
+                    }
+                }
+            }
+        }
+
+        /**
+         * Given a relative module name, like ./something, normalize it to
+         * a real name that can be mapped to a path.
+         * @param {String} name the relative name
+         * @param {String} baseName a real name that the name arg is relative
+         * to.
+         * @param {Boolean} applyMap apply the map config to the value. Should
+         * only be done if this normalization is for a dependency ID.
+         * @returns {String} normalized name
+         */
+        function normalize(name, baseName, applyMap) {
+            var pkgMain, mapValue, nameParts, i, j, nameSegment, lastIndex,
+                foundMap, foundI, foundStarMap, starI, normalizedBaseParts,
+                baseParts = (baseName && baseName.split('/')),
+                map = config.map,
+                starMap = map && map['*'];
+
+            //Adjust any relative paths.
+            if (name) {
+                name = name.split('/');
+                lastIndex = name.length - 1;
+
+                // If wanting node ID compatibility, strip .js from end
+                // of IDs. Have to do this here, and not in nameToUrl
+                // because node allows either .js or non .js to map
+                // to same file.
+                if (config.nodeIdCompat && jsSuffixRegExp.test(name[lastIndex])) {
+                    name[lastIndex] = name[lastIndex].replace(jsSuffixRegExp, '');
+                }
+
+                // Starts with a '.' so need the baseName
+                if (name[0].charAt(0) === '.' && baseParts) {
+                    //Convert baseName to array, and lop off the last part,
+                    //so that . matches that 'directory' and not name of the baseName's
+                    //module. For instance, baseName of 'one/two/three', maps to
+                    //'one/two/three.js', but we want the directory, 'one/two' for
+                    //this normalization.
+                    normalizedBaseParts = baseParts.slice(0, baseParts.length - 1);
+                    name = normalizedBaseParts.concat(name);
+                }
+
+                trimDots(name);
+                name = name.join('/');
+            }
+
+            //Apply map config if available.
+            if (applyMap && map && (baseParts || starMap)) {
+                nameParts = name.split('/');
+
+                outerLoop: for (i = nameParts.length; i > 0; i -= 1) {
+                    nameSegment = nameParts.slice(0, i).join('/');
+
+                    if (baseParts) {
+                        //Find the longest baseName segment match in the config.
+                        //So, do joins on the biggest to smallest lengths of baseParts.
+                        for (j = baseParts.length; j > 0; j -= 1) {
+                            mapValue = getOwn(map, baseParts.slice(0, j).join('/'));
+
+                            //baseName segment has config, find if it has one for
+                            //this name.
+                            if (mapValue) {
+                                mapValue = getOwn(mapValue, nameSegment);
+                                if (mapValue) {
+                                    //Match, update name to the new value.
+                                    foundMap = mapValue;
+                                    foundI = i;
+                                    break outerLoop;
+                                }
+                            }
+                        }
+                    }
+
+                    //Check for a star map match, but just hold on to it,
+                    //if there is a shorter segment match later in a matching
+                    //config, then favor over this star map.
+                    if (!foundStarMap && starMap && getOwn(starMap, nameSegment)) {
+                        foundStarMap = getOwn(starMap, nameSegment);
+                        starI = i;
+                    }
+                }
+
+                if (!foundMap && foundStarMap) {
+                    foundMap = foundStarMap;
+                    foundI = starI;
+                }
+
+                if (foundMap) {
+                    nameParts.splice(0, foundI, foundMap);
+                    name = nameParts.join('/');
+                }
+            }
+
+            // If the name points to a package's name, use
+            // the package main instead.
+            pkgMain = getOwn(config.pkgs, name);
+
+            return pkgMain ? pkgMain : name;
+        }
+
+        function removeScript(name) {
+            if (isBrowser) {
+                each(scripts(), function (scriptNode) {
+                    if (scriptNode.getAttribute('data-requiremodule') === name &&
+                            scriptNode.getAttribute('data-requirecontext') === context.contextName) {
+                        scriptNode.parentNode.removeChild(scriptNode);
+                        return true;
+                    }
+                });
+            }
+        }
+
+        function hasPathFallback(id) {
+            var pathConfig = getOwn(config.paths, id);
+            if (pathConfig && isArray(pathConfig) && pathConfig.length > 1) {
+                //Pop off the first array value, since it failed, and
+                //retry
+                pathConfig.shift();
+                context.require.undef(id);
+
+                //Custom require that does not do map translation, since
+                //ID is "absolute", already mapped/resolved.
+                context.makeRequire(null, {
+                    skipMap: true
+                })([id]);
+
+                return true;
+            }
+        }
+
+        //Turns a plugin!resource to [plugin, resource]
+        //with the plugin being undefined if the name
+        //did not have a plugin prefix.
+        function splitPrefix(name) {
+            var prefix,
+                index = name ? name.indexOf('!') : -1;
+            if (index > -1) {
+                prefix = name.substring(0, index);
+                name = name.substring(index + 1, name.length);
+            }
+            return [prefix, name];
+        }
+
+        /**
+         * Creates a module mapping that includes plugin prefix, module
+         * name, and path. If parentModuleMap is provided it will
+         * also normalize the name via require.normalize()
+         *
+         * @param {String} name the module name
+         * @param {String} [parentModuleMap] parent module map
+         * for the module name, used to resolve relative names.
+         * @param {Boolean} isNormalized: is the ID already normalized.
+         * This is true if this call is done for a define() module ID.
+         * @param {Boolean} applyMap: apply the map config to the ID.
+         * Should only be true if this map is for a dependency.
+         *
+         * @returns {Object}
+         */
+        function makeModuleMap(name, parentModuleMap, isNormalized, applyMap) {
+            var url, pluginModule, suffix, nameParts,
+                prefix = null,
+                parentName = parentModuleMap ? parentModuleMap.name : null,
+                originalName = name,
+                isDefine = true,
+                normalizedName = '';
+
+            //If no name, then it means it is a require call, generate an
+            //internal name.
+            if (!name) {
+                isDefine = false;
+                name = '_@r' + (requireCounter += 1);
+            }
+
+            nameParts = splitPrefix(name);
+            prefix = nameParts[0];
+            name = nameParts[1];
+
+            if (prefix) {
+                prefix = normalize(prefix, parentName, applyMap);
+                pluginModule = getOwn(defined, prefix);
+            }
+
+            //Account for relative paths if there is a base name.
+            if (name) {
+                if (prefix) {
+                    if (isNormalized) {
+                        normalizedName = name;
+                    } else if (pluginModule && pluginModule.normalize) {
+                        //Plugin is loaded, use its normalize method.
+                        normalizedName = pluginModule.normalize(name, function (name) {
+                            return normalize(name, parentName, applyMap);
+                        });
+                    } else {
+                        // If nested plugin references, then do not try to
+                        // normalize, as it will not normalize correctly. This
+                        // places a restriction on resourceIds, and the longer
+                        // term solution is not to normalize until plugins are
+                        // loaded and all normalizations to allow for async
+                        // loading of a loader plugin. But for now, fixes the
+                        // common uses. Details in #1131
+                        normalizedName = name.indexOf('!') === -1 ?
+                                         normalize(name, parentName, applyMap) :
+                                         name;
+                    }
+                } else {
+                    //A regular module.
+                    normalizedName = normalize(name, parentName, applyMap);
+
+                    //Normalized name may be a plugin ID due to map config
+                    //application in normalize. The map config values must
+                    //already be normalized, so do not need to redo that part.
+                    nameParts = splitPrefix(normalizedName);
+                    prefix = nameParts[0];
+                    normalizedName = nameParts[1];
+                    isNormalized = true;
+
+                    url = context.nameToUrl(normalizedName);
+                }
+            }
+
+            //If the id is a plugin id that cannot be determined if it needs
+            //normalization, stamp it with a unique ID so two matching relative
+            //ids that may conflict can be separate.
+            suffix = prefix && !pluginModule && !isNormalized ?
+                     '_unnormalized' + (unnormalizedCounter += 1) :
+                     '';
+
+            return {
+                prefix: prefix,
+                name: normalizedName,
+                parentMap: parentModuleMap,
+                unnormalized: !!suffix,
+                url: url,
+                originalName: originalName,
+                isDefine: isDefine,
+                id: (prefix ?
+                        prefix + '!' + normalizedName :
+                        normalizedName) + suffix
+            };
+        }
+
+        function getModule(depMap) {
+            var id = depMap.id,
+                mod = getOwn(registry, id);
+
+            if (!mod) {
+                mod = registry[id] = new context.Module(depMap);
+            }
+
+            return mod;
+        }
+
+        function on(depMap, name, fn) {
+            var id = depMap.id,
+                mod = getOwn(registry, id);
+
+            if (hasProp(defined, id) &&
+                    (!mod || mod.defineEmitComplete)) {
+                if (name === 'defined') {
+                    fn(defined[id]);
+                }
+            } else {
+                mod = getModule(depMap);
+                if (mod.error && name === 'error') {
+                    fn(mod.error);
+                } else {
+                    mod.on(name, fn);
+                }
+            }
+        }
+
+        function onError(err, errback) {
+            var ids = err.requireModules,
+                notified = false;
+
+            if (errback) {
+                errback(err);
+            } else {
+                each(ids, function (id) {
+                    var mod = getOwn(registry, id);
+                    if (mod) {
+                        //Set error on module, so it skips timeout checks.
+                        mod.error = err;
+                        if (mod.events.error) {
+                            notified = true;
+                            mod.emit('error', err);
+                        }
+                    }
+                });
+
+                if (!notified) {
+                    req.onError(err);
+                }
+            }
+        }
+
+        /**
+         * Internal method to transfer globalQueue items to this context's
+         * defQueue.
+         */
+        function takeGlobalQueue() {
+            //Push all the globalDefQueue items into the context's defQueue
+            if (globalDefQueue.length) {
+                each(globalDefQueue, function(queueItem) {
+                    var id = queueItem[0];
+                    if (typeof id === 'string') {
+                        context.defQueueMap[id] = true;
+                    }
+                    defQueue.push(queueItem);
+                });
+                globalDefQueue = [];
+            }
+        }
+
+        handlers = {
+            'require': function (mod) {
+                if (mod.require) {
+                    return mod.require;
+                } else {
+                    return (mod.require = context.makeRequire(mod.map));
+                }
+            },
+            'exports': function (mod) {
+                mod.usingExports = true;
+                if (mod.map.isDefine) {
+                    if (mod.exports) {
+                        return (defined[mod.map.id] = mod.exports);
+                    } else {
+                        return (mod.exports = defined[mod.map.id] = {});
+                    }
+                }
+            },
+            'module': function (mod) {
+                if (mod.module) {
+                    return mod.module;
+                } else {
+                    return (mod.module = {
+                        id: mod.map.id,
+                        uri: mod.map.url,
+                        config: function () {
+                            return getOwn(config.config, mod.map.id) || {};
+                        },
+                        exports: mod.exports || (mod.exports = {})
+                    });
+                }
+            }
+        };
+
+        function cleanRegistry(id) {
+            //Clean up machinery used for waiting modules.
+            delete registry[id];
+            delete enabledRegistry[id];
+        }
+
+        function breakCycle(mod, traced, processed) {
+            var id = mod.map.id;
+
+            if (mod.error) {
+                mod.emit('error', mod.error);
+            } else {
+                traced[id] = true;
+                each(mod.depMaps, function (depMap, i) {
+                    var depId = depMap.id,
+                        dep = getOwn(registry, depId);
+
+                    //Only force things that have not completed
+                    //being defined, so still in the registry,
+                    //and only if it has not been matched up
+                    //in the module already.
+                    if (dep && !mod.depMatched[i] && !processed[depId]) {
+                        if (getOwn(traced, depId)) {
+                            mod.defineDep(i, defined[depId]);
+                            mod.check(); //pass false?
+                        } else {
+                            breakCycle(dep, traced, processed);
+                        }
+                    }
+                });
+                processed[id] = true;
+            }
+        }
+
+        function checkLoaded() {
+            var err, usingPathFallback,
+                waitInterval = config.waitSeconds * 1000,
+                //It is possible to disable the wait interval by using waitSeconds of 0.
+                expired = waitInterval && (context.startTime + waitInterval) < new Date().getTime(),
+                noLoads = [],
+                reqCalls = [],
+                stillLoading = false,
+                needCycleCheck = true;
+
+            //Do not bother if this call was a result of a cycle break.
+            if (inCheckLoaded) {
+                return;
+            }
+
+            inCheckLoaded = true;
+
+            //Figure out the state of all the modules.
+            eachProp(enabledRegistry, function (mod) {
+                var map = mod.map,
+                    modId = map.id;
+
+                //Skip things that are not enabled or in error state.
+                if (!mod.enabled) {
+                    return;
+                }
+
+                if (!map.isDefine) {
+                    reqCalls.push(mod);
+                }
+
+                if (!mod.error) {
+                    //If the module should be executed, and it has not
+                    //been inited and time is up, remember it.
+                    if (!mod.inited && expired) {
+                        if (hasPathFallback(modId)) {
+                            usingPathFallback = true;
+                            stillLoading = true;
+                        } else {
+                            noLoads.push(modId);
+                            removeScript(modId);
+                        }
+                    } else if (!mod.inited && mod.fetched && map.isDefine) {
+                        stillLoading = true;
+                        if (!map.prefix) {
+                            //No reason to keep looking for unfinished
+                            //loading. If the only stillLoading is a
+                            //plugin resource though, keep going,
+                            //because it may be that a plugin resource
+                            //is waiting on a non-plugin cycle.
+                            return (needCycleCheck = false);
+                        }
+                    }
+                }
+            });
+
+            if (expired && noLoads.length) {
+                //If wait time expired, throw error of unloaded modules.
+                err = makeError('timeout', 'Load timeout for modules: ' + noLoads, null, noLoads);
+                err.contextName = context.contextName;
+                return onError(err);
+            }
+
+            //Not expired, check for a cycle.
+            if (needCycleCheck) {
+                each(reqCalls, function (mod) {
+                    breakCycle(mod, {}, {});
+                });
+            }
+
+            //If still waiting on loads, and the waiting load is something
+            //other than a plugin resource, or there are still outstanding
+            //scripts, then just try back later.
+            if ((!expired || usingPathFallback) && stillLoading) {
+                //Something is still waiting to load. Wait for it, but only
+                //if a timeout is not already in effect.
+                if ((isBrowser || isWebWorker) && !checkLoadedTimeoutId) {
+                    checkLoadedTimeoutId = setTimeout(function () {
+                        checkLoadedTimeoutId = 0;
+                        checkLoaded();
+                    }, 50);
+                }
+            }
+
+            inCheckLoaded = false;
+        }
+
+        Module = function (map) {
+            this.events = getOwn(undefEvents, map.id) || {};
+            this.map = map;
+            this.shim = getOwn(config.shim, map.id);
+            this.depExports = [];
+            this.depMaps = [];
+            this.depMatched = [];
+            this.pluginMaps = {};
+            this.depCount = 0;
+
+            /* this.exports this.factory
+               this.depMaps = [],
+               this.enabled, this.fetched
+            */
+        };
+
+        Module.prototype = {
+            init: function (depMaps, factory, errback, options) {
+                options = options || {};
+
+                //Do not do more inits if already done. Can happen if there
+                //are multiple define calls for the same module. That is not
+                //a normal, common case, but it is also not unexpected.
+                if (this.inited) {
+                    return;
+                }
+
+                this.factory = factory;
+
+                if (errback) {
+                    //Register for errors on this module.
+                    this.on('error', errback);
+                } else if (this.events.error) {
+                    //If no errback already, but there are error listeners
+                    //on this module, set up an errback to pass to the deps.
+                    errback = bind(this, function (err) {
+                        this.emit('error', err);
+                    });
+                }
+
+                //Do a copy of the dependency array, so that
+                //source inputs are not modified. For example
+                //"shim" deps are passed in here directly, and
+                //doing a direct modification of the depMaps array
+                //would affect that config.
+                this.depMaps = depMaps && depMaps.slice(0);
+
+                this.errback = errback;
+
+                //Indicate this module has be initialized
+                this.inited = true;
+
+                this.ignore = options.ignore;
+
+                //Could have option to init this module in enabled mode,
+                //or could have been previously marked as enabled. However,
+                //the dependencies are not known until init is called. So
+                //if enabled previously, now trigger dependencies as enabled.
+                if (options.enabled || this.enabled) {
+                    //Enable this module and dependencies.
+                    //Will call this.check()
+                    this.enable();
+                } else {
+                    this.check();
+                }
+            },
+
+            defineDep: function (i, depExports) {
+                //Because of cycles, defined callback for a given
+                //export can be called more than once.
+                if (!this.depMatched[i]) {
+                    this.depMatched[i] = true;
+                    this.depCount -= 1;
+                    this.depExports[i] = depExports;
+                }
+            },
+
+            fetch: function () {
+                if (this.fetched) {
+                    return;
+                }
+                this.fetched = true;
+
+                context.startTime = (new Date()).getTime();
+
+                var map = this.map;
+
+                //If the manager is for a plugin managed resource,
+                //ask the plugin to load it now.
+                if (this.shim) {
+                    context.makeRequire(this.map, {
+                        enableBuildCallback: true
+                    })(this.shim.deps || [], bind(this, function () {
+                        return map.prefix ? this.callPlugin() : this.load();
+                    }));
+                } else {
+                    //Regular dependency.
+                    return map.prefix ? this.callPlugin() : this.load();
+                }
+            },
+
+            load: function () {
+                var url = this.map.url;
+
+                //Regular dependency.
+                if (!urlFetched[url]) {
+                    urlFetched[url] = true;
+                    context.load(this.map.id, url);
+                }
+            },
+
+            /**
+             * Checks if the module is ready to define itself, and if so,
+             * define it.
+             */
+            check: function () {
+                if (!this.enabled || this.enabling) {
+                    return;
+                }
+
+                var err, cjsModule,
+                    id = this.map.id,
+                    depExports = this.depExports,
+                    exports = this.exports,
+                    factory = this.factory;
+
+                if (!this.inited) {
+                    // Only fetch if not already in the defQueue.
+                    if (!hasProp(context.defQueueMap, id)) {
+                        this.fetch();
+                    }
+                } else if (this.error) {
+                    this.emit('error', this.error);
+                } else if (!this.defining) {
+                    //The factory could trigger another require call
+                    //that would result in checking this module to
+                    //define itself again. If already in the process
+                    //of doing that, skip this work.
+                    this.defining = true;
+
+                    if (this.depCount < 1 && !this.defined) {
+                        if (isFunction(factory)) {
+                            //If there is an error listener, favor passing
+                            //to that instead of throwing an error. However,
+                            //only do it for define()'d  modules. require
+                            //errbacks should not be called for failures in
+                            //their callbacks (#699). However if a global
+                            //onError is set, use that.
+                            if ((this.events.error && this.map.isDefine) ||
+                                req.onError !== defaultOnError) {
+                                try {
+                                    exports = context.execCb(id, factory, depExports, exports);
+                                } catch (e) {
+                                    err = e;
+                                }
+                            } else {
+                                exports = context.execCb(id, factory, depExports, exports);
+                            }
+
+                            // Favor return value over exports. If node/cjs in play,
+                            // then will not have a return value anyway. Favor
+                            // module.exports assignment over exports object.
+                            if (this.map.isDefine && exports === undefined) {
+                                cjsModule = this.module;
+                                if (cjsModule) {
+                                    exports = cjsModule.exports;
+                                } else if (this.usingExports) {
+                                    //exports already set the defined value.
+                                    exports = this.exports;
+                                }
+                            }
+
+                            if (err) {
+                                err.requireMap = this.map;
+                                err.requireModules = this.map.isDefine ? [this.map.id] : null;
+                                err.requireType = this.map.isDefine ? 'define' : 'require';
+                                return onError((this.error = err));
+                            }
+
+                        } else {
+                            //Just a literal value
+                            exports = factory;
+                        }
+
+                        this.exports = exports;
+
+                        if (this.map.isDefine && !this.ignore) {
+                            defined[id] = exports;
+
+                            if (req.onResourceLoad) {
+                                var resLoadMaps = [];
+                                each(this.depMaps, function (depMap) {
+                                    resLoadMaps.push(depMap.normalizedMap || depMap);
+                                });
+                                req.onResourceLoad(context, this.map, resLoadMaps);
+                            }
+                        }
+
+                        //Clean up
+                        cleanRegistry(id);
+
+                        this.defined = true;
+                    }
+
+                    //Finished the define stage. Allow calling check again
+                    //to allow define notifications below in the case of a
+                    //cycle.
+                    this.defining = false;
+
+                    if (this.defined && !this.defineEmitted) {
+                        this.defineEmitted = true;
+                        this.emit('defined', this.exports);
+                        this.defineEmitComplete = true;
+                    }
+
+                }
+            },
+
+            callPlugin: function () {
+                var map = this.map,
+                    id = map.id,
+                    //Map already normalized the prefix.
+                    pluginMap = makeModuleMap(map.prefix);
+
+                //Mark this as a dependency for this plugin, so it
+                //can be traced for cycles.
+                this.depMaps.push(pluginMap);
+
+                on(pluginMap, 'defined', bind(this, function (plugin) {
+                    var load, normalizedMap, normalizedMod,
+                        bundleId = getOwn(bundlesMap, this.map.id),
+                        name = this.map.name,
+                        parentName = this.map.parentMap ? this.map.parentMap.name : null,
+                        localRequire = context.makeRequire(map.parentMap, {
+                            enableBuildCallback: true
+                        });
+
+                    //If current map is not normalized, wait for that
+                    //normalized name to load instead of continuing.
+                    if (this.map.unnormalized) {
+                        //Normalize the ID if the plugin allows it.
+                        if (plugin.normalize) {
+                            name = plugin.normalize(name, function (name) {
+                                return normalize(name, parentName, true);
+                            }) || '';
+                        }
+
+                        //prefix and name should already be normalized, no need
+                        //for applying map config again either.
+                        normalizedMap = makeModuleMap(map.prefix + '!' + name,
+                                                      this.map.parentMap,
+                                                      true);
+                        on(normalizedMap,
+                            'defined', bind(this, function (value) {
+                                this.map.normalizedMap = normalizedMap;
+                                this.init([], function () { return value; }, null, {
+                                    enabled: true,
+                                    ignore: true
+                                });
+                            }));
+
+                        normalizedMod = getOwn(registry, normalizedMap.id);
+                        if (normalizedMod) {
+                            //Mark this as a dependency for this plugin, so it
+                            //can be traced for cycles.
+                            this.depMaps.push(normalizedMap);
+
+                            if (this.events.error) {
+                                normalizedMod.on('error', bind(this, function (err) {
+                                    this.emit('error', err);
+                                }));
+                            }
+                            normalizedMod.enable();
+                        }
+
+                        return;
+                    }
+
+                    //If a paths config, then just load that file instead to
+                    //resolve the plugin, as it is built into that paths layer.
+                    if (bundleId) {
+                        this.map.url = context.nameToUrl(bundleId);
+                        this.load();
+                        return;
+                    }
+
+                    load = bind(this, function (value) {
+                        this.init([], function () { return value; }, null, {
+                            enabled: true
+                        });
+                    });
+
+                    load.error = bind(this, function (err) {
+                        this.inited = true;
+                        this.error = err;
+                        err.requireModules = [id];
+
+                        //Remove temp unnormalized modules for this module,
+                        //since they will never be resolved otherwise now.
+                        eachProp(registry, function (mod) {
+                            if (mod.map.id.indexOf(id + '_unnormalized') === 0) {
+                                cleanRegistry(mod.map.id);
+                            }
+                        });
+
+                        onError(err);
+                    });
+
+                    //Allow plugins to load other code without having to know the
+                    //context or how to 'complete' the load.
+                    load.fromText = bind(this, function (text, textAlt) {
+                        /*jslint evil: true */
+                        var moduleName = map.name,
+                            moduleMap = makeModuleMap(moduleName),
+                            hasInteractive = useInteractive;
+
+                        //As of 2.1.0, support just passing the text, to reinforce
+                        //fromText only being called once per resource. Still
+                        //support old style of passing moduleName but discard
+                        //that moduleName in favor of the internal ref.
+                        if (textAlt) {
+                            text = textAlt;
+                        }
+
+                        //Turn off interactive script matching for IE for any define
+                        //calls in the text, then turn it back on at the end.
+                        if (hasInteractive) {
+                            useInteractive = false;
+                        }
+
+                        //Prime the system by creating a module instance for
+                        //it.
+                        getModule(moduleMap);
+
+                        //Transfer any config to this other module.
+                        if (hasProp(config.config, id)) {
+                            config.config[moduleName] = config.config[id];
+                        }
+
+                        try {
+                            req.exec(text);
+                        } catch (e) {
+                            return onError(makeError('fromtexteval',
+                                             'fromText eval for ' + id +
+                                            ' failed: ' + e,
+                                             e,
+                                             [id]));
+                        }
+
+                        if (hasInteractive) {
+                            useInteractive = true;
+                        }
+
+                        //Mark this as a dependency for the plugin
+                        //resource
+                        this.depMaps.push(moduleMap);
+
+                        //Support anonymous modules.
+                        context.completeLoad(moduleName);
+
+                        //Bind the value of that module to the value for this
+                        //resource ID.
+                        localRequire([moduleName], load);
+                    });
+
+                    //Use parentName here since the plugin's name is not reliable,
+                    //could be some weird string with no path that actually wants to
+                    //reference the parentName's path.
+                    plugin.load(map.name, localRequire, load, config);
+                }));
+
+                context.enable(pluginMap, this);
+                this.pluginMaps[pluginMap.id] = pluginMap;
+            },
+
+            enable: function () {
+                enabledRegistry[this.map.id] = this;
+                this.enabled = true;
+
+                //Set flag mentioning that the module is enabling,
+                //so that immediate calls to the defined callbacks
+                //for dependencies do not trigger inadvertent load
+                //with the depCount still being zero.
+                this.enabling = true;
+
+                //Enable each dependency
+                each(this.depMaps, bind(this, function (depMap, i) {
+                    var id, mod, handler;
+
+                    if (typeof depMap === 'string') {
+                        //Dependency needs to be converted to a depMap
+                        //and wired up to this module.
+                        depMap = makeModuleMap(depMap,
+                                               (this.map.isDefine ? this.map : this.map.parentMap),
+                                               false,
+                                               !this.skipMap);
+                        this.depMaps[i] = depMap;
+
+                        handler = getOwn(handlers, depMap.id);
+
+                        if (handler) {
+                            this.depExports[i] = handler(this);
+                            return;
+                        }
+
+                        this.depCount += 1;
+
+                        on(depMap, 'defined', bind(this, function (depExports) {
+                            if (this.undefed) {
+                                return;
+                            }
+                            this.defineDep(i, depExports);
+                            this.check();
+                        }));
+
+                        if (this.errback) {
+                            on(depMap, 'error', bind(this, this.errback));
+                        } else if (this.events.error) {
+                            // No direct errback on this module, but something
+                            // else is listening for errors, so be sure to
+                            // propagate the error correctly.
+                            on(depMap, 'error', bind(this, function(err) {
+                                this.emit('error', err);
+                            }));
+                        }
+                    }
+
+                    id = depMap.id;
+                    mod = registry[id];
+
+                    //Skip special modules like 'require', 'exports', 'module'
+                    //Also, don't call enable if it is already enabled,
+                    //important in circular dependency cases.
+                    if (!hasProp(handlers, id) && mod && !mod.enabled) {
+                        context.enable(depMap, this);
+                    }
+                }));
+
+                //Enable each plugin that is used in
+                //a dependency
+                eachProp(this.pluginMaps, bind(this, function (pluginMap) {
+                    var mod = getOwn(registry, pluginMap.id);
+                    if (mod && !mod.enabled) {
+                        context.enable(pluginMap, this);
+                    }
+                }));
+
+                this.enabling = false;
+
+                this.check();
+            },
+
+            on: function (name, cb) {
+                var cbs = this.events[name];
+                if (!cbs) {
+                    cbs = this.events[name] = [];
+                }
+                cbs.push(cb);
+            },
+
+            emit: function (name, evt) {
+                each(this.events[name], function (cb) {
+                    cb(evt);
+                });
+                if (name === 'error') {
+                    //Now that the error handler was triggered, remove
+                    //the listeners, since this broken Module instance
+                    //can stay around for a while in the registry.
+                    delete this.events[name];
+                }
+            }
+        };
+
+        function callGetModule(args) {
+            //Skip modules already defined.
+            if (!hasProp(defined, args[0])) {
+                getModule(makeModuleMap(args[0], null, true)).init(args[1], args[2]);
+            }
+        }
+
+        function removeListener(node, func, name, ieName) {
+            //Favor detachEvent because of IE9
+            //issue, see attachEvent/addEventListener comment elsewhere
+            //in this file.
+            if (node.detachEvent && !isOpera) {
+                //Probably IE. If not it will throw an error, which will be
+                //useful to know.
+                if (ieName) {
+                    node.detachEvent(ieName, func);
+                }
+            } else {
+                node.removeEventListener(name, func, false);
+            }
+        }
+
+        /**
+         * Given an event from a script node, get the requirejs info from it,
+         * and then removes the event listeners on the node.
+         * @param {Event} evt
+         * @returns {Object}
+         */
+        function getScriptData(evt) {
+            //Using currentTarget instead of target for Firefox 2.0's sake. Not
+            //all old browsers will be supported, but this one was easy enough
+            //to support and still makes sense.
+            var node = evt.currentTarget || evt.srcElement;
+
+            //Remove the listeners once here.
+            removeListener(node, context.onScriptLoad, 'load', 'onreadystatechange');
+            removeListener(node, context.onScriptError, 'error');
+
+            return {
+                node: node,
+                id: node && node.getAttribute('data-requiremodule')
+            };
+        }
+
+        function intakeDefines() {
+            var args;
+
+            //Any defined modules in the global queue, intake them now.
+            takeGlobalQueue();
+
+            //Make sure any remaining defQueue items get properly processed.
+            while (defQueue.length) {
+                args = defQueue.shift();
+                if (args[0] === null) {
+                    return onError(makeError('mismatch', 'Mismatched anonymous define() module: ' +
+                        args[args.length - 1]));
+                } else {
+                    //args are id, deps, factory. Should be normalized by the
+                    //define() function.
+                    callGetModule(args);
+                }
+            }
+            context.defQueueMap = {};
+        }
+
+        context = {
+            config: config,
+            contextName: contextName,
+            registry: registry,
+            defined: defined,
+            urlFetched: urlFetched,
+            defQueue: defQueue,
+            defQueueMap: {},
+            Module: Module,
+            makeModuleMap: makeModuleMap,
+            nextTick: req.nextTick,
+            onError: onError,
+
+            /**
+             * Set a configuration for the context.
+             * @param {Object} cfg config object to integrate.
+             */
+            configure: function (cfg) {
+                //Make sure the baseUrl ends in a slash.
+                if (cfg.baseUrl) {
+                    if (cfg.baseUrl.charAt(cfg.baseUrl.length - 1) !== '/') {
+                        cfg.baseUrl += '/';
+                    }
+                }
+
+                // Convert old style urlArgs string to a function.
+                if (typeof cfg.urlArgs === 'string') {
+                    var urlArgs = cfg.urlArgs;
+                    cfg.urlArgs = function(id, url) {
+                        return (url.indexOf('?') === -1 ? '?' : '&') + urlArgs;
+                    };
+                }
+
+                //Save off the paths since they require special processing,
+                //they are additive.
+                var shim = config.shim,
+                    objs = {
+                        paths: true,
+                        bundles: true,
+                        config: true,
+                        map: true
+                    };
+
+                eachProp(cfg, function (value, prop) {
+                    if (objs[prop]) {
+                        if (!config[prop]) {
+                            config[prop] = {};
+                        }
+                        mixin(config[prop], value, true, true);
+                    } else {
+                        config[prop] = value;
+                    }
+                });
+
+                //Reverse map the bundles
+                if (cfg.bundles) {
+                    eachProp(cfg.bundles, function (value, prop) {
+                        each(value, function (v) {
+                            if (v !== prop) {
+                                bundlesMap[v] = prop;
+                            }
+                        });
+                    });
+                }
+
+                //Merge shim
+                if (cfg.shim) {
+                    eachProp(cfg.shim, function (value, id) {
+                        //Normalize the structure
+                        if (isArray(value)) {
+                            value = {
+                                deps: value
+                            };
+                        }
+                        if ((value.exports || value.init) && !value.exportsFn) {
+                            value.exportsFn = context.makeShimExports(value);
+                        }
+                        shim[id] = value;
+                    });
+                    config.shim = shim;
+                }
+
+                //Adjust packages if necessary.
+                if (cfg.packages) {
+                    each(cfg.packages, function (pkgObj) {
+                        var location, name;
+
+                        pkgObj = typeof pkgObj === 'string' ? {name: pkgObj} : pkgObj;
+
+                        name = pkgObj.name;
+                        location = pkgObj.location;
+                        if (location) {
+                            config.paths[name] = pkgObj.location;
+                        }
+
+                        //Save pointer to main module ID for pkg name.
+                        //Remove leading dot in main, so main paths are normalized,
+                        //and remove any trailing .js, since different package
+                        //envs have different conventions: some use a module name,
+                        //some use a file name.
+                        config.pkgs[name] = pkgObj.name + '/' + (pkgObj.main || 'main')
+                                     .replace(currDirRegExp, '')
+                                     .replace(jsSuffixRegExp, '');
+                    });
+                }
+
+                //If there are any "waiting to execute" modules in the registry,
+                //update the maps for them, since their info, like URLs to load,
+                //may have changed.
+                eachProp(registry, function (mod, id) {
+                    //If module already has init called, since it is too
+                    //late to modify them, and ignore unnormalized ones
+                    //since they are transient.
+                    if (!mod.inited && !mod.map.unnormalized) {
+                        mod.map = makeModuleMap(id, null, true);
+                    }
+                });
+
+                //If a deps array or a config callback is specified, then call
+                //require with those args. This is useful when require is defined as a
+                //config object before require.js is loaded.
+                if (cfg.deps || cfg.callback) {
+                    context.require(cfg.deps || [], cfg.callback);
+                }
+            },
+
+            makeShimExports: function (value) {
+                function fn() {
+                    var ret;
+                    if (value.init) {
+                        ret = value.init.apply(global, arguments);
+                    }
+                    return ret || (value.exports && getGlobal(value.exports));
+                }
+                return fn;
+            },
+
+            makeRequire: function (relMap, options) {
+                options = options || {};
+
+                function localRequire(deps, callback, errback) {
+                    var id, map, requireMod;
+
+                    if (options.enableBuildCallback && callback && isFunction(callback)) {
+                        callback.__requireJsBuild = true;
+                    }
+
+                    if (typeof deps === 'string') {
+                        if (isFunction(callback)) {
+                            //Invalid call
+                            return onError(makeError('requireargs', 'Invalid require call'), errback);
+                        }
+
+                        //If require|exports|module are requested, get the
+                        //value for them from the special handlers. Caveat:
+                        //this only works while module is being defined.
+                        if (relMap && hasProp(handlers, deps)) {
+                            return handlers[deps](registry[relMap.id]);
+                        }
+
+                        //Synchronous access to one module. If require.get is
+                        //available (as in the Node adapter), prefer that.
+                        if (req.get) {
+                            return req.get(context, deps, relMap, localRequire);
+                        }
+
+                        //Normalize module name, if it contains . or ..
+                        map = makeModuleMap(deps, relMap, false, true);
+                        id = map.id;
+
+                        if (!hasProp(defined, id)) {
+                            return onError(makeError('notloaded', 'Module name "' +
+                                        id +
+                                        '" has not been loaded yet for context: ' +
+                                        contextName +
+                                        (relMap ? '' : '. Use require([])')));
+                        }
+                        return defined[id];
+                    }
+
+                    //Grab defines waiting in the global queue.
+                    intakeDefines();
+
+                    //Mark all the dependencies as needing to be loaded.
+                    context.nextTick(function () {
+                        //Some defines could have been added since the
+                        //require call, collect them.
+                        intakeDefines();
+
+                        requireMod = getModule(makeModuleMap(null, relMap));
+
+                        //Store if map config should be applied to this require
+                        //call for dependencies.
+                        requireMod.skipMap = options.skipMap;
+
+                        requireMod.init(deps, callback, errback, {
+                            enabled: true
+                        });
+
+                        checkLoaded();
+                    });
+
+                    return localRequire;
+                }
+
+                mixin(localRequire, {
+                    isBrowser: isBrowser,
+
+                    /**
+                     * Converts a module name + .extension into an URL path.
+                     * *Requires* the use of a module name. It does not support using
+                     * plain URLs like nameToUrl.
+                     */
+                    toUrl: function (moduleNamePlusExt) {
+                        var ext,
+                            index = moduleNamePlusExt.lastIndexOf('.'),
+                            segment = moduleNamePlusExt.split('/')[0],
+                            isRelative = segment === '.' || segment === '..';
+
+                        //Have a file extension alias, and it is not the
+                        //dots from a relative path.
+                        if (index !== -1 && (!isRelative || index > 1)) {
+                            ext = moduleNamePlusExt.substring(index, moduleNamePlusExt.length);
+                            moduleNamePlusExt = moduleNamePlusExt.substring(0, index);
+                        }
+
+                        return context.nameToUrl(normalize(moduleNamePlusExt,
+                                                relMap && relMap.id, true), ext,  true);
+                    },
+
+                    defined: function (id) {
+                        return hasProp(defined, makeModuleMap(id, relMap, false, true).id);
+                    },
+
+                    specified: function (id) {
+                        id = makeModuleMap(id, relMap, false, true).id;
+                        return hasProp(defined, id) || hasProp(registry, id);
+                    }
+                });
+
+                //Only allow undef on top level require calls
+                if (!relMap) {
+                    localRequire.undef = function (id) {
+                        //Bind any waiting define() calls to this context,
+                        //fix for #408
+                        takeGlobalQueue();
+
+                        var map = makeModuleMap(id, relMap, true),
+                            mod = getOwn(registry, id);
+
+                        mod.undefed = true;
+                        removeScript(id);
+
+                        delete defined[id];
+                        delete urlFetched[map.url];
+                        delete undefEvents[id];
+
+                        //Clean queued defines too. Go backwards
+                        //in array so that the splices do not
+                        //mess up the iteration.
+                        eachReverse(defQueue, function(args, i) {
+                            if (args[0] === id) {
+                                defQueue.splice(i, 1);
+                            }
+                        });
+                        delete context.defQueueMap[id];
+
+                        if (mod) {
+                            //Hold on to listeners in case the
+                            //module will be attempted to be reloaded
+                            //using a different config.
+                            if (mod.events.defined) {
+                                undefEvents[id] = mod.events;
+                            }
+
+                            cleanRegistry(id);
+                        }
+                    };
+                }
+
+                return localRequire;
+            },
+
+            /**
+             * Called to enable a module if it is still in the registry
+             * awaiting enablement. A second arg, parent, the parent module,
+             * is passed in for context, when this method is overridden by
+             * the optimizer. Not shown here to keep code compact.
+             */
+            enable: function (depMap) {
+                var mod = getOwn(registry, depMap.id);
+                if (mod) {
+                    getModule(depMap).enable();
+                }
+            },
+
+            /**
+             * Internal method used by environment adapters to complete a load event.
+             * A load event could be a script load or just a load pass from a synchronous
+             * load call.
+             * @param {String} moduleName the name of the module to potentially complete.
+             */
+            completeLoad: function (moduleName) {
+                var found, args, mod,
+                    shim = getOwn(config.shim, moduleName) || {},
+                    shExports = shim.exports;
+
+                takeGlobalQueue();
+
+                while (defQueue.length) {
+                    args = defQueue.shift();
+                    if (args[0] === null) {
+                        args[0] = moduleName;
+                        //If already found an anonymous module and bound it
+                        //to this name, then this is some other anon module
+                        //waiting for its completeLoad to fire.
+                        if (found) {
+                            break;
+                        }
+                        found = true;
+                    } else if (args[0] === moduleName) {
+                        //Found matching define call for this script!
+                        found = true;
+                    }
+
+                    callGetModule(args);
+                }
+                context.defQueueMap = {};
+
+                //Do this after the cycle of callGetModule in case the result
+                //of those calls/init calls changes the registry.
+                mod = getOwn(registry, moduleName);
+
+                if (!found && !hasProp(defined, moduleName) && mod && !mod.inited) {
+                    if (config.enforceDefine && (!shExports || !getGlobal(shExports))) {
+                        if (hasPathFallback(moduleName)) {
+                            return;
+                        } else {
+                            return onError(makeError('nodefine',
+                                             'No define call for ' + moduleName,
+                                             null,
+                                             [moduleName]));
+                        }
+                    } else {
+                        //A script that does not call define(), so just simulate
+                        //the call for it.
+                        callGetModule([moduleName, (shim.deps || []), shim.exportsFn]);
+                    }
+                }
+
+                checkLoaded();
+            },
+
+            /**
+             * Converts a module name to a file path. Supports cases where
+             * moduleName may actually be just an URL.
+             * Note that it **does not** call normalize on the moduleName,
+             * it is assumed to have already been normalized. This is an
+             * internal API, not a public one. Use toUrl for the public API.
+             */
+            nameToUrl: function (moduleName, ext, skipExt) {
+                var paths, syms, i, parentModule, url,
+                    parentPath, bundleId,
+                    pkgMain = getOwn(config.pkgs, moduleName);
+
+                if (pkgMain) {
+                    moduleName = pkgMain;
+                }
+
+                bundleId = getOwn(bundlesMap, moduleName);
+
+                if (bundleId) {
+                    return context.nameToUrl(bundleId, ext, skipExt);
+                }
+
+                //If a colon is in the URL, it indicates a protocol is used and it is just
+                //an URL to a file, or if it starts with a slash, contains a query arg (i.e. ?)
+                //or ends with .js, then assume the user meant to use an url and not a module id.
+                //The slash is important for protocol-less URLs as well as full paths.
+                if (req.jsExtRegExp.test(moduleName)) {
+                    //Just a plain path, not module name lookup, so just return it.
+                    //Add extension if it is included. This is a bit wonky, only non-.js things pass
+                    //an extension, this method probably needs to be reworked.
+                    url = moduleName + (ext || '');
+                } else {
+                    //A module that needs to be converted to a path.
+                    paths = config.paths;
+
+                    syms = moduleName.split('/');
+                    //For each module name segment, see if there is a path
+                    //registered for it. Start with most specific name
+                    //and work up from it.
+                    for (i = syms.length; i > 0; i -= 1) {
+                        parentModule = syms.slice(0, i).join('/');
+
+                        parentPath = getOwn(paths, parentModule);
+                        if (parentPath) {
+                            //If an array, it means there are a few choices,
+                            //Choose the one that is desired
+                            if (isArray(parentPath)) {
+                                parentPath = parentPath[0];
+                            }
+                            syms.splice(0, i, parentPath);
+                            break;
+                        }
+                    }
+
+                    //Join the path parts together, then figure out if baseUrl is needed.
+                    url = syms.join('/');
+                    url += (ext || (/^data\:|^blob\:|\?/.test(url) || skipExt ? '' : '.js'));
+                    url = (url.charAt(0) === '/' || url.match(/^[\w\+\.\-]+:/) ? '' : config.baseUrl) + url;
+                }
+
+                return config.urlArgs && !/^blob\:/.test(url) ?
+                       url + config.urlArgs(moduleName, url) : url;
+            },
+
+            //Delegates to req.load. Broken out as a separate function to
+            //allow overriding in the optimizer.
+            load: function (id, url) {
+                req.load(context, id, url);
+            },
+
+            /**
+             * Executes a module callback function. Broken out as a separate function
+             * solely to allow the build system to sequence the files in the built
+             * layer in the right sequence.
+             *
+             * @private
+             */
+            execCb: function (name, callback, args, exports) {
+                return callback.apply(exports, args);
+            },
+
+            /**
+             * callback for script loads, used to check status of loading.
+             *
+             * @param {Event} evt the event from the browser for the script
+             * that was loaded.
+             */
+            onScriptLoad: function (evt) {
+                //Using currentTarget instead of target for Firefox 2.0's sake. Not
+                //all old browsers will be supported, but this one was easy enough
+                //to support and still makes sense.
+                if (evt.type === 'load' ||
+                        (readyRegExp.test((evt.currentTarget || evt.srcElement).readyState))) {
+                    //Reset interactive script so a script node is not held onto for
+                    //to long.
+                    interactiveScript = null;
+
+                    //Pull out the name of the module and the context.
+                    var data = getScriptData(evt);
+                    context.completeLoad(data.id);
+                }
+            },
+
+            /**
+             * Callback for script errors.
+             */
+            onScriptError: function (evt) {
+                var data = getScriptData(evt);
+                if (!hasPathFallback(data.id)) {
+                    var parents = [];
+                    eachProp(registry, function(value, key) {
+                        if (key.indexOf('_@r') !== 0) {
+                            each(value.depMaps, function(depMap) {
+                                if (depMap.id === data.id) {
+                                    parents.push(key);
+                                    return true;
+                                }
+                            });
+                        }
+                    });
+                    return onError(makeError('scripterror', 'Script error for "' + data.id +
+                                             (parents.length ?
+                                             '", needed by: ' + parents.join(', ') :
+                                             '"'), evt, [data.id]));
+                }
+            }
+        };
+
+        context.require = context.makeRequire();
+        return context;
+    }
+
+    /**
+     * Main entry point.
+     *
+     * If the only argument to require is a string, then the module that
+     * is represented by that string is fetched for the appropriate context.
+     *
+     * If the first argument is an array, then it will be treated as an array
+     * of dependency string names to fetch. An optional function callback can
+     * be specified to execute when all of those dependencies are available.
+     *
+     * Make a local req variable to help Caja compliance (it assumes things
+     * on a require that are not standardized), and to give a short
+     * name for minification/local scope use.
+     */
+    req = requirejs = function (deps, callback, errback, optional) {
+
+        //Find the right context, use default
+        var context, config,
+            contextName = defContextName;
+
+        // Determine if have config object in the call.
+        if (!isArray(deps) && typeof deps !== 'string') {
+            // deps is a config object
+            config = deps;
+            if (isArray(callback)) {
+                // Adjust args if there are dependencies
+                deps = callback;
+                callback = errback;
+                errback = optional;
+            } else {
+                deps = [];
+            }
+        }
+
+        if (config && config.context) {
+            contextName = config.context;
+        }
+
+        context = getOwn(contexts, contextName);
+        if (!context) {
+            context = contexts[contextName] = req.s.newContext(contextName);
+        }
+
+        if (config) {
+            context.configure(config);
+        }
+
+        return context.require(deps, callback, errback);
+    };
+
+    /**
+     * Support require.config() to make it easier to cooperate with other
+     * AMD loaders on globally agreed names.
+     */
+    req.config = function (config) {
+        return req(config);
+    };
+
+    /**
+     * Execute something after the current tick
+     * of the event loop. Override for other envs
+     * that have a better solution than setTimeout.
+     * @param  {Function} fn function to execute later.
+     */
+    req.nextTick = typeof setTimeout !== 'undefined' ? function (fn) {
+        setTimeout(fn, 4);
+    } : function (fn) { fn(); };
+
+    /**
+     * Export require as a global, but only if it does not already exist.
+     */
+    if (!require) {
+        require = req;
+    }
+
+    req.version = version;
+
+    //Used to filter out dependencies that are already paths.
+    req.jsExtRegExp = /^\/|:|\?|\.js$/;
+    req.isBrowser = isBrowser;
+    s = req.s = {
+        contexts: contexts,
+        newContext: newContext
+    };
+
+    //Create default context.
+    req({});
+
+    //Exports some context-sensitive methods on global require.
+    each([
+        'toUrl',
+        'undef',
+        'defined',
+        'specified'
+    ], function (prop) {
+        //Reference from contexts instead of early binding to default context,
+        //so that during builds, the latest instance of the default context
+        //with its config gets used.
+        req[prop] = function () {
+            var ctx = contexts[defContextName];
+            return ctx.require[prop].apply(ctx, arguments);
+        };
+    });
+
+    if (isBrowser) {
+        head = s.head = document.getElementsByTagName('head')[0];
+        //If BASE tag is in play, using appendChild is a problem for IE6.
+        //When that browser dies, this can be removed. Details in this jQuery bug:
+        //http://dev.jquery.com/ticket/2709
+        baseElement = document.getElementsByTagName('base')[0];
+        if (baseElement) {
+            head = s.head = baseElement.parentNode;
+        }
+    }
+
+    /**
+     * Any errors that require explicitly generates will be passed to this
+     * function. Intercept/override it if you want custom error handling.
+     * @param {Error} err the error object.
+     */
+    req.onError = defaultOnError;
+
+    /**
+     * Creates the node for the load command. Only used in browser envs.
+     */
+    req.createNode = function (config, moduleName, url) {
+        var node = config.xhtml ?
+                document.createElementNS('http://www.w3.org/1999/xhtml', 'html:script') :
+                document.createElement('script');
+        node.type = config.scriptType || 'text/javascript';
+        node.charset = 'utf-8';
+        node.async = true;
+        return node;
+    };
+
+    /**
+     * Does the request to load a module for the browser case.
+     * Make this a separate function to allow other environments
+     * to override it.
+     *
+     * @param {Object} context the require context to find state.
+     * @param {String} moduleName the name of the module.
+     * @param {Object} url the URL to the module.
+     */
+    req.load = function (context, moduleName, url) {
+        var config = (context && context.config) || {},
+            node;
+        if (isBrowser) {
+            //In the browser so use a script tag
+            node = req.createNode(config, moduleName, url);
+
+            node.setAttribute('data-requirecontext', context.contextName);
+            node.setAttribute('data-requiremodule', moduleName);
+
+            //Set up load listener. Test attachEvent first because IE9 has
+            //a subtle issue in its addEventListener and script onload firings
+            //that do not match the behavior of all other browsers with
+            //addEventListener support, which fire the onload event for a
+            //script right after the script execution. See:
+            //https://connect.microsoft.com/IE/feedback/details/648057/script-onload-event-is-not-fired-immediately-after-script-execution
+            //UNFORTUNATELY Opera implements attachEvent but does not follow the script
+            //script execution mode.
+            if (node.attachEvent &&
+                    //Check if node.attachEvent is artificially added by custom script or
+                    //natively supported by browser
+                    //read https://github.com/requirejs/requirejs/issues/187
+                    //if we can NOT find [native code] then it must NOT natively supported.
+                    //in IE8, node.attachEvent does not have toString()
+                    //Note the test for "[native code" with no closing brace, see:
+                    //https://github.com/requirejs/requirejs/issues/273
+                    !(node.attachEvent.toString && node.attachEvent.toString().indexOf('[native code') < 0) &&
+                    !isOpera) {
+                //Probably IE. IE (at least 6-8) do not fire
+                //script onload right after executing the script, so
+                //we cannot tie the anonymous define call to a name.
+                //However, IE reports the script as being in 'interactive'
+                //readyState at the time of the define call.
+                useInteractive = true;
+
+                node.attachEvent('onreadystatechange', context.onScriptLoad);
+                //It would be great to add an error handler here to catch
+                //404s in IE9+. However, onreadystatechange will fire before
+                //the error handler, so that does not help. If addEventListener
+                //is used, then IE will fire error before load, but we cannot
+                //use that pathway given the connect.microsoft.com issue
+                //mentioned above about not doing the 'script execute,
+                //then fire the script load event listener before execute
+                //next script' that other browsers do.
+                //Best hope: IE10 fixes the issues,
+                //and then destroys all installs of IE 6-9.
+                //node.attachEvent('onerror', context.onScriptError);
+            } else {
+                node.addEventListener('load', context.onScriptLoad, false);
+                node.addEventListener('error', context.onScriptError, false);
+            }
+            node.src = url;
+
+            //Calling onNodeCreated after all properties on the node have been
+            //set, but before it is placed in the DOM.
+            if (config.onNodeCreated) {
+                config.onNodeCreated(node, config, moduleName, url);
+            }
+
+            //For some cache cases in IE 6-8, the script executes before the end
+            //of the appendChild execution, so to tie an anonymous define
+            //call to the module name (which is stored on the node), hold on
+            //to a reference to this node, but clear after the DOM insertion.
+            currentlyAddingScript = node;
+            if (baseElement) {
+                head.insertBefore(node, baseElement);
+            } else {
+                head.appendChild(node);
+            }
+            currentlyAddingScript = null;
+
+            return node;
+        } else if (isWebWorker) {
+            try {
+                //In a web worker, use importScripts. This is not a very
+                //efficient use of importScripts, importScripts will block until
+                //its script is downloaded and evaluated. However, if web workers
+                //are in play, the expectation is that a build has been done so
+                //that only one script needs to be loaded anyway. This may need
+                //to be reevaluated if other use cases become common.
+
+                // Post a task to the event loop to work around a bug in WebKit
+                // where the worker gets garbage-collected after calling
+                // importScripts(): https://webkit.org/b/153317
+                setTimeout(function() {}, 0);
+                importScripts(url);
+
+                //Account for anonymous modules
+                context.completeLoad(moduleName);
+            } catch (e) {
+                context.onError(makeError('importscripts',
+                                'importScripts failed for ' +
+                                    moduleName + ' at ' + url,
+                                e,
+                                [moduleName]));
+            }
+        }
+    };
+
+    function getInteractiveScript() {
+        if (interactiveScript && interactiveScript.readyState === 'interactive') {
+            return interactiveScript;
+        }
+
+        eachReverse(scripts(), function (script) {
+            if (script.readyState === 'interactive') {
+                return (interactiveScript = script);
+            }
+        });
+        return interactiveScript;
+    }
+
+    //Look for a data-main script attribute, which could also adjust the baseUrl.
+    if (isBrowser && !cfg.skipDataMain) {
+        //Figure out baseUrl. Get it from the script tag with require.js in it.
+        eachReverse(scripts(), function (script) {
+            //Set the 'head' where we can append children by
+            //using the script's parent.
+            if (!head) {
+                head = script.parentNode;
+            }
+
+            //Look for a data-main attribute to set main script for the page
+            //to load. If it is there, the path to data main becomes the
+            //baseUrl, if it is not already set.
+            dataMain = script.getAttribute('data-main');
+            if (dataMain) {
+                //Preserve dataMain in case it is a path (i.e. contains '?')
+                mainScript = dataMain;
+
+                //Set final baseUrl if there is not already an explicit one,
+                //but only do so if the data-main value is not a loader plugin
+                //module ID.
+                if (!cfg.baseUrl && mainScript.indexOf('!') === -1) {
+                    //Pull off the directory of data-main for use as the
+                    //baseUrl.
+                    src = mainScript.split('/');
+                    mainScript = src.pop();
+                    subPath = src.length ? src.join('/')  + '/' : './';
+
+                    cfg.baseUrl = subPath;
+                }
+
+                //Strip off any trailing .js since mainScript is now
+                //like a module name.
+                mainScript = mainScript.replace(jsSuffixRegExp, '');
+
+                //If mainScript is still a path, fall back to dataMain
+                if (req.jsExtRegExp.test(mainScript)) {
+                    mainScript = dataMain;
+                }
+
+                //Put the data-main script in the files to load.
+                cfg.deps = cfg.deps ? cfg.deps.concat(mainScript) : [mainScript];
+
+                return true;
+            }
+        });
+    }
+
+    /**
+     * The function that handles definitions of modules. Differs from
+     * require() in that a string for the module should be the first argument,
+     * and the function to execute after dependencies are loaded should
+     * return a value to define the module corresponding to the first argument's
+     * name.
+     */
+    define = function (name, deps, callback) {
+        var node, context;
+
+        //Allow for anonymous modules
+        if (typeof name !== 'string') {
+            //Adjust args appropriately
+            callback = deps;
+            deps = name;
+            name = null;
+        }
+
+        //This module may not have dependencies
+        if (!isArray(deps)) {
+            callback = deps;
+            deps = null;
+        }
+
+        //If no name, and callback is a function, then figure out if it a
+        //CommonJS thing with dependencies.
+        if (!deps && isFunction(callback)) {
+            deps = [];
+            //Remove comments from the callback string,
+            //look for require calls, and pull them into the dependencies,
+            //but only if there are function args.
+            if (callback.length) {
+                callback
+                    .toString()
+                    .replace(commentRegExp, commentReplace)
+                    .replace(cjsRequireRegExp, function (match, dep) {
+                        deps.push(dep);
+                    });
+
+                //May be a CommonJS thing even without require calls, but still
+                //could use exports, and module. Avoid doing exports and module
+                //work though if it just needs require.
+                //REQUIRES the function to expect the CommonJS variables in the
+                //order listed below.
+                deps = (callback.length === 1 ? ['require'] : ['require', 'exports', 'module']).concat(deps);
+            }
+        }
+
+        //If in IE 6-8 and hit an anonymous define() call, do the interactive
+        //work.
+        if (useInteractive) {
+            node = currentlyAddingScript || getInteractiveScript();
+            if (node) {
+                if (!name) {
+                    name = node.getAttribute('data-requiremodule');
+                }
+                context = contexts[node.getAttribute('data-requirecontext')];
+            }
+        }
+
+        //Always save off evaluating the def call until the script onload handler.
+        //This allows multiple modules to be in a file without prematurely
+        //tracing dependencies, and allows for anonymous module support,
+        //where the module name is not known until the script onload event
+        //occurs. If no context, use the global queue, and get it processed
+        //in the onscript load callback.
+        if (context) {
+            context.defQueue.push([name, deps, callback]);
+            context.defQueueMap[name] = true;
+        } else {
+            globalDefQueue.push([name, deps, callback]);
+        }
+    };
+
+    define.amd = {
+        jQuery: true
+    };
+
+    /**
+     * Executes the text. Normally just uses eval, but can be modified
+     * to use a better, environment-specific call. Only used for transpiling
+     * loader plugins, not for plain JS modules.
+     * @param {String} text the text to execute/evaluate.
+     */
+    req.exec = function (text) {
+        /*jslint evil: true */
+        return eval(text);
+    };
+
+    //Set up with config info.
+    req(cfg);
+}(this, (typeof setTimeout === 'undefined' ? undefined : setTimeout)));

--- a/settings.py
+++ b/settings.py
@@ -140,12 +140,19 @@ if DRIVER == 'Remote':
     USER_TWO_PASSWORD = env(
         '{}_USER_TWO_PASSWORD'.format(upper_build), env('USER_TWO_PASSWORD', '')
     )
+    USER_THREE = env('{}_USER_THREE'.format(upper_build), env('USER_THREE', ''))
+    USER_THREE_PASSWORD = env(
+        '{}_USER_THREE_PASSWORD'.format(upper_build), env('USER_THREE_PASSWORD', '')
+    )
 else:
     USER_ONE = env('USER_ONE')
     USER_ONE_PASSWORD = env('USER_ONE_PASSWORD')
 
     USER_TWO = env('USER_TWO')
     USER_TWO_PASSWORD = env('USER_TWO_PASSWORD')
+
+    USER_THREE = env('USER_THREE')
+    USER_THREE_PASSWORD = env('USER_THREE_PASSWORD')
 
 
 # Used to skip certain tests on specific stagings

--- a/tests/test_feintercept.py
+++ b/tests/test_feintercept.py
@@ -1,0 +1,97 @@
+import pytest
+import settings
+import requests
+import os
+import sys
+import configparser
+import js2py
+from pages.files import FilesListPage
+from pages.base import GuidBasePage
+from pages.project import FilesPage, ProjectPage
+from pages.search import SearchPage
+from base.locators import ComponentLocator
+from tests.test_dashboard import dashboard_page
+from tests.test_my_projects import my_projects_page
+from components.navbars import EmberNavbar, HomeNavbar, RegistriesNavbar
+from api import osf_api
+import markers  
+import ipdb
+import random
+import threading as thread
+import time
+from selenium.webdriver.common.action_chains import ActionChains
+
+from selenium.common.exceptions import (
+    NoSuchElementException,
+    StaleElementReferenceException,
+    TimeoutException,
+)
+from selenium.webdriver.support import expected_conditions as EC
+from selenium.webdriver.support.ui import WebDriverWait
+from selenium.webdriver.common.by import By
+
+from selenium.webdriver.common.keys import Keys
+
+from pages.landing import LandingPage
+
+from pages.login import (
+    CASAuthorizationPage,
+    GenericCASPage,
+    InstitutionalLoginPage,
+    LoginPage,
+    Login2FAPage,
+    LoginToSPage,
+    login,
+    LoginToSPage,
+    InstitutionalLoginPage,
+    GenericCASPage,
+    login,
+    login_admin,
+    login_read_only,
+    login_read_write,
+    logout
+)
+
+from pages.dashboard import DashboardPage
+
+from components.navbars import (
+    HomeNavbar, 
+    RegistriesNavbar
+)
+
+from pages.registries import (
+    MyRegistrationsPage,
+    RegistrationAddNewPage,
+    RegistrationDetailPage,
+    RegistrationDraftPage,
+    RegistriesLandingPage,
+    RegistriesDiscoverPage,
+    RegistriesNavbar
+)
+
+from pages.preprints import (PreprintDiscoverPage)
+
+
+@markers.core_functionality
+class TestFEIntercept:
+    # collect names using requirejs
+    def test_collect_component_names(self, driver, user=osf_api.current_user()):
+        url = 'https://staging2.osf.io/registries?view_only='
+        login_read_write(driver)
+ 
+        preprint_page = PreprintDiscoverPage(driver)
+        preprint_page.goto()
+
+        js_script = '''
+        var documentObject = null;
+        console.log("Preprint Page");
+        if (documentObject == null || documentObject == undefined) { console.log("no context found"); }else{ documentObject = window.location.pathname; } console.log(documentObject);}
+        console.log(requirejs.entries)
+        '''
+        driver.execute_script(js_script)
+
+        ipdb.set_trace()
+
+        assert True
+
+        # logout(driver)

--- a/tests/test_versioning.py
+++ b/tests/test_versioning.py
@@ -1,19 +1,25 @@
+import pytest
+import settings
+import requests
+import os
+import sys
+import configparser
+import js2py
+from pages.files import FilesListPage
+from pages.base import GuidBasePage
+from pages.project import FilesPage, ProjectPage
+from pages.search import SearchPage
 from base.locators import ComponentLocator
 from tests.test_dashboard import dashboard_page
 from tests.test_my_projects import my_projects_page
-from api import osf_api
 from components.navbars import EmberNavbar, HomeNavbar, RegistriesNavbar
-import pytest
+from api import osf_api
 import markers
-import settings
-import requests
-import os 
-import sys
-import configparser
-import ipdb 
+import ipdb
 import random
 import threading as thread
 import time
+from selenium.webdriver.common.action_chains import ActionChains
 
 from selenium.common.exceptions import (
     NoSuchElementException,
@@ -45,10 +51,11 @@ from pages.login import (
     login_read_write,
     logout
 )
+
 from pages.dashboard import DashboardPage
 
 from components.navbars import (
-    HomeNavbar, 
+    HomeNavbar,
     RegistriesNavbar
 )
 
@@ -75,294 +82,442 @@ from pages.registries import (
 #     return landing_page
 @markers.core_functionality
 class TestVersioningElements:
-
-    def test_handle_login(self, driver, user=osf_api.current_user()):
-
-        ipdb.set_trace()
         # login as read write user
-        login_read_write(driver)
-        print(f'Logging in as read write user')
-        dashboard_page = DashboardPage(driver)
-        dashboard_page.goto()
-        DashboardPage(driver, verify=True)
-        logout(driver)
+        def test_handle_login_rw(self, driver, user=osf_api.current_user()):
+            login_read_write(driver)
+            print(f'Logging in as read write user')
+            dashboard_page = DashboardPage(driver)
+            dashboard_page.goto()
+            DashboardPage(driver, verify=True)
+            # logout(driver)
 
-        ipdb.set_trace()
         # login as read only user
-        login_read_only(driver)
-        print(f'Logging in as read only user')
-        dashboard_page = DashboardPage(driver)
-        dashboard_page.goto()
-        DashboardPage(driver, verify=True)
-        logout(driver)
+        def test_handle_login_ronly(self, driver, user=osf_api.current_user()):
+            login_read_only(driver)
+            print(f'Logging in as read only user')
+            dashboard_page = DashboardPage(driver)
+            dashboard_page.goto()
+            DashboardPage(driver, verify=True)
+            # logout(driver)
 
-        ipdb.set_trace()
         # login as admin user
-        login_admin(driver)
-        print(f'Logging in as admin user')
-        dashboard_page = DashboardPage(driver)
-        dashboard_page.goto()
-        DashboardPage(driver, verify=True)
-        logout(driver)
+        def test_handle_login_rwx(self, driver, user=osf_api.current_user()):
+            login_admin(driver)
+            print(f'Logging in as admin user')
+            dashboard_page = DashboardPage(driver)
+            dashboard_page.goto()
+            DashboardPage(driver, verify=True)
+            # logout(driver)
 
-    # find all contributor & email
+        def test_handle_all_logout(self, driver, user=osf_api.current_user()):
+            logout(driver)
 
-    # navigate to gmail for each one
+        # find all contributor & email
 
-    # regex the title
+        # navigate to gmail for each one
 
-    # click the approve button
+        # regex the title
 
-    # close tab
+        # click the approve button
 
-    # do for each in array of conributor emails
+        # close tab
 
-    # create a edit
+        # do for each in array of conributor emails
 
-    # approve by the same approve email but for edits
+        # create a edit
+
+        # approve by the same approve email but for edits
+
+        # rename a file
+        def test_files_page_redesign(self, driver, user = osf_api.current_user()):
+            TestVersioningElements.test_handle_login_rwx(self, driver, user = osf_api.current_user())
+
+            # login(driver)
+            dashboard_page = DashboardPage(driver)
+            ac = ActionChains(driver)
+            dashboard_page.goto()
+            DashboardPage(driver, verify=True)
+
+            collect_name = 'console.log(requirejs.entries);'
+
+            driver.execute_script(collect_name)
+
+            ipdb.set_trace()
+
+            # find search bar and search Registries
+            search_page = SearchPage(driver) #not search page, update
+            search_bar = search_page.search_bar # search bar locator is correct, transport
+            search_bar.click()
+            project_name = 'African and European Birbs' # TODO place in Excel
+            search_bar.send_keys(project_name)
+            WebDriverWait(driver, 5)
+            search_bar.send_keys(Keys.ENTER)
+            WebDriverWait(driver, 5)
+
+            ipdb.set_trace()
+            first_matching_result = dashboard_page.result_first_match
+            print(first_matching_result)
+            first_matching_result.click()
+
+            project_page = ProjectPage(driver)
+
+            project_page_title = project_page.title
+
+            project_inner_html = project_page_title.get_property("innerHTML").strip()
+
+            print("{}".format(project_inner_html))
+            string_project_title = "{}".format(project_inner_html)
+            if string_project_title == project_name:
+                print('Project names match, proceeding with test')
+            else:
+                print('Config project name and title do not match')
+            # print( project_page_title.__str__)
+            # assert project_page_title == project_name
+
+            # click file on file widget
+            # file_provider = project_page.file_widget
+            # print("v:{} ".format(type(file_provider), file_provider))
+            # print(file_provider)
+
+            # click Registrations tab
+
+            project_files_tab = project_page.project_files_tab
+            # add logic for window sizing
+            project_files_tab.click()
+            WebDriverWait(driver, 5)
+
+            files_list_view = FilesListPage(driver)
+            current_url = driver.current_url
+            files_list_url = files_list_view.url
+            # files_list_view = files_page
+
+            print("{}".format(current_url))
+            print("{}".format(files_list_url))
+
+            # select provider
+            provider = 'osfstorage' # TODO place in Excel
 
 
-    # create registration
-    def test_my_registries_upates_button_exists(self, driver, user = osf_api.current_user()):
+            # redirect to file detail
+            first_file = files_list_view.file_link
+            print(f'The current page:', driver.title)
 
-        # login and go to dashboard
-        login(driver)
-        dashboard_page = DashboardPage(driver)
-        dashboard_page.goto()
-        DashboardPage(driver, verify=True)
 
-        # find dropdown for registries and click it
-        home_nav_bar = HomeNavbar(driver)
-        home_dropdown_caret = home_nav_bar.service_dropdown
-        home_dropdown_caret.click()
-        home_registries_link = home_nav_bar.registries_link
-        home_registries_link.click()
+            # ActionChains(mydriver).key_up(Keys.ALT).perform()
 
-        # click add new registration button
-        registries_navbar = RegistriesNavbar(driver)
-        add_new_registration = registries_navbar.add_new_link
-        add_new_registration.click()
+            first_file.click()
+            # ac.move_to_element(first_file).key_down(Keys.ALT).click().key_up(Keys.ALT).perform()
+            ac.key_down(Keys.COMMAND).key_down('W').perform()
+            ipdb.set_trace()
+            # first_file.send_keys(Keys.COMMAND)
+            # first_file.send_keys('W')
 
-        # verify on add new page
-        registries_add_new_page = RegistrationAddNewPage(driver, verify=True)
-        assert registries_add_new_page.dropdown_wormhole
+            file_list_tab = driver.window_handles[0]
+            #obtain browser tab window
+            file_detail_tab  = driver.window_handles[1]
+            driver.switch_to.window(file_detail_tab)
+            print(f'The current page:', driver.title)
+            driver.close()
+            print(f'The current page:', driver.title)
 
-        # add wait to ensure form loads (may be able to reduce wait later)
-        WebDriverWait(driver, 20).until(
-            EC.presence_of_element_located(
-                (By.CSS_SELECTOR, '[data-test-new-registration-form]')
+
+            # select file action
+            file_actions_menu =  files_list_view.file_actions_menu
+            file_actions_menu.click()
+
+
+            # download file click
+            download_file = files_list_view.download_file_action
+            download_file.click()
+
+            # delete file
+            delete_file = files_list_view.delete_file_action
+            delete_file.click()
+                # cancel delete
+                # delete delete
+
+            #  embed file
+                # JS
+                # HTML
+            # share
+                # email
+                # FB
+                # Twitter
+
+                
+
+            ipdb.set_trace()
+
+            # Files from Registrations
+
+            # ensure card title is the same as above ^
+
+            # registration_card =
+
+            # registration_card_title =
+
+            # click first matching card title
+
+            # click storage provider
+
+            # Click Files
+
+            # click first file
+
+            # return only osfstorage or EGAP by clicking text box
+            # find if Registration contains a file
+            # if so, click Registration
+
+            # click Files tab
+
+            # def navigate_to_dashboard():
+
+            # def rename_file():
+
+            # def rename_folder():
+
+
+
+        # create registration
+        def test_my_registries_upates_button_exists(self, driver, user = osf_api.current_user()):
+
+            # login and go to dashboard
+            login(driver)
+            dashboard_page = DashboardPage(driver)
+            dashboard_page.goto()
+            DashboardPage(driver, verify=True)
+
+            # find dropdown for registries and click it
+            home_nav_bar = HomeNavbar(driver)
+            home_dropdown_caret = home_nav_bar.service_dropdown
+            home_dropdown_caret.click()
+            home_registries_link = home_nav_bar.registries_link
+            home_registries_link.click()
+
+            # click add new registration button
+            registries_navbar = RegistriesNavbar(driver)
+            add_new_registration = registries_navbar.add_new_link
+            add_new_registration.click()
+
+            # verify on add new page
+            registries_add_new_page = RegistrationAddNewPage(driver, verify=True)
+            assert registries_add_new_page.dropdown_wormhole
+
+            # add wait to ensure form loads (may be able to reduce wait later)
+            WebDriverWait(driver, 20).until(
+                EC.presence_of_element_located(
+                    (By.CSS_SELECTOR, '[data-test-new-registration-form]')
+                )
             )
-        ) 
 
-        # yes to projects 
-        yes_button_exists = registries_add_new_page.has_project_button
-        yes_button_exists.click()
-        print("t:{}  v:{} ".format(type(yes_button_exists), yes_button_exists)) # print type and representation
+            # yes to projects
+            yes_button_exists = registries_add_new_page.has_project_button
+            yes_button_exists.click()
+            print("t:{}  v:{} ".format(type(yes_button_exists), yes_button_exists)) # print type and representation
 
-        # NOTE uncomment for no projects and comment out yes logic
-        # no_button_exists = registries_add_new_page.no_project_button
-        # no_button_exists.click()
+            # NOTE uncomment for no projects and comment out yes logic
+            # no_button_exists = registries_add_new_page.no_project_button
+            # no_button_exists.click()
 
-        project_power_select = registries_add_new_page.project_selection_dropdown
-        project_power_select.click()
+            project_power_select = registries_add_new_page.project_selection_dropdown
+            project_power_select.click()
 
-        # select first project
-        # first_project = registries_add_new_page.first_project_selection
-        # first_project.click()
+            # select first project
+            # first_project = registries_add_new_page.first_project_selection
+            # first_project.click()
 
-        # select second project
-        second_project = registries_add_new_page.second_project_selection
-        second_project.click()
+            # select second project
+            second_project = registries_add_new_page.second_project_selection
+            second_project.click()
 
-        WebDriverWait(driver, 5)
+            WebDriverWait(driver, 5)
 
-        # click registration schema type dropdown
-        schema_power_select_dropdown = registries_add_new_page.schema_type_dropdown
-        schema_power_select_dropdown.click()
+            # click registration schema type dropdown
+            schema_power_select_dropdown = registries_add_new_page.schema_type_dropdown
+            schema_power_select_dropdown.click()
 
-        WebDriverWait(driver, 5)
+            WebDriverWait(driver, 5)
 
-        # select preregistration schema
-        preregistration_schema_select = registries_add_new_page.preregistration_schema_selection
-        preregistration_schema_select.click()
+            # select preregistration schema
+            preregistration_schema_select = registries_add_new_page.preregistration_schema_selection
+            preregistration_schema_select.click()
 
-        WebDriverWait(driver, 5)
+            WebDriverWait(driver, 5)
 
-        ipdb.set_trace()
-        # click submit 
-        submit_button_add_new = registries_add_new_page.add_new_submit_button
-        submit_button_add_new.click()
+            ipdb.set_trace()
+            # click submit
+            submit_button_add_new = registries_add_new_page.add_new_submit_button
+            submit_button_add_new.click()
 
-        # verify transition to draft page
-        registration_draft_page = RegistrationDraftPage(driver, verify=True)
-        draft_registration_page_identity = registration_draft_page.identity
-        assert draft_registration_page_identity
-        print("t:{}  v:{} ".format(type(draft_registration_page_identity), draft_registration_page_identity)) 
+            # verify transition to draft page
+            registration_draft_page = RegistrationDraftPage(driver, verify=True)
+            draft_registration_page_identity = registration_draft_page.identity
+            assert draft_registration_page_identity
+            print("t:{}  v:{} ".format(type(draft_registration_page_identity), draft_registration_page_identity))
 
-        # fill out title 
-        input_registration_title = registration_draft_page.registration_title_input
-        input_registration_title.clear()
-        registration_random = str(random.randrange(1, 1000000))
-        registration_title = 'Outcome Reporting Moderation Test'  + registration_random
-        print(f'The Registration title is: ', registration_title)
-        input_registration_title.send_keys(registration_title)
+            # fill out title
+            input_registration_title = registration_draft_page.registration_title_input
+            input_registration_title.clear()
+            registration_random = str(random.randrange(1, 1000000))
+            registration_title = 'Outcome Reporting Moderation Test'  + registration_random
+            print(f'The Registration title is: ', registration_title)
+            input_registration_title.send_keys(registration_title)
 
-        WebDriverWait(driver, 5)
+            WebDriverWait(driver, 5)
 
-        # fill out description 
-        input_registration_description = registration_draft_page.registration_description_input
-        input_registration_description.clear()
-        input_registration_description.send_keys('This registration is for testing the outcome reporting moderation workflow for versioning.')
+            # fill out description
+            input_registration_description = registration_draft_page.registration_description_input
+            input_registration_description.clear()
+            input_registration_description.send_keys('This registration is for testing the outcome reporting moderation workflow for versioning.')
 
-        ipdb.set_trace()
-        # click '+' add contributor button
-        button_add_contributor = registration_draft_page.add_contributor_plus_button
-        button_add_contributor.click()
+            ipdb.set_trace()
+            # click '+' add contributor button
+            button_add_contributor = registration_draft_page.add_contributor_plus_button
+            button_add_contributor.click()
 
-        WebDriverWait(driver, 5)
+            WebDriverWait(driver, 5)
 
-        # clear contributor search box
-        # TODO add logic for checking if contributors are present, ensure 1 admin is there
-        search_box_add_contributor = registration_draft_page.add_contributor_search_box
-        search_box_add_contributor.clear()
+            # clear contributor search box
+            # TODO add logic for checking if contributors are present, ensure 1 admin is there
+            search_box_add_contributor = registration_draft_page.add_contributor_search_box
+            search_box_add_contributor.clear()
 
-        # send keys for contributor name
-        WebDriverWait(driver, 5)
-        name = 'Ashley Robinson' # add to config later
-        search_box_add_contributor.send_keys(name)
+            # send keys for contributor name
+            WebDriverWait(driver, 5)
+            name = 'Ashley Robinson' # add to config later
+            search_box_add_contributor.send_keys(name)
 
-        # click search for contributor
-        WebDriverWait(driver, 5)
-        search_button_add_contributor = registration_draft_page.add_contributor_search_button
-        search_button_add_contributor.click()
+            # click search for contributor
+            WebDriverWait(driver, 5)
+            search_button_add_contributor = registration_draft_page.add_contributor_search_button
+            search_button_add_contributor.click()
 
-        # add first found contributor
-        try: 
-          result_add_first_contributor = registration_draft_page.add_first_contributor_result
-          if(len(result_add_first_contributor) > 0):
-            print(f'Contributor not yet added: ')
-            result_add_first_contributor.click()
-          else:
-            print(f'Contributor already added')
-              
-        # except NoSuchElementException:
-        except TypeError:
-          print('There is a type mismatch')
-        WebDriverWait(driver, 5)
+            # add first found contributor
+            try:
+                result_add_first_contributor = registration_draft_page.add_first_contributor_result
+                if(len(result_add_first_contributor) > 0):
+                    print(f'Contributor not yet added: ')
+                    result_add_first_contributor.click()
+                else:
+                    print(f'Contributor already added')
+            # except NoSuchElementException:
+            except TypeError:
+                print(f'There is a type mismatch')
+            WebDriverWait(driver, 5)
 
-        # click category dropdown 
-        power_select_category = registration_draft_page.category_power_select
-        power_select_category.click()
+            # click category dropdown
+            power_select_category = registration_draft_page.category_power_select
+            power_select_category.click()
 
-        WebDriverWait(driver, 5)
+            WebDriverWait(driver, 5)
 
-        # select analysis category
-        dropdown_select_analysis_category = registration_draft_page.category_analysis_dropdown_select
-        dropdown_select_analysis_category.click()
+            # select analysis category
+            dropdown_select_analysis_category = registration_draft_page.category_analysis_dropdown_select
+            dropdown_select_analysis_category.click()
 
-        WebDriverWait(driver, 5)
+            WebDriverWait(driver, 5)
 
-        # click license dropdown
-        power_select_license = registration_draft_page.license_power_select
-        power_select_license.click()
+            # click license dropdown
+            power_select_license = registration_draft_page.license_power_select
+            power_select_license.click()
 
-        WebDriverWait(driver, 5)
+            WebDriverWait(driver, 5)
 
-        # select cc international license
-        select_license_cc_international = registration_draft_page.license_cc_international_select
-        select_license_cc_international.click()
+            # select cc international license
+            select_license_cc_international = registration_draft_page.license_cc_international_select
+            select_license_cc_international.click()
 
-        WebDriverWait(driver, 5)
+            WebDriverWait(driver, 5)
 
-        # check engineering subject
-        checkbox_engineering_subject = registration_draft_page.subject_engineering_checkbox
-        isEngineeringChecked = checkbox_engineering_subject.is_selected()
-        if isEngineeringChecked == False:
-            checkbox_engineering_subject.click()
+            # check engineering subject
+            checkbox_engineering_subject = registration_draft_page.subject_engineering_checkbox
+            isEngineeringChecked = checkbox_engineering_subject.is_selected()
+            if isEngineeringChecked == False:
+                checkbox_engineering_subject.click()
 
-        WebDriverWait(driver, 5)
+            WebDriverWait(driver, 5)
 
-        # add tag for mirage moderation backend
-        input_tags = registration_draft_page.tags_input
-        input_tags.clear()
-        input_tags.send_keys('cobalt')
-        input_tags.send_keys(Keys.RETURN)
+            # add tag for mirage moderation backend
+            input_tags = registration_draft_page.tags_input
+            input_tags.clear()
+            input_tags.send_keys('cobalt')
+            input_tags.send_keys(Keys.RETURN)
 
-        WebDriverWait(driver, 5)
+            WebDriverWait(driver, 5)
 
-        ipdb.set_trace()
-        # click next
-        next_button_draft_registration = registration_draft_page.draft_registration_next_button
-        next_button_draft_registration.click()
+            ipdb.set_trace()
+            # click next
+            next_button_draft_registration = registration_draft_page.draft_registration_next_button
+            next_button_draft_registration.click()
 
-        # select for no data         
-        # radio_button_no_data_collected = registration_draft_page.no_data_collected_radio_button
-        # radio_button_no_data_collected.click()
+            # select for no data
+            # radio_button_no_data_collected = registration_draft_page.no_data_collected_radio_button
+            # radio_button_no_data_collected.click()
 
-        # select for data collected
-        radio_button_data_collected = registration_draft_page.data_collected_radio_button
-        radio_button_data_collected.click()
+            # select for data collected
+            radio_button_data_collected = registration_draft_page.data_collected_radio_button
+            radio_button_data_collected.click()
 
-        WebDriverWait(driver, 5)
+            WebDriverWait(driver, 5)
 
-        # select for viewed data
-        radio_button_data_looked_at = registration_draft_page.data_looked_at_radio_button
-        radio_button_data_looked_at.click()
+            # select for viewed data
+            radio_button_data_looked_at = registration_draft_page.data_looked_at_radio_button
+            radio_button_data_looked_at.click()
 
-        WebDriverWait(driver, 10)
+            WebDriverWait(driver, 10)
 
-        # select for unviewed data
-        # radio_button_data_not_looked_at = registration_draft_page.data_not_looked_at_radio_button
-        # radio_button_data_not_looked_at.click()
+            # select for unviewed data
+            # radio_button_data_not_looked_at = registration_draft_page.data_not_looked_at_radio_button
+            # radio_button_data_not_looked_at.click()
 
-        # TODO remove this trace
-        ipdb.set_trace()
+            # TODO remove this trace
+            ipdb.set_trace()
 
-        # enter any additional comments
-        textarea_comments = registration_draft_page.comments_textarea
-        textarea_comments.clear()
-        textarea_comments.send_keys('Thank you for attending this demo.')
-        textarea_comments.send_keys(Keys.RETURN)
+            # enter any additional comments
+            textarea_comments = registration_draft_page.comments_textarea
+            textarea_comments.clear()
+            textarea_comments.send_keys('Thank you for attending this demo.')
+            textarea_comments.send_keys(Keys.RETURN)
 
-        # review entered answers
-        review_button_draft = registration_draft_page.draft_review_button
-        review_button_draft.click()
+            # review entered answers
+            review_button_draft = registration_draft_page.draft_review_button
+            review_button_draft.click()
 
-        WebDriverWait(driver, 5)
+            WebDriverWait(driver, 5)
 
-        # register draft
-        register_button_draft = registration_draft_page.register_draft_button
-        register_button_draft.click()
+            # register draft
+            register_button_draft = registration_draft_page.register_draft_button
+            register_button_draft.click()
 
-        # choose to make registration public 
-        radio_make_registration_public = registration_draft_page.make_registration_public_radio
-        radio_make_registration_public.click()
+            # choose to make registration public
+            radio_make_registration_public = registration_draft_page.make_registration_public_radio
+            radio_make_registration_public.click()
 
-        # choose to make registration embargo 
-        # add logic to get current time and add 5 years
-        # radio_make_registration_embargo = registration_draft_page.make_registration_embargo_radio
-        # register_button_draft.click()
-        ipdb.set_trace()
-        # cancel for demo purposes
-        # back_button_demo = registration_draft_page.demo_back_button
-        # back_button_demo.click()
+            # choose to make registration embargo
+            # add logic to get current time and add 5 years
+            # radio_make_registration_embargo = registration_draft_page.make_registration_embargo_radio
+            # register_button_draft.click()
+            ipdb.set_trace()
+            # cancel for demo purposes
+            # back_button_demo = registration_draft_page.demo_back_button
+            # back_button_demo.click()
 
-        # register registration NOTE untested
-        # register_button_draft = registration_draft_page.register_draft_button
-        # register_button_draft.click()
+            # register registration NOTE untested
+            # register_button_draft = registration_draft_page.register_draft_button
+            # register_button_draft.click()
 
-        submit_button_draft = registration_draft_page.submit_draft_button
-        submit_button_draft.click()
-    
-        ipdb.set_trace()
-        logout(driver)
+            submit_button_draft = registration_draft_page.submit_draft_button
+            submit_button_draft.click()
 
-    def runAllVersioning(self):
-        if __name__ == '__main__':
-            thread.Thread(target = self.handle_login).start()
-            thread.Thread(target = self.test_my_registries_upates_button_exists).start()
+            ipdb.set_trace()
+            logout(driver)
+
+        def runAllVersioning(self):
+            if __name__ == '__main__':
+                thread.Thread(target = self.handle_login).start()
+                thread.Thread(target = self.test_my_registries_upates_button_exists).start()
 
 
-run = TestVersioningElements()
-run.runAllVersioning()
+    # run = TestVersioningElements()
+    # run.runAllVersioning()
         

--- a/tests/test_versioning.py
+++ b/tests/test_versioning.py
@@ -1,0 +1,309 @@
+from base.locators import ComponentLocator
+from tests.test_dashboard import dashboard_page
+from tests.test_my_projects import my_projects_page
+from api import osf_api
+from components.navbars import EmberNavbar, HomeNavbar, RegistriesNavbar
+import pytest
+import markers
+import settings
+import requests
+import os 
+import sys
+import configparser
+import ipdb 
+import random
+
+from selenium.common.exceptions import (
+    NoSuchElementException,
+    StaleElementReferenceException,
+    TimeoutException,
+)
+from selenium.webdriver.support import expected_conditions as EC
+from selenium.webdriver.support.ui import WebDriverWait
+from selenium.webdriver.common.by import By
+
+from selenium.webdriver.common.keys import Keys
+
+from pages.landing import LandingPage
+
+from pages.login import (
+    CASAuthorizationPage,
+    GenericCASPage,
+    InstitutionalLoginPage,
+    LoginPage,
+    Login2FAPage,
+    LoginToSPage,
+    login,
+    LoginToSPage,
+    InstitutionalLoginPage,
+    GenericCASPage,
+    login,
+    logout
+)
+from pages.dashboard import DashboardPage
+
+from components.navbars import (
+    HomeNavbar, 
+    RegistriesNavbar
+)
+
+from pages.registries import (
+    MyRegistrationsPage,
+    RegistrationAddNewPage,
+    RegistrationDetailPage,
+    RegistrationDraftPage,
+    RegistriesLandingPage,
+    RegistriesDiscoverPage,
+    RegistriesNavbar
+)
+
+# @pytest.fixture
+# def user_contr_rw_login(driver):
+#     login_page = LoginPage(driver)
+#     login_page.goto()
+#     return login_page
+
+# @pytest.fixture
+# def landing_page(driver):
+#     landing_page = RegistriesLandingPage(driver)
+#     landing_page.goto()
+#     return landing_page
+
+class TestVersioningElements:
+    @markers.core_functionality
+    def test_my_registries_upates_button_exists(self, driver, user = osf_api.current_user()):
+
+        # login and go to dashboard
+        login(driver)
+        dashboard_page = DashboardPage(driver)
+        dashboard_page.goto()
+        DashboardPage(driver, verify=True)
+
+        # find dropdown for registries and click it
+        home_nav_bar = HomeNavbar(driver)
+        home_dropdown_caret = home_nav_bar.service_dropdown
+        home_dropdown_caret.click()
+        home_registries_link = home_nav_bar.registries_link
+        home_registries_link.click()
+
+        # click add new registration button
+        registries_navbar = RegistriesNavbar(driver)
+        add_new_registration = registries_navbar.add_new_link
+        add_new_registration.click()
+
+        # verify on add new page
+        registries_add_new_page = RegistrationAddNewPage(driver, verify=True)
+        assert registries_add_new_page.dropdown_wormhole
+
+        # add wait to ensure form loads (may be able to reduce wait later)
+        WebDriverWait(driver, 20).until(
+            EC.presence_of_element_located(
+                (By.CSS_SELECTOR, '[data-test-new-registration-form]')
+            )
+        ) 
+
+        # yes to projects 
+        yes_button_exists = registries_add_new_page.has_project_button
+        yes_button_exists.click()
+        print("t:{}  v:{} ".format(type(yes_button_exists), yes_button_exists)) # print type and representation
+
+        # NOTE uncomment for no projects and comment out yes logic
+        # no_button_exists = registries_add_new_page.no_project_button
+        # no_button_exists.click()
+
+        project_power_select = registries_add_new_page.project_selection_dropdown
+        project_power_select.click()
+
+        # select first project
+        # first_project = registries_add_new_page.first_project_selection
+        # first_project.click()
+
+        # select second project
+        second_project = registries_add_new_page.second_project_selection
+        second_project.click()
+
+        WebDriverWait(driver, 5)
+
+        # click registration schema type dropdown
+        schema_power_select_dropdown = registries_add_new_page.schema_type_dropdown
+        schema_power_select_dropdown.click()
+
+        WebDriverWait(driver, 5)
+
+        # select preregistration schema
+        preregistration_schema_select = registries_add_new_page.preregistration_schema_selection
+        preregistration_schema_select.click()
+
+        WebDriverWait(driver, 5)
+
+        ipdb.set_trace()
+        # click submit 
+        submit_button_add_new = registries_add_new_page.add_new_submit_button
+        submit_button_add_new.click()
+
+        # verify transition to draft page
+        registration_draft_page = RegistrationDraftPage(driver, verify=True)
+        draft_registration_page_identity = registration_draft_page.identity
+        assert draft_registration_page_identity
+        print("t:{}  v:{} ".format(type(draft_registration_page_identity), draft_registration_page_identity)) 
+
+        # fill out title 
+        input_registration_title = registration_draft_page.registration_title_input
+        input_registration_title.clear()
+        registration_random = str(random.randrange(1, 1000000))
+        registration_title = 'Outcome Reporting Moderation Test'  + registration_random
+        print(f'The Registration title is: ', registration_title)
+        input_registration_title.send_keys(registration_title)
+
+        WebDriverWait(driver, 5)
+
+        # fill out description 
+        input_registration_description = registration_draft_page.registration_description_input
+        input_registration_description.clear()
+        input_registration_description.send_keys('This registration is for testing the outcome reporting moderation workflow for versioning.')
+
+        ipdb.set_trace()
+        # click '+' add contributor button
+        button_add_contributor = registration_draft_page.add_contributor_plus_button
+        button_add_contributor.click()
+
+        WebDriverWait(driver, 5)
+
+        # clear contributor search box
+        # TODO add logic for checking if contributors are present, ensure 1 admin is there
+        search_box_add_contributor = registration_draft_page.add_contributor_search_box
+        search_box_add_contributor.clear()
+
+        # send keys for contributor name
+        WebDriverWait(driver, 5)
+        name = 'Ashley Robinson' # add to config later
+        search_box_add_contributor.send_keys(name)
+
+        # click search for contributor
+        WebDriverWait(driver, 5)
+        search_button_add_contributor = registration_draft_page.add_contributor_search_button
+        search_button_add_contributor.click()
+
+        # add first found contributor
+        try: 
+          result_add_first_contributor = registration_draft_page.add_first_contributor_result
+          if(len(result_add_first_contributor) > 0):
+            print(f'Contributor not yet added: ', s)
+            result_add_first_contributor.click()
+          else:
+            print(f'Contributor already added')
+              
+        # except NoSuchElementException:
+        except TypeError:
+          print('There is a type mismatch')
+        WebDriverWait(driver, 5)
+
+        # click category dropdown 
+        power_select_category = registration_draft_page.category_power_select
+        power_select_category.click()
+
+        WebDriverWait(driver, 5)
+
+        # select analysis category
+        dropdown_select_analysis_category = registration_draft_page.category_analysis_dropdown_select
+        dropdown_select_analysis_category.click()
+
+        WebDriverWait(driver, 5)
+
+        # click license dropdown
+        power_select_license = registration_draft_page.license_power_select
+        power_select_license.click()
+
+        WebDriverWait(driver, 5)
+
+        # select cc international license
+        select_license_cc_international = registration_draft_page.license_cc_international_select
+        select_license_cc_international.click()
+
+        WebDriverWait(driver, 5)
+
+        # check engineering subject
+        checkbox_engineering_subject = registration_draft_page.subject_engineering_checkbox
+        isEngineeringChecked = checkbox_engineering_subject.is_selected()
+        if isEngineeringChecked == False:
+            checkbox_engineering_subject.click()
+
+        WebDriverWait(driver, 5)
+
+        # add tag for mirage moderation backend
+        input_tags = registration_draft_page.tags_input
+        input_tags.clear()
+        input_tags.send_keys('cobalt')
+        input_tags.send_keys(Keys.RETURN)
+
+        WebDriverWait(driver, 5)
+
+        ipdb.set_trace()
+        # click next
+        next_button_draft_registration = registration_draft_page.draft_registration_next_button
+        next_button_draft_registration.click()
+
+        # select for no data         
+        # radio_button_no_data_collected = registration_draft_page.no_data_collected_radio_button
+        # radio_button_no_data_collected.click()
+
+        # select for data collected
+        radio_button_data_collected = registration_draft_page.data_collected_radio_button
+        radio_button_data_collected.click()
+
+        WebDriverWait(driver, 5)
+
+        # select for viewed data
+        radio_button_data_looked_at = registration_draft_page.data_looked_at_radio_button
+        radio_button_data_looked_at.click()
+
+        WebDriverWait(driver, 10)
+
+        # select for unviewed data
+        # radio_button_data_not_looked_at = registration_draft_page.data_not_looked_at_radio_button
+        # radio_button_data_not_looked_at.click()
+
+        # TODO remove this trace
+        ipdb.set_trace()
+
+        # enter any additional comments
+        textarea_comments = registration_draft_page.comments_textarea
+        textarea_comments.clear()
+        textarea_comments.send_keys('Thank you for attending this demo.')
+        textarea_comments.send_keys(Keys.RETURN)
+
+        # review entered answers
+        review_button_draft = registration_draft_page.draft_review_button
+        review_button_draft.click()
+
+        WebDriverWait(driver, 5)
+
+        # register draft
+        register_button_draft = registration_draft_page.register_draft_button
+        register_button_draft.click()
+
+        # choose to make registration public 
+        radio_make_registration_public = registration_draft_page.make_registration_public_radio
+        radio_make_registration_public.click()
+
+        # choose to make registration embargo 
+        # add logic to get current time and add 5 years
+        # radio_make_registration_embargo = registration_draft_page.make_registration_embargo_radio
+        # register_button_draft.click()
+        ipdb.set_trace()
+        # cancel for demo purposes
+        # back_button_demo = registration_draft_page.demo_back_button
+        # back_button_demo.click()
+
+        # register registration NOTE untested
+        # register_button_draft = registration_draft_page.register_draft_button
+        # register_button_draft.click()
+
+        submit_button_draft = registration_draft_page.submit_draft_button
+        submit_button_draft.click()
+    
+        ipdb.set_trace()
+        logout(driver)
+
+
+        

--- a/tests/test_versioning.py
+++ b/tests/test_versioning.py
@@ -12,6 +12,8 @@ import sys
 import configparser
 import ipdb 
 import random
+import threading as thread
+import time
 
 from selenium.common.exceptions import (
     NoSuchElementException,
@@ -38,6 +40,9 @@ from pages.login import (
     InstitutionalLoginPage,
     GenericCASPage,
     login,
+    login_admin,
+    login_read_only,
+    login_read_write,
     logout
 )
 from pages.dashboard import DashboardPage
@@ -68,9 +73,56 @@ from pages.registries import (
 #     landing_page = RegistriesLandingPage(driver)
 #     landing_page.goto()
 #     return landing_page
-
+@markers.core_functionality
 class TestVersioningElements:
-    @markers.core_functionality
+
+    def test_handle_login(self, driver, user=osf_api.current_user()):
+
+        ipdb.set_trace()
+        # login as read write user
+        login_read_write(driver)
+        print(f'Logging in as read write user')
+        dashboard_page = DashboardPage(driver)
+        dashboard_page.goto()
+        DashboardPage(driver, verify=True)
+        logout(driver)
+
+        ipdb.set_trace()
+        # login as read only user
+        login_read_only(driver)
+        print(f'Logging in as read only user')
+        dashboard_page = DashboardPage(driver)
+        dashboard_page.goto()
+        DashboardPage(driver, verify=True)
+        logout(driver)
+
+        ipdb.set_trace()
+        # login as admin user
+        login_admin(driver)
+        print(f'Logging in as admin user')
+        dashboard_page = DashboardPage(driver)
+        dashboard_page.goto()
+        DashboardPage(driver, verify=True)
+        logout(driver)
+
+    # find all contributor & email
+
+    # navigate to gmail for each one
+
+    # regex the title
+
+    # click the approve button
+
+    # close tab
+
+    # do for each in array of conributor emails
+
+    # create a edit
+
+    # approve by the same approve email but for edits
+
+
+    # create registration
     def test_my_registries_upates_button_exists(self, driver, user = osf_api.current_user()):
 
         # login and go to dashboard
@@ -305,5 +357,12 @@ class TestVersioningElements:
         ipdb.set_trace()
         logout(driver)
 
+    def runAllVersioning(self):
+        if __name__ == '__main__':
+            thread.Thread(target = self.handle_login).start()
+            thread.Thread(target = self.test_my_registries_upates_button_exists).start()
 
+
+run = TestVersioningElements()
+run.runAllVersioning()
         

--- a/tests/test_versioning.py
+++ b/tests/test_versioning.py
@@ -188,7 +188,7 @@ class TestVersioningElements:
         try: 
           result_add_first_contributor = registration_draft_page.add_first_contributor_result
           if(len(result_add_first_contributor) > 0):
-            print(f'Contributor not yet added: ', s)
+            print(f'Contributor not yet added: ')
             result_add_first_contributor.click()
           else:
             print(f'Contributor already added')


### PR DESCRIPTION
Ticket: https://openscience.atlassian.net/browse/FEATURE-1477
Feature flags:

-      feature/fe-intercept
-      feature/oxygen-browser
-      feature/profile-page-redesign 

## Purpose

This script tests the functionality of Emberized Registries pages. Currently, it will create a Registration with the Preregistration schema, autocomplete its form elements, register, and submits the Registration. Values have not been exported to an external config file and are currently still hard-coded. Considerations for Excel, Google Docs, and .csv are being considered for potential file formats. Next steps will be:

- successfully launch test_versioning.py from the FrontEnd's LoadInteractables component
- complete other possible registration schemas, list options, etc (will be assisted by LoadInteractables)
- add controller class that handles log in/out of different user accounts 

## Summary of Changes

Added the create registration workflow for Registries in the test_versioning.py file, added logic for if a contributor was present; added xpath selectors for navigable and form/button elements in the registries.py file.

## Reviewer's Actions
`git fetch <remote> pull/<PR_number>/head:<branch_name>`

Run this test using
`tests/test_versioning.py -s -v`

## Testing Changes Moving Forward

TBD

## Ticket

https://openscience.atlassian.net/browse/ENG-TBD
