### PR TITLE
[ENG-3575] - Remove Project List Load Assertion from Institutions Custom Domain Test

### DIFF
--- a/tests/test_institutions.py
+++ b/tests/test_institutions.py
@@ -34,18 +34,20 @@ class TestCustomDomains:
     @markers.smoke_test
     @pytest.mark.parametrize('domain', settings.CUSTOM_INSTITUTION_DOMAINS)
     def test_arrive_at_myprojects_page(self, driver, domain):
-        """Test custom institutional domains. Skipped on any server that has no custom domains"""
+        """Test custom institutional domains. Skipped on any server that has no custom
+        domains. Currently only Production and Stage 1 have custom domains.
+        """
         # TODO: Add check for institution name
         driver.get(domain)
         institution_page = InstitutionBrandedPage(driver, verify=True)
         assert domain in driver.current_url
-        # first check if the collection is empty - this may often be the case in the test environments
+        # First check if the collection is empty - this may often be the case in the
+        # test environments
         if institution_page.empty_collection_indicator.absent():
-            # wait for projects table to start loading and verify that there are some projects listed
-            WebDriverWait(driver, 60).until(
+            # Wait for projects table to start loading and verify that there is at
+            # least one project listed
+            WebDriverWait(driver, 40).until(
                 EC.presence_of_element_located(
                     (By.CSS_SELECTOR, '#tb-tbody > div > div > div.tb-row')
                 )
             )
-            # projects are loaded in batches in varying sizes - anywhere from 4 to 15 at a time
-            assert len(institution_page.project_list) >= 4


### PR DESCRIPTION
<!-- Before you submit your Pull Request, please confirm that:

     - Any test that will create public data either has the `QAtest` tag or the `dont_run_on_production` marker
     - `core_functionality` is marked as such
     - Your tests will be able to run on *all* servers (all stagings, test)
 -->


## Purpose
To fix a test failure in the nightly Production Smoke Test run due to the fact that for one specific institution (JMU) the first batch of projects loaded in the table is only 2 projects when we are expecting at least 4.


## Summary of Changes

- tests/test_institutions.py - remove the assert statement that is expecting at least 4 projects to load in the first batch, and reduce the wait for the first project to load to 40 seconds. 


## Reviewer's Actions
`git fetch <remote> pull/<PR_number>/head:testFix/institutions`

Run this test using
`tests/test_institutions.py -s -v`

## Testing Changes Moving Forward
N/A


## Ticket
ENG-3575 - SEL: Institutions Test - Production Failure - TestCustomDomains::test_arrive_at_myprojects_page[https://osf.jmu.edu]
https://openscience.atlassian.net/browse/ENG-3575
