### PR TITLE
[ENG-3597] - Re-enable My Projects Page test

### DIFF
--- a/pages/project.py
+++ b/pages/project.py
@@ -75,6 +75,11 @@ class MyProjectsPage(OSFBasePage):
     first_collection_remove_button = Locator(
         By.CSS_SELECTOR, '[data-target="#removeColl"]', settings.QUICK_TIMEOUT
     )
+    all_my_projects_and_components_link = Locator(
+        By.CSS_SELECTOR, 'li[data-index="0"] span', settings.QUICK_TIMEOUT
+    )
+    empty_collection_indicator = Locator(By.CLASS_NAME, 'db-non-load-template')
+    breadcrumbs = Locator(By.CSS_SELECTOR, 'div.db-breadcrumbs > ul > li > span')
 
     # Components
     create_collection_modal = ComponentLocator(CreateCollectionModal)


### PR DESCRIPTION
<!-- Before you submit your Pull Request, please confirm that:

     - Any test that will create public data either has the `QAtest` tag or the `dont_run_on_production` marker
     - `core_functionality` is marked as such
     - Your tests will be able to run on *all* servers (all stagings, test)
 -->


## Purpose
To re-enable a test that has been skipped for a long time in all environments. 


## Summary of Changes

- pages/project.py - added 3 new elements for the My Projects page: all_my_projects_and_components_link, empty_collection_indicator, and breadcrumbs
- tests/test_my_projects.py - deleted the skip statement that was skipping all of the tests in every environment. Replaced skip statement with dont_run_on_prod marker since we still don't want to run these tests in Production. Added step to click the all_my_projects_and_components_link in the My Projects page sidebar after creating a new project. This is necessary in some testing environments due to some unknown issue with the project table not being properly refreshed so that the newly created project displays correctly.  Also adding some extra verification steps in test_create_custom_collection.


## Reviewer's Actions
`git fetch <remote> pull/<PR_number>/head:testFix/my-projects`

Run this test using
`tests/test_my_projects.py -s -v`

## Testing Changes Moving Forward
N/A


## Ticket
ENG-3597 - SEL: Re-enable My Projects Page Test
https://openscience.atlassian.net/browse/ENG-3597
