### PR TITLE
[ENG-2858] - Remove old Travis references

### DIFF
--- a/.github/workflows/production_smoke_tests.yml
+++ b/.github/workflows/production_smoke_tests.yml
@@ -86,4 +86,4 @@ jobs:
           PREFERRED_NODE: ra4bf
           TEST_BUILD: ${{ matrix.browser }}
         run: |
-          invoke test_travis_on_prod
+          invoke test_selenium_on_prod

--- a/.github/workflows/selenium_staging_tests.yml
+++ b/.github/workflows/selenium_staging_tests.yml
@@ -91,9 +91,9 @@ jobs:
         env:
           TEST_BUILD: ${{ matrix.browser }}
         run: |
-          invoke test_travis_part_one
+          invoke test_selenium_part_one
       - name: run staging tests, part two
         env:
           TEST_BUILD: ${{ matrix.browser }}
         run: |
-          invoke test_travis_part_two
+          invoke test_selenium_part_two

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 - repo: https://github.com/psf/black
-  rev: 21.7b0
+  rev: 22.3.0
   hooks:
     - id: black
       args:

--- a/README.md
+++ b/README.md
@@ -3,7 +3,9 @@
 This is the UI test automation for the OSF. It uses Selenium WebDriver and Pytest to create end-to-end OSF tests.
 
 
-[![Build Status](https://travis-ci.org/cos-qa/osf-selenium-tests.svg?branch=master)](https://travis-ci.org/cos-qa/osf-selenium-tests)
+![production_smoke_tests](https://github.com/cos-qa/osf-selenium-tests/actions/workflows/production_smoke_tests.yml/badge.svg)
+![develop_staging_tests](https://github.com/cos-qa/osf-selenium-tests/actions/workflows/selenium_staging_tests.yml/badge.svg)
+
 
 
 ## Setting up

--- a/pages/registrations.py
+++ b/pages/registrations.py
@@ -1,20 +1,32 @@
-import settings
-
 from selenium.webdriver.common.by import By
+
+import settings
 from base.locators import Locator
 from pages.base import OSFBasePage
 
 
 class MyRegistrationsPage(OSFBasePage):
     url = settings.OSF_HOME + '/registries/my-registrations/'
-    identity = Locator(By.CSS_SELECTOR, 'div[data-analytics-scope="My Registrations page"]')
+    identity = Locator(
+        By.CSS_SELECTOR, 'div[data-analytics-scope="My Registrations page"]'
+    )
 
     drafts_tab = Locator(By.CSS_SELECTOR, '[data-test-my-registrations-nav="drafts"]')
     no_drafts_message = Locator(By.CSS_SELECTOR, 'p[data-test-draft-list-no-drafts]')
-    create_a_registration_button_drafts = Locator(By.CSS_SELECTOR, 'a[data-test-my-reg-drafts-add-new-button]')
-    draft_registration_title = Locator(By.CSS_SELECTOR, 'a[data-analytics-name="view_registration"]')
+    create_a_registration_button_drafts = Locator(
+        By.CSS_SELECTOR, 'a[data-test-my-reg-drafts-add-new-button]'
+    )
+    draft_registration_title = Locator(
+        By.CSS_SELECTOR, 'a[data-analytics-name="view_registration"]'
+    )
 
-    submissions_tab = Locator(By.CSS_SELECTOR, '[data-test-my-registrations-nav="submitted"]')
-    no_submissions_message = Locator(By.CSS_SELECTOR, 'p[data-test-draft-list-no-registrations]')
-    create_a_registration_button_submitted = Locator(By.CSS_SELECTOR, 'a[data-test-my-reg-registrations-add-new-button]')
+    submissions_tab = Locator(
+        By.CSS_SELECTOR, '[data-test-my-registrations-nav="submitted"]'
+    )
+    no_submissions_message = Locator(
+        By.CSS_SELECTOR, 'p[data-test-draft-list-no-registrations]'
+    )
+    create_a_registration_button_submitted = Locator(
+        By.CSS_SELECTOR, 'a[data-test-my-reg-registrations-add-new-button]'
+    )
     public_registration_title = Locator(By.CSS_SELECTOR, 'a[data-test-node-title]')

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,5 +10,5 @@ environs==3.0.0
 faker==0.9.0
 pre-commit==2.14.0
 ipdb==0.12.2
-black==21.7b0
+black==22.3.0
 isort==5.9.3

--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -18,7 +18,7 @@ logging.getLogger('invoke').setLevel(logging.CRITICAL)
 HERE = os.path.abspath(os.path.join(os.path.dirname(os.path.abspath(__file__)), '..'))
 BIN_PATH = os.path.dirname(sys.executable)
 bin_prefix = lambda cmd: os.path.join(BIN_PATH, cmd)
-MAX_TRAVIS_RETRIES = int(os.getenv('MAX_TRAVIS_RETRIES', 3))
+MAX_RETRIES = int(os.getenv('MAX_RETRIES', 3))
 
 
 @task(aliases=['flake8'])
@@ -75,33 +75,33 @@ def test_module(ctx, module=None, params=None):
 
 
 @task
-def test_travis_on_prod(ctx):
+def test_selenium_on_prod(ctx):
     """
     Runs targeted prod smoke tests on the latest Chrome
     """
     flake(ctx)
     print('>>> Testing modules in "{}" in Chrome'.format('tests'))
-    test_travis_with_retries(
+    test_selenium_with_retries(
         ctx, 'Master', _get_test_file_list(), module=['-m', 'smoke_test']
     )
 
 
 @task
-def test_travis_part_one(ctx):
+def test_selenium_part_one(ctx):
     """Run first group of tests on the browser defined by TEST_BUILD."""
     all_test_files = _get_test_file_list()
     midpoint = len(all_test_files) // 2
     file_list = all_test_files[:midpoint]
-    test_travis_with_retries(ctx, 'part one', file_list)
+    test_selenium_with_retries(ctx, 'part one', file_list)
 
 
 @task
-def test_travis_part_two(ctx):
+def test_selenium_part_two(ctx):
     """Run second group of tests on the browser defined by TEST_BUILD."""
     all_test_files = _get_test_file_list()
     midpoint = len(all_test_files) // 2
     file_list = all_test_files[midpoint:]
-    test_travis_with_retries(ctx, 'part two', file_list)
+    test_selenium_with_retries(ctx, 'part two', file_list)
 
 
 def _get_test_file_list():
@@ -111,7 +111,7 @@ def _get_test_file_list():
 
 
 @task
-def test_travis_with_retries(ctx, partition_name, file_list, module=None):
+def test_selenium_with_retries(ctx, partition_name, file_list, module=None):
     """Run group of tests on the browser defined by TEST_BUILD."""
     flake(ctx)
 
@@ -128,7 +128,7 @@ def test_travis_with_retries(ctx, partition_name, file_list, module=None):
 
     file_list = ['--last-failed', '--last-failed-no-failures', 'none'] + file_list
 
-    for i in range(1, MAX_TRAVIS_RETRIES + 1):
+    for i in range(1, MAX_RETRIES + 1):
         print(
             '>>> Retesting {} failures, iteration {}, in "/test/" '
             'in {}'.format(partition_name, i, os.environ['TEST_BUILD'])


### PR DESCRIPTION
<!-- Before you submit your Pull Request, please confirm that:

     - Any test that will create public data either has the `QAtest` tag or the `dont_run_on_production` marker
     - `core_functionality` is marked as such
     - Your tests will be able to run on *all* servers (all stagings, test)
 -->


## Purpose
Our current selenium test suite runs via Github Actions so we are removing old references to Travis CI. 


## Summary of Changes
- Update `invoke` commands 
- Update `tasks/__init__.py`
- [BONUS] Update README status badges for passing/failing tests. 
- Update Black linting tool to version 22.3.0


## Reviewer's Actions
`git fetch <remote> pull/198/head:feature/remove-travis`

Run this test by:

Temporarily add this line of code to `test_selenium_part_one` and `test_selenium_part_two` in the file `tasks/__init__.py` : 
- `os.environ['TEST_BUILD'] = 'chrome'`
- Locally, run `invoke test_selenium_part_one` against a staging server. 
- Then, run `invoke test_selenium_part_two` against a staging server. 


## Testing Changes Moving Forward
- N/A


## Ticket

https://openscience.atlassian.net/browse/ENG-2858
