### PR TITLE
[ENG-3694] - Change learn more button locator and correct typo

### DIFF
--- a/pages/landing.py
+++ b/pages/landing.py
@@ -16,7 +16,9 @@ class LandingPage(OSFBasePage):
 
     get_started_button = Locator(By.CSS_SELECTOR, '[data-test-get-started-button]')
     search_input = Locator(By.CSS_SELECTOR, '[data-test-search-input]')
-    learn_more_button = Locator(By.CSS_SELECTOR, '[data-test-learn-more-button]')
+    learn_more_button = Locator(
+        By.CSS_SELECTOR, '[data-analytics-name="Learn more button"]'
+    )
     testimonial_1_button = Locator(
         By.CSS_SELECTOR, '[data-analytics-name="Go to slide 1"]'
     )

--- a/tests/test_landing.py
+++ b/tests/test_landing.py
@@ -33,7 +33,7 @@ class TestHomeLandingPage:
         search_page.loading_indicator.here_then_gone()
         assert search_page.search_results
 
-    def test_learn_nore(self, driver, landing_page):
+    def test_learn_more(self, driver, landing_page):
         landing_page.learn_more_button.click()
         assert driver.current_url == 'https://www.cos.io/products/osf'
 


### PR DESCRIPTION
<!-- Before you submit your Pull Request, please confirm that:

     - Any test that will create public data either has the `QAtest` tag or the `dont_run_on_production` marker
     - `core_functionality` is marked as such
     - Your tests will be able to run on *all* servers (all stagings, test)
 -->


## Purpose
To change the locator for the learn more button on the OSF Home Landing Page to avoid potential issues in Firefox since the previous locator is in the html in two places.


## Summary of Changes

- pages/landing.py - update the locator for learn_more_button
- tests/test_landing.py - correct a typo


## Reviewer's Actions
`git fetch <remote> pull/<PR_number>/testFix/landing`

Run this test using
`tests/test_landing.py -s -v`

## Testing Changes Moving Forward
N/A


## Ticket
ENG-3694: SEL: Landing Page Test - Change locator for Learn more button
https://openscience.atlassian.net/browse/ENG-3694
