### PR TITLE
[ENG-3698] - Update Navbar Support links from Preprint Pages

### DIFF
--- a/pages/support.py
+++ b/pages/support.py
@@ -5,13 +5,6 @@ from base.locators import Locator
 from pages.base import OSFBasePage
 
 
-# Temporary Old Support Page - Delete this after eop: 0.139.0 preprints release
-class OldSupportPage(OSFBasePage):
-    url = settings.OSF_HOME + '/support'
-
-    identity = Locator(By.CSS_SELECTOR, '._Support_15i3vw', settings.LONG_TIMEOUT)
-
-
 class SupportPage(OSFBasePage):
     url = 'https://help.osf.io/'
 

--- a/tests/test_navbar.py
+++ b/tests/test_navbar.py
@@ -21,10 +21,7 @@ from pages.registries import (
     RegistriesLandingPage,
 )
 from pages.search import SearchPage
-from pages.support import (
-    OldSupportPage,
-    SupportPage,
-)
+from pages.support import SupportPage
 from pages.user import (
     ProfileInformationPage,
     UserProfilePage,
@@ -164,8 +161,7 @@ class TestPreprintsNavbarLoggedOut(NavbarTestLoggedOutMixin):
 
     def test_support_link(self, page, driver):
         page.navbar.support_link.click()
-        support_url = 'https://help.osf.io/hc/en-us/categories/360001530554-Preprints'
-        assert driver.current_url == support_url
+        assert SupportPage(driver, verify=True)
 
     def test_sign_up_button(self, page, driver):
         page.navbar.sign_up_button.click()
@@ -182,13 +178,6 @@ class TestPreprintsNavbarLoggedIn(NavbarTestLoggedInMixin):
         page = PreprintLandingPage(driver)
         page.goto_with_reload()
         return page
-
-    # Temporary Override of test from mix in - Delete this after eop: 0.139.0 preprints
-    # release
-    def test_user_profile_menu_support_link(self, driver, page):
-        page.navbar.user_dropdown.click()
-        page.navbar.user_dropdown_support.click()
-        assert OldSupportPage(driver, verify=True)
 
     def test_add_a_preprint_link(self, page, driver):
         page.navbar.add_a_preprint_link.click()


### PR DESCRIPTION
<!-- Before you submit your Pull Request, please confirm that:

     - Any test that will create public data either has the `QAtest` tag or the `dont_run_on_production` marker
     - `core_functionality` is marked as such
     - Your tests will be able to run on *all* servers (all stagings, test)
 -->


## Purpose
To fix the Support link on the navbar of Preprint pages and the OSF Support link on the logged in user dropdown menu to point to the new HelpScout Support page.

## Summary of Changes

- pages/support.py - delete the temporary OldSupportPage that is no longer necessary.
- tests/test_navbar.py - update test_support_link for the logged out Preprints test class to expect new helpscout support page and delete the temporary override test: test_user_profile_menu_support_link


## Reviewer's Actions
`git fetch <remote> pull/<PR_number>/head:testFix/navbar-new-support`

Run this test using
`tests/test_navbar.py -s -v`

## Testing Changes Moving Forward
N/A


## Ticket
ENG-3698: SEL: Navbar Test - Update Support Links from Preprint Pages
https://openscience.atlassian.net/browse/ENG-3698
