### PR TITLE
[ENG-3684] - Add testing of individual institution login pages

### DIFF
--- a/pages/login.py
+++ b/pages/login.py
@@ -89,6 +89,16 @@ class InstitutionalLoginPage(BasePage):
     dropdown_options = GroupLocator(By.CSS_SELECTOR, '#institutionSelect option')
 
 
+class GenericInstitutionLoginPage(BasePage):
+    identity = Locator(By.CSS_SELECTOR, 'input[type="password"]')
+
+
+class GenericInstitutionEmailLoginPage(BasePage):
+    # This is for institution login pages that first ask for an email to initiate the
+    # login process before asking for a password.
+    identity = Locator(By.CSS_SELECTOR, 'input[type="email"]')
+
+
 class ForgotPasswordPage(BasePage):
     url = settings.OSF_HOME + '/forgotpassword/'
 


### PR DESCRIPTION
<!-- Before you submit your Pull Request, please confirm that:

     - Any test that will create public data either has the `QAtest` tag or the `dont_run_on_production` marker
     - `core_functionality` is marked as such
     - Your tests will be able to run on *all* servers (all stagings, test)
 -->


## Purpose
To add testing of individual institution login pages to the nightly Production Smoke Test run which will expand the comprehensiveness of the Login test.


## Summary of Changes

- pages/login.py - add 2 new generic institution login page classes: GenericInstitutionLoginPage and GenericInstitutionEmailLoginPage
- tests/test_login.py - add new test: test_individual_institution_login_pages and its associated fixture: institution_list.  The fixture gets the list of available institutions from the dropdown listbox on the OSF Institution Login page and the test uses this list to select each institution from the listbox and then click the Sign In button. Then the test verifies that it gets navigated to a valid institution login page.


## Reviewer's Actions
`git fetch <remote> pull/<PR_number>/head:feature/login-institution-pages`

Run this test using
`tests/test_login.py -s -v`

## Testing Changes Moving Forward
N/A


## Ticket
ENG-3684: SEL: Login Test - Add Testing of Individual Institution Login Pages
https://openscience.atlassian.net/browse/ENG-3684
