### PR TITLE
[ENG-3650] - Add Testing of Branded Registry Provider Pages

### DIFF
--- a/pages/registries.py
+++ b/pages/registries.py
@@ -17,7 +17,7 @@ from pages.base import (
 
 
 class BaseRegistriesPage(OSFBasePage):
-    base_url = settings.OSF_HOME + '/registries/'
+    base_url = urljoin(settings.OSF_HOME, 'registries/')
     url_addition = ''
     navbar = ComponentLocator(RegistriesNavbar)
 
@@ -33,8 +33,8 @@ class BaseRegistriesPage(OSFBasePage):
     def url(self):
         """Set the URL based on the provider except when the provider is OSF."""
         if self.provider and self.provider_id != 'osf':
-            self.base_url = urljoin(self.base_url, self.provider_id)
-        return self.base_url + self.url_addition
+            self.base_url = urljoin(self.base_url, self.provider_id) + '/'
+        return urljoin(self.base_url, self.url_addition)
 
 
 class RegistriesLandingPage(BaseRegistriesPage):
@@ -45,7 +45,7 @@ class RegistriesLandingPage(BaseRegistriesPage):
 
 
 class RegistriesDiscoverPage(BaseRegistriesPage):
-    url_addition = '/discover'
+    url_addition = 'discover'
 
     identity = Locator(
         By.CSS_SELECTOR, 'div[data-analytics-scope="Registries Discover page"]'
@@ -76,7 +76,7 @@ class RegistrationDetailPage(GuidBasePage):
 
 
 class RegistrationAddNewPage(BaseRegistriesPage):
-    url_addition = '/new'
+    url_addition = 'new'
     identity = Locator(
         By.CSS_SELECTOR, 'form[data-test-new-registration-form]', settings.LONG_TIMEOUT
     )

--- a/pages/registries.py
+++ b/pages/registries.py
@@ -1,3 +1,5 @@
+from urllib.parse import urljoin
+
 from selenium.common.exceptions import NoSuchElementException
 from selenium.webdriver.common.by import By
 
@@ -15,14 +17,27 @@ from pages.base import (
 
 
 class BaseRegistriesPage(OSFBasePage):
-
-    # Components
+    base_url = settings.OSF_HOME + '/registries/'
+    url_addition = ''
     navbar = ComponentLocator(RegistriesNavbar)
+
+    def __init__(self, driver, verify=False, provider=None):
+        self.provider = provider
+        if provider:
+            self.provider_id = provider['id']
+            self.provider_name = provider['attributes']['name']
+
+        super().__init__(driver, verify)
+
+    @property
+    def url(self):
+        """Set the URL based on the provider except when the provider is OSF."""
+        if self.provider and self.provider_id != 'osf':
+            self.base_url = urljoin(self.base_url, self.provider_id)
+        return self.base_url + self.url_addition
 
 
 class RegistriesLandingPage(BaseRegistriesPage):
-    url = settings.OSF_HOME + '/registries'
-
     identity = Locator(
         By.CSS_SELECTOR, '._RegistriesHeader_3zbd8x', settings.LONG_TIMEOUT
     )
@@ -30,7 +45,7 @@ class RegistriesLandingPage(BaseRegistriesPage):
 
 
 class RegistriesDiscoverPage(BaseRegistriesPage):
-    url = settings.OSF_HOME + '/registries/discover'
+    url_addition = '/discover'
 
     identity = Locator(
         By.CSS_SELECTOR, 'div[data-analytics-scope="Registries Discover page"]'
@@ -61,9 +76,13 @@ class RegistrationDetailPage(GuidBasePage):
 
 
 class RegistrationAddNewPage(BaseRegistriesPage):
-    url = settings.OSF_HOME + '/registries/osf/new'
-    identity = Locator(By.CSS_SELECTOR, 'form[data-test-new-registration-form]', settings.LONG_TIMEOUT)
+    url_addition = '/new'
+    identity = Locator(
+        By.CSS_SELECTOR, 'form[data-test-new-registration-form]', settings.LONG_TIMEOUT
+    )
 
 
 class RegistrationDraftPage(BaseRegistriesPage):
-    identity = Locator(By.CSS_SELECTOR, 'nav[data-test-side-nav]', settings.LONG_TIMEOUT)
+    identity = Locator(
+        By.CSS_SELECTOR, 'nav[data-test-side-nav]', settings.LONG_TIMEOUT
+    )

--- a/tests/test_registries.py
+++ b/tests/test_registries.py
@@ -3,6 +3,7 @@ from selenium.webdriver.common.keys import Keys
 
 import markers
 import settings
+from api import osf_api
 from pages.registries import (
     RegistrationDetailPage,
     RegistriesDiscoverPage,
@@ -58,3 +59,24 @@ class TestRegistriesDiscoverPage:
         detail_page.identity.present()
         assert RegistrationDetailPage(driver, verify=True)
         assert detail_page.identity.text in target_registration_title
+
+
+@markers.smoke_test
+class TestBrandedRegistriesPages:
+    def providers():
+        """Return all registration providers."""
+        return osf_api.get_providers_list(type='registrations')
+
+    @pytest.fixture(params=providers(), ids=[prov['id'] for prov in providers()])
+    def provider(self, request):
+        return request.param
+
+    def test_discover_page(self, session, driver, provider):
+        """This test will load the Discover page for each Branded Registry Provider that
+        exists in an environment.
+        """
+        if provider['attributes']['branded_discovery_page']:
+            discover_page = RegistriesDiscoverPage(driver, provider=provider)
+            discover_page.goto()
+            discover_page.loading_indicator.here_then_gone()
+            assert RegistriesDiscoverPage(driver, verify=True)


### PR DESCRIPTION
<!-- Before you submit your Pull Request, please confirm that:

     - Any test that will create public data either has the `QAtest` tag or the `dont_run_on_production` marker
     - `core_functionality` is marked as such
     - Your tests will be able to run on *all* servers (all stagings, test)
 -->


## Purpose
 To make the Registries test more comprehensive by adding the testing of any Branded Registries in each environment. 


## Summary of Changes

- pages/registries.py - refactor registries pages so that they can handle pages for individual branded providers.
- tests/test_registries.py - add new test class: TestBrandedRegistriesPages and new test: test_discover_page that loads the Discover page of every branded registry provider in the given environment.


## Reviewer's Actions
`git fetch <remote> pull/<PR_number>/head:testFix/branded-registries`

Run this test using
`tests/test_registries.py -s -v`

## Testing Changes Moving Forward
N/A


## Ticket
ENG-3650: SEL: Registries Test - Add Testing of Branded Registries in Each Environment
https://openscience.atlassian.net/browse/ENG-3650
