### PR TITLE
[ENG-3687] - Update Navbar Support links from Ember Pages

### DIFF
--- a/pages/support.py
+++ b/pages/support.py
@@ -5,7 +5,14 @@ from base.locators import Locator
 from pages.base import OSFBasePage
 
 
-class SupportPage(OSFBasePage):
+# Temporary Old Support Page - Delete this after eop: 0.139.0 preprints release
+class OldSupportPage(OSFBasePage):
     url = settings.OSF_HOME + '/support'
 
     identity = Locator(By.CSS_SELECTOR, '._Support_15i3vw', settings.LONG_TIMEOUT)
+
+
+class SupportPage(OSFBasePage):
+    url = 'https://help.osf.io/'
+
+    identity = Locator(By.CSS_SELECTOR, 'img[alt="OSF Support"]', settings.LONG_TIMEOUT)

--- a/tests/test_navbar.py
+++ b/tests/test_navbar.py
@@ -21,7 +21,10 @@ from pages.registries import (
     RegistriesLandingPage,
 )
 from pages.search import SearchPage
-from pages.support import SupportPage
+from pages.support import (
+    OldSupportPage,
+    SupportPage,
+)
 from pages.user import (
     ProfileInformationPage,
     UserProfilePage,
@@ -180,6 +183,13 @@ class TestPreprintsNavbarLoggedIn(NavbarTestLoggedInMixin):
         page.goto_with_reload()
         return page
 
+    # Temporary Override of test from mix in - Delete this after eop: 0.139.0 preprints
+    # release
+    def test_user_profile_menu_support_link(self, driver, page):
+        page.navbar.user_dropdown.click()
+        page.navbar.user_dropdown_support.click()
+        assert OldSupportPage(driver, verify=True)
+
     def test_add_a_preprint_link(self, page, driver):
         page.navbar.add_a_preprint_link.click()
         PreprintSubmitPage(driver, verify=True)
@@ -208,8 +218,7 @@ class TestRegistriesNavbarLoggedOut(NavbarTestLoggedOutMixin):
 
     def test_help_link(self, page, driver):
         page.navbar.help_link.click()
-        help_url = 'https://help.osf.io/hc/en-us/categories/360001550953'
-        assert driver.current_url == help_url
+        assert SupportPage(driver, verify=True)
 
     # In the Registries navbar there is no Sign Up button, instead it is a Join link
     def test_sign_up_button(self, page, driver):
@@ -257,11 +266,7 @@ class TestMeetingsNavbarLoggedOut(NavbarTestLoggedOutMixin):
 
     def test_support_link(self, page, driver):
         page.navbar.support_link.click()
-        assert '360001550933' in driver.current_url or 'support' in driver.current_url
-
-        # For future use
-        # support_url = 'https://openscience.zendesk.com/hc/en-us/categories/360001550933'
-        # assert driver.current_url == support_url
+        assert SupportPage(driver, verify=True)
 
 
 @markers.smoke_test


### PR DESCRIPTION
<!-- Before you submit your Pull Request, please confirm that:

     - Any test that will create public data either has the `QAtest` tag or the `dont_run_on_production` marker
     - `core_functionality` is marked as such
     - Your tests will be able to run on *all* servers (all stagings, test)
 -->


## Purpose
To fix the Support link on the navbar of Ember pages and the OSF Support link on the logged in user dropdown menu to point to the new HelpScout Support page.


## Summary of Changes

- pages/support.py - Update the url and identity link for the SupportPage class and add a temporary OldSupportPage class for use by the Preprints navbar links which will be fixed in a later release.
- tests/test_navbar.py - Update a few tests to verify routing of help or support links to new support page, and adding temporary override of mixin test: test_user_profile_menu_support_link for the TestPreprintsNavbarLoggedIn class.


## Reviewer's Actions
`git fetch <remote> pull/<PR_number>/head:testFix/navbar-new-support`

Run this test using
`tests/test_navbar.py -s -v`

## Testing Changes Moving Forward

- Will need to update again and delete some parts of this test after next Preprints Release: eop: 0.139.0


## Ticket
ENG-3687: SEL: Navbar Test - Update Support Links from Ember Pages
https://openscience.atlassian.net/browse/ENG-3687
