### PR TITLE
[ENG-3705] - Add Testing of Preprint Metrics

### DIFF
--- a/api/osf_api.py
+++ b/api/osf_api.py
@@ -365,3 +365,39 @@ def update_node_public_attribute(session, node_id, status=False):
         item_id=node_id,
         raw_body=json.dumps(raw_payload),
     )
+
+
+def get_most_recent_preprint_node_id(session=None):
+    """Return the most recently submitted preprint node id"""
+    if not session:
+        session = get_default_session()
+    url = '/v2/preprints/'
+    data = session.get(url)['data']
+    if data:
+        return data[0]['id']
+    else:
+        return None
+
+
+def get_preprint_views_count(session=None, node_id=None):
+    """Return the views count for the given preprint node id"""
+    if not session:
+        session = get_default_session()
+    url = '/v2/preprints/{}/?metrics[views]=total'.format(node_id)
+    metadata = session.get(url)['meta']
+    if metadata:
+        return metadata['metrics']['views']
+    else:
+        return None
+
+
+def get_preprint_downloads_count(session=None, node_id=None):
+    """Return the downloads count for the given preprint node id"""
+    if not session:
+        session = get_default_session()
+    url = '/v2/preprints/{}/files/osfstorage/'.format(node_id)
+    data = session.get(url)['data']
+    if data:
+        return data[0]['attributes']['extra']['downloads']
+    else:
+        return None

--- a/pages/preprints.py
+++ b/pages/preprints.py
@@ -181,6 +181,12 @@ class PreprintDetailPage(GuidBasePage, BasePreprintPage):
     identity = Locator(By.ID, 'preprintTitle', settings.LONG_TIMEOUT)
     title = Locator(By.ID, 'preprintTitle', settings.LONG_TIMEOUT)
     view_page = Locator(By.ID, 'view-page')
+    views_downloads_counts = Locator(
+        By.CSS_SELECTOR, 'div.share-row.p-sm.osf-box-lt.clearfix > div'
+    )
+    download_button = Locator(
+        By.CSS_SELECTOR, 'div.share-row.p-sm.osf-box-lt.clearfix > a'
+    )
 
 
 class ReviewsDashboardPage(OSFBasePage):

--- a/tests/test_preprints.py
+++ b/tests/test_preprints.py
@@ -221,6 +221,65 @@ class TestPreprintSearch:
         assert PreprintDetailPage(driver, verify=True)
 
 
+@markers.smoke_test
+class TestPreprintMetrics:
+    @pytest.fixture(scope='session')
+    def latest_preprint_node(self):
+        """Return the node id of the latest preprint submitted in the given environment"""
+        return osf_api.get_most_recent_preprint_node_id()
+
+    def test_preprint_views_count(self, driver, latest_preprint_node):
+        """Test the Views Count functionality on the Preprint Detail page by getting
+        the views count for a preprint using the api and comparing it to the views
+        count value displayed on the page. Also verifying that the views count will
+        be incremented if the page is reloaded (only in testing environments).
+        """
+        api_views_count = osf_api.get_preprint_views_count(node_id=latest_preprint_node)
+        preprint_page = PreprintDetailPage(driver, guid=latest_preprint_node)
+        preprint_page.goto()
+        assert PreprintDetailPage(driver, verify=True)
+        page_views_count = int(preprint_page.views_downloads_counts.text[7:9])
+        assert api_views_count == page_views_count
+        # Don't reload the page in Production since we don't want to artificially
+        # inflate the metrics
+        if not settings.PRODUCTION:
+            # Verify that the views count from the api increases by 1 after we reload
+            # the page.
+            preprint_page.reload()
+            assert (
+                osf_api.get_preprint_views_count(node_id=latest_preprint_node)
+                == api_views_count + 1
+            )
+
+    def test_preprint_downloads_count(self, driver, latest_preprint_node):
+        """Test the Downloads Count functionality on the Preprint Detail page by
+        getting the downloads count for a preprint using the api and comparing it to
+        the downloads count value displayed on the page. Also verifying that the
+        downloads count will be incremented when the downloads button on the page is
+        clicked (only in testing environments).
+        """
+        api_downloads_count = osf_api.get_preprint_downloads_count(
+            node_id=latest_preprint_node
+        )
+        preprint_page = PreprintDetailPage(driver, guid=latest_preprint_node)
+        preprint_page.goto()
+        assert PreprintDetailPage(driver, verify=True)
+        page_downloads_count = int(
+            preprint_page.views_downloads_counts.text.split('Downloads:')[1]
+        )
+        assert api_downloads_count == page_downloads_count
+        # Don't download the Preprint in Production since we don't want to artificially
+        # inflate the metrics
+        if not settings.PRODUCTION:
+            # Verify that the downloads count from the api increases by 1 after we
+            # download the document.
+            preprint_page.download_button.click()
+            assert (
+                osf_api.get_preprint_downloads_count(node_id=latest_preprint_node)
+                == api_downloads_count + 1
+            )
+
+
 @pytest.fixture(scope='session')
 def providers():
     """Return all preprint providers."""


### PR DESCRIPTION
<!-- Before you submit your Pull Request, please confirm that:

     - Any test that will create public data either has the `QAtest` tag or the `dont_run_on_production` marker
     - `core_functionality` is marked as such
     - Your tests will be able to run on *all* servers (all stagings, test)
 -->


## Purpose
To expand the Preprints Test to accommodate a recent upgrade to Preprints which added the display of metrics (views and downloads counts) to the Preprint Detail page.


## Summary of Changes

- api/osf_api.py - add three new functions: get_most_recent_preprint_node_id, get_preprint_views_count, and get_preprint_downloads_count
- pages/preprints.py - add two new locators for the views and downloads counts section and the download button on the Preprint Detail page.
- tests/test_preprints.py - add new test class: TestPreprintMetrics which contains a fixture: latest_preprint_node and two test methods: test_preprint_views_count and test_preprint_downloads_count


## Reviewer's Actions
`git fetch <remote> pull/<PR_number>/head:feature/preprints-metrics`

Run this test using
`tests/test_preprints.py -s -v` **NOTE: If running in Production include "-m smoke_test"** 

## Testing Changes Moving Forward
N/A


## Ticket
ENG-3705: SEL: Preprints Test - Add tests for Views and Downloads Counts on Preprint Detail Page
https://openscience.atlassian.net/browse/ENG-3705
