### PR TITLE
[ENG-3715] - Add New Project Registrations Page Test

### DIFF
--- a/api/osf_api.py
+++ b/api/osf_api.py
@@ -403,12 +403,10 @@ def get_preprint_downloads_count(session=None, node_id=None):
         return None
 
 
-def get_registration_schemas_for_provider(
-    session=None, provider_id='osf', data_type='name'
-):
+def get_registration_schemas_for_provider(session=None, provider_id='osf'):
     """Returns a list of allowed registration schemas for an individual provider.  The
-    list will be either schema names or a paired list of schema names and ids.  The
-    default data type is 'name'.  The default provider_id is 'osf'.
+    list will be a paired list of schema names and ids.  The The default provider_id is
+    'osf'.
     """
     if not session:
         session = get_default_session()
@@ -417,18 +415,9 @@ def get_registration_schemas_for_provider(
     # total registration schemas. It's under 30 at this time, but using 50 here gives us
     # plenty of room to add more schemas without having to update this function.
     data = session.get(url, query_parameters={'page[size]': 50})['data']
-    if data:
-        schema_list = []
-        for schema in data:
-            name = schema['attributes']['name']
-            if data_type == 'name':
-                schema_list.append(name)
-            elif data_type == 'name_id':
-                schema_id = schema['id']
-                schema_list.append([name, schema_id])
-        return schema_list
-    else:
+    if data is None:
         return None
+    return [[schema['attributes']['name'], schema['id']] for schema in data]
 
 
 def create_draft_registration(session, node_id=None, schema_id=None):

--- a/api/osf_api.py
+++ b/api/osf_api.py
@@ -425,11 +425,6 @@ def create_draft_registration(session, node_id=None, schema_id=None):
     if not session:
         session = get_default_session()
     url = '/v2/nodes/{}/draft_registrations/'.format(node_id)
-    # NOTE: The OSF api documentation says to use:
-    # 'attributes': {'registration_supplement': {schema_id} }
-    # but that doesn't work. That produced an error message that indicated that the
-    # schema id was missing and required.  Passing the raw_body parameter below does
-    # provide the api with the schema id in a format that works.
     raw_payload = {
         'data': {
             'type': 'draft_registrations',

--- a/components/project.py
+++ b/components/project.py
@@ -25,3 +25,36 @@ class LogWidget(BaseElement):
 
     # Group Locators
     log_items = GroupLocator(By.CSS_SELECTOR, '#logFeed .db-activity-item')
+
+
+class CreateRegistrationModal(BaseElement):
+    modal_window = Locator(By.CSS_SELECTOR, '[data-test-new-registration-modal]')
+    cancel_button = Locator(
+        By.CSS_SELECTOR, 'button[data-test-new-registration-modal-cancel-button]'
+    )
+    create_draft_button = Locator(
+        By.CSS_SELECTOR, 'button[data-test-new-registration-modal-create-draft-button]'
+    )
+
+    # Group Locators
+    schema_list = GroupLocator(
+        By.CSS_SELECTOR, '[data-test-new-registration-modal-schema]'
+    )
+
+    def get_schema_names_list(self):
+        """Returns the schema names from the schema list"""
+        names_list = []
+        for schema in self.schema_list:
+            names_list.append(schema.text)
+        return names_list
+
+    def select_schema_radio_button(self, schema_name='Open-Ended Registration'):
+        """Selects the radio button corresponding to the given schema name"""
+        for schema in self.schema_list:
+            if schema.text == schema_name:
+                schema.find_element_by_css_selector('.ember-view').click()
+
+
+class ConfirmDeleteDraftRegistrationModal(BaseElement):
+    cancel_button = Locator(By.CSS_SELECTOR, 'button[data-test-cancel-delete]')
+    delete_button = Locator(By.CSS_SELECTOR, 'button[data-test-confirm-delete]')

--- a/components/project.py
+++ b/components/project.py
@@ -43,16 +43,14 @@ class CreateRegistrationModal(BaseElement):
 
     def get_schema_names_list(self):
         """Returns the schema names from the schema list"""
-        names_list = []
-        for schema in self.schema_list:
-            names_list.append(schema.text)
-        return names_list
+        return [schema.text for schema in self.schema_list]
 
     def select_schema_radio_button(self, schema_name='Open-Ended Registration'):
         """Selects the radio button corresponding to the given schema name"""
         for schema in self.schema_list:
             if schema.text == schema_name:
                 schema.find_element_by_css_selector('.ember-view').click()
+                break
 
 
 class ConfirmDeleteDraftRegistrationModal(BaseElement):

--- a/pages/project.py
+++ b/pages/project.py
@@ -14,6 +14,8 @@ from components.dashboard import (
     ProjectCreatedModal,
 )
 from components.project import (
+    ConfirmDeleteDraftRegistrationModal,
+    CreateRegistrationModal,
     FileWidget,
     LogWidget,
 )
@@ -136,3 +138,65 @@ class FilesPage(GuidBasePage):
 The class FileWidget in components/project.py is used for tests test_file_widget_loads
 and test_addon_files_load in test_project.py.
 In the future, we may want to put all files tests in one place."""
+
+
+class RegistrationsPage(GuidBasePage):
+    base_url = settings.OSF_HOME + '/{guid}/registrations/'
+
+    identity = Locator(By.CSS_SELECTOR, '[data-test-registrations-container]')
+    registrations_tab = Locator(By.CSS_SELECTOR, 'ul._TabList_ojvago > li')
+    draft_registrations_tab = Locator(By.CSS_SELECTOR, '[data-test-drafts-tab]')
+    registration_card = Locator(By.CSS_SELECTOR, '[data-test-node-card]')
+    draft_registration_card = Locator(
+        By.CSS_SELECTOR, '[data-test-draft-registration-card]'
+    )
+    no_registrations_message_1 = Locator(
+        By.CSS_SELECTOR,
+        'div._RegistrationsPane_ojvago > div > div > div > div > p:nth-child(1)',
+    )
+    no_registrations_message_2 = Locator(
+        By.CSS_SELECTOR,
+        'div._RegistrationsPane_ojvago > div > div > div > div > p:nth-child(2)',
+    )
+    no_registrations_message_3 = Locator(
+        By.CSS_SELECTOR,
+        'div._RegistrationsPane_ojvago > div > div > div > div > p:nth-child(3)',
+    )
+    no_draft_registrations_message_1 = Locator(
+        By.CSS_SELECTOR,
+        'div._RegistrationsPane_ojvago > div > div > div > p:nth-child(1)',
+    )
+    no_draft_registrations_message_2 = Locator(
+        By.CSS_SELECTOR,
+        'div._RegistrationsPane_ojvago > div > div > div > p:nth-child(2)',
+    )
+    no_draft_registrations_message_3 = Locator(
+        By.CSS_SELECTOR,
+        'div._RegistrationsPane_ojvago > div > div > div > p:nth-child(3)',
+    )
+    here_support_link = Locator(By.LINK_TEXT, 'here')
+    new_registration_button = Locator(
+        By.CSS_SELECTOR, '[data-test-new-registration-button]'
+    )
+    # The following are for the first Draft Registration Card on the page. If we ever
+    # deal with more than one draft registration card, then we should probably use
+    # group locators and indexing.
+    draft_registration_title = Locator(
+        By.CSS_SELECTOR, 'h4[data-test-draft-registration-card-title] > a'
+    )
+    draft_registration_schema_name = Locator(
+        By.CSS_SELECTOR, 'div[data-test-form-type] > dd'
+    )
+    draft_registration_provider = Locator(
+        By.CSS_SELECTOR, 'div[data-test-provider-name] > dd'
+    )
+    review_draft_button = Locator(By.CSS_SELECTOR, '[data-test-draft-card-review]')
+    edit_draft_button = Locator(By.CSS_SELECTOR, '[data-test-draft-card-edit]')
+    delete_draft_button = Locator(
+        By.CSS_SELECTOR, '[data-test-delete-button-secondary-destroy]'
+    )
+    # Components
+    create_registration_modal = ComponentLocator(CreateRegistrationModal)
+    delete_draft_registration_modal = ComponentLocator(
+        ConfirmDeleteDraftRegistrationModal
+    )

--- a/pages/registries.py
+++ b/pages/registries.py
@@ -83,6 +83,22 @@ class RegistrationAddNewPage(BaseRegistriesPage):
 
 
 class RegistrationDraftPage(BaseRegistriesPage):
+    # This is a very generic draft registration page since it is using the side nav
+    # bar as the locator which is on every draft page.
     identity = Locator(
         By.CSS_SELECTOR, 'nav[data-test-side-nav]', settings.LONG_TIMEOUT
+    )
+
+
+class DraftRegistrationMetadataPage(BaseRegistriesPage):
+    identity = Locator(
+        By.CSS_SELECTOR, 'div[data-test-metadata-title]', settings.LONG_TIMEOUT
+    )
+
+
+class DraftRegistrationReviewPage(BaseRegistriesPage):
+    identity = Locator(
+        By.CSS_SELECTOR,
+        '[data-test-toggle-anchor-nav-button]',
+        settings.LONG_TIMEOUT,
     )

--- a/tests/test_project_registrations.py
+++ b/tests/test_project_registrations.py
@@ -23,7 +23,7 @@ def registrations_page(driver, default_project):
 
 @pytest.fixture()
 def registrations_page_with_draft(session, registrations_page):
-    """This fixture uses the registration_page fixture above and adds a draft
+    """This fixture uses the registrations_page fixture above and adds a draft
     registration to the temporary project.  NOTE: Since we are creating the draft
     registration from a temporary project that gets automatically deleted when we are
     done with it, the draft registration as a child of the project will also get
@@ -55,7 +55,7 @@ class TestProjectRegistrationsPage:
     def test_empty_registrations_tab(self, driver, registrations_page):
         """Tests that when the Project Registration page is first loaded, the submitted
         Registrations tab is selected and displayed by default. Also since this is a
-        newly createdd project there should not be any existing submitted registrations.
+        newly created project there should not be any existing submitted registrations.
         """
         assert (
             registrations_page.registrations_tab.get_attribute('aria-selected')
@@ -85,7 +85,7 @@ class TestProjectRegistrationsPage:
     def test_empty_draft_registrations_tab(self, driver, registrations_page):
         """Tests that when the Project Registration page is first loaded, you can switch
         to the Draft Registrations tab by clicking the tab link.  And since this is a
-        newly createdd project there should not be any existing draft registrations.
+        newly created project there should not be any existing draft registrations.
         """
         registrations_page.draft_registrations_tab.click()
         assert (
@@ -182,7 +182,7 @@ class TestProjectRegistrationsPage:
     def test_review_draft_registration(
         self, session, driver, registrations_page_with_draft
     ):
-        """Using the registration_page_with_draft fixture that already has a draft
+        """Using the registrations_page_with_draft fixture that already has a draft
         registration created for the temporary project, verify that the draft
         registration is visble on the Draft registrations tab of the Project
         Registrations page.  Then click the Review button and verify that you are
@@ -207,7 +207,7 @@ class TestProjectRegistrationsPage:
     def test_edit_draft_registration(
         self, session, driver, registrations_page_with_draft
     ):
-        """Using the registration_page_with_draft fixture that already has a draft
+        """Using the registrations_page_with_draft fixture that already has a draft
         registration created for the temporary project, verify that the draft
         registration is visble on the Draft registrations tab of the Project
         Registrations page.  Then click the Edit button and verify that you are
@@ -224,7 +224,7 @@ class TestProjectRegistrationsPage:
     def test_delete_draft_registration(
         self, session, driver, registrations_page_with_draft
     ):
-        """Using the registration_page_with_draft fixture that already has a draft
+        """Using the registrations_page_with_draft fixture that already has a draft
         registration created for the temporary project, verify that the draft
         registration is visble on the Draft registrations tab of the Project
         Registrations page.  Then verify that you can delete the draft registration

--- a/tests/test_project_registrations.py
+++ b/tests/test_project_registrations.py
@@ -1,0 +1,248 @@
+import pytest
+from selenium.webdriver.common.action_chains import ActionChains
+
+import markers
+from api import osf_api
+from pages.project import RegistrationsPage
+from pages.registries import (
+    DraftRegistrationMetadataPage,
+    DraftRegistrationReviewPage,
+)
+from pages.support import SupportPage
+
+
+@pytest.fixture()
+def registrations_page(driver, default_project):
+    """Fixture that uses a temporary project created in the testing environments and
+    then navigates to the Registrations page for that project.
+    """
+    registrations_page = RegistrationsPage(driver, guid=default_project.id)
+    registrations_page.goto()
+    return registrations_page
+
+
+@pytest.fixture()
+def registrations_page_with_draft(session, registrations_page):
+    """This fixture uses the registration_page fixture above and adds a draft
+    registration to the temporary project.  NOTE: Since we are creating the draft
+    registration from a temporary project that gets automatically deleted when we are
+    done with it, the draft registration as a child of the project will also get
+    deleted.
+    """
+
+    # First get the list of allowed registration schemas for OSF in a name and id pair
+    # list. Then loop through the list to pull out just the id for the Open-Ended
+    # Registration schema. We'll need this schema id to create the draft.
+    schema_list = osf_api.get_registration_schemas_for_provider(
+        provider_id='osf', data_type='name_id'
+    )
+    for schema in schema_list:
+        if schema[0] == 'Open-Ended Registration':
+            schema_id = schema[1]
+    # Use the api to create a draft registration for the temporary project
+    osf_api.create_draft_registration(
+        session, node_id=registrations_page.guid, schema_id=schema_id
+    )
+    # Reload the page so that the draft is visible on the tab
+    registrations_page.reload()
+    registrations_page.draft_registrations_tab.click()
+    return registrations_page
+
+
+@markers.dont_run_on_prod
+@pytest.mark.usefixtures('must_be_logged_in')
+class TestProjectRegistrationsPage:
+    def test_empty_registrations_tab(self, driver, registrations_page):
+        """Tests that when the Project Registration page is first loaded, the submitted
+        Registrations tab is selected and displayed by default. Also since this is a
+        newly createdd project there should not be any existing submitted registrations.
+        """
+        assert (
+            registrations_page.registrations_tab.get_attribute('aria-selected')
+            == 'true'
+        )
+        assert (
+            registrations_page.draft_registrations_tab.get_attribute('aria-selected')
+            == 'false'
+        )
+        assert registrations_page.registration_card.absent()
+        assert (
+            registrations_page.no_registrations_message_1.text
+            == 'There have been no completed registrations of this project.'
+        )
+        assert (
+            registrations_page.no_registrations_message_2.text
+            == 'Start a new registration by clicking the “New registration” button. Once created, registrations cannot be edited or deleted.'
+        )
+        assert (
+            registrations_page.no_registrations_message_3.text
+            == 'Learn more about registrations here.'
+        )
+        # Click 'here' link and verify redirection to support page
+        registrations_page.here_support_link.click()
+        assert SupportPage(driver, verify=True)
+
+    def test_empty_draft_registrations_tab(self, driver, registrations_page):
+        """Tests that when the Project Registration page is first loaded, you can switch
+        to the Draft Registrations tab by clicking the tab link.  And since this is a
+        newly createdd project there should not be any existing draft registrations.
+        """
+        registrations_page.draft_registrations_tab.click()
+        assert (
+            registrations_page.registrations_tab.get_attribute('aria-selected')
+            == 'false'
+        )
+        assert (
+            registrations_page.draft_registrations_tab.get_attribute('aria-selected')
+            == 'true'
+        )
+        assert registrations_page.draft_registration_card.absent()
+        assert (
+            registrations_page.no_draft_registrations_message_1.text
+            == 'There are no draft registrations of this project.'
+        )
+        assert (
+            registrations_page.no_draft_registrations_message_2.text
+            == 'Start a new registration by clicking the “New registration” button. Once created, registrations cannot be edited or deleted.'
+        )
+        assert (
+            registrations_page.no_draft_registrations_message_3.text
+            == 'Learn more about registrations here.'
+        )
+        # Click 'here' link and verify redirection to support page
+        registrations_page.here_support_link.click()
+        assert SupportPage(driver, verify=True)
+
+    def test_create_new_registration_modal(self, driver, registrations_page):
+        """Tests the Create Registration Modal window that opens when you click the
+        New registration button on the Project Registrations page.
+        """
+        registrations_page.new_registration_button.click()
+        create_registration_modal = registrations_page.create_registration_modal
+        assert create_registration_modal.modal_window.present()
+        # Verify that the first schema in the list is pre-selected
+        first_schema = create_registration_modal.schema_list[0]
+        assert first_schema.find_element_by_css_selector('.ember-view').is_selected()
+        # Get list of allowed schemas for OSF Registries from the api and verify the
+        # list on the modal matches the api list
+        api_schema_list = osf_api.get_registration_schemas_for_provider(
+            provider_id='osf', data_type='name'
+        )
+        api_schema_list.sort()
+        modal_schema_list = create_registration_modal.get_schema_names_list()
+        modal_schema_list.sort()
+        assert api_schema_list == modal_schema_list
+        # Click the Cancel button to close the modal window
+        try:
+            create_registration_modal.cancel_button.click()
+        except ValueError:
+            # In some environments there may be several schemas listed on the modal
+            # which may push the Cancel button below the visible part of the screen
+            # depending on the screen resolution. Currently this modal window does
+            # not have the ability to vertically scroll, so the scroll_into_view
+            # method will not work. There is an open ticket for the scrolling issue:
+            # ENG-3740.
+            cancel_button = driver.find_element_by_css_selector(
+                'button[data-test-new-registration-modal-cancel-button]'
+            )
+            ActionChains(driver).move_to_element(cancel_button).perform()
+            cancel_button.click()
+        # Verify the modal window has closed
+        assert create_registration_modal.modal_window.absent()
+
+    def test_create_new_draft_registration(self, driver, registrations_page):
+        """Tests the creation of a new draft registration from the Project Registrations
+        page by clicking the New regsitration button on the page.  Then on the Create
+        Registration modal window, select a schema and click the Create draft button to
+        actually create the draft registration.
+        """
+        registrations_page.new_registration_button.click()
+        create_registration_modal = registrations_page.create_registration_modal
+        assert create_registration_modal.modal_window.present()
+        create_registration_modal.select_schema_radio_button(
+            schema_name='Open-Ended Registration'
+        )
+        try:
+            create_registration_modal.create_draft_button.click()
+        except ValueError:
+            # In some environments there may be several schemas listed on the modal
+            # which may push the Create draft button below the visible part of the
+            # screen depending on the screen resolution. Currently this modal window
+            # does not have the ability to vertically scroll, so the scroll_into_view
+            # method will not work. There is an open ticket for the scrolling issue:
+            # ENG-3740.
+            create_draft_button = driver.find_element_by_css_selector(
+                'button[data-test-new-registration-modal-create-draft-button]'
+            )
+            ActionChains(driver).move_to_element(create_draft_button).perform()
+            create_draft_button.click()
+        # Verify that you are redirected to the Draft Registration Metadata page
+        DraftRegistrationMetadataPage(driver, verify=True)
+
+    def test_review_draft_registration(
+        self, session, driver, registrations_page_with_draft
+    ):
+        """Using the registration_page_with_draft fixture that already has a draft
+        registration created for the temporary project, verify that the draft
+        registration is visble on the Draft registrations tab of the Project
+        Registrations page.  Then click the Review button and verify that you are
+        redirected to the Draft Registration Review page.
+        """
+        assert registrations_page_with_draft.draft_registration_card.present()
+        assert (
+            registrations_page_with_draft.draft_registration_title.text
+            == 'OSF Test Project'
+        )
+        assert (
+            registrations_page_with_draft.draft_registration_schema_name.text
+            == 'Open-Ended Registration'
+        )
+        assert (
+            registrations_page_with_draft.draft_registration_provider.text
+            == 'OSF Registries'
+        )
+        registrations_page_with_draft.review_draft_button.click()
+        assert DraftRegistrationReviewPage(driver, verify=True)
+
+    def test_edit_draft_registration(
+        self, session, driver, registrations_page_with_draft
+    ):
+        """Using the registration_page_with_draft fixture that already has a draft
+        registration created for the temporary project, verify that the draft
+        registration is visble on the Draft registrations tab of the Project
+        Registrations page.  Then click the Edit button and verify that you are
+        redirected to the Draft Registration Metadata page.
+        """
+        assert registrations_page_with_draft.draft_registration_card.present()
+        assert (
+            registrations_page_with_draft.draft_registration_title.text
+            == 'OSF Test Project'
+        )
+        registrations_page_with_draft.edit_draft_button.click()
+        DraftRegistrationMetadataPage(driver, verify=True)
+
+    def test_delete_draft_registration(
+        self, session, driver, registrations_page_with_draft
+    ):
+        """Using the registration_page_with_draft fixture that already has a draft
+        registration created for the temporary project, verify that the draft
+        registration is visble on the Draft registrations tab of the Project
+        Registrations page.  Then verify that you can delete the draft registration
+        using the Delete button on the page.
+        """
+        assert registrations_page_with_draft.draft_registration_card.present()
+        assert (
+            registrations_page_with_draft.draft_registration_title.text
+            == 'OSF Test Project'
+        )
+        # Click the Delete button for the Draft Registration card and then click the
+        # Delete button on the Comfirm Delete Draft Registration Modal
+        registrations_page_with_draft.delete_draft_button.click()
+        registrations_page_with_draft.delete_draft_registration_modal.delete_button.click()
+        # Verify that the Draft Registration is no longer visible on the Draft
+        # Registrations tab.
+        assert registrations_page_with_draft.draft_registration_card.absent()
+        assert (
+            registrations_page_with_draft.no_draft_registrations_message_1.text
+            == 'There are no draft registrations of this project.'
+        )

--- a/tests/test_project_registrations.py
+++ b/tests/test_project_registrations.py
@@ -150,7 +150,7 @@ class TestProjectRegistrationsPage:
 
     def test_create_new_draft_registration(self, driver, registrations_page):
         """Tests the creation of a new draft registration from the Project Registrations
-        page by clicking the New regsitration button on the page.  Then on the Create
+        page by clicking the New registration button on the page.  Then on the Create
         Registration modal window, select a schema and click the Create draft button to
         actually create the draft registration.
         """
@@ -182,7 +182,7 @@ class TestProjectRegistrationsPage:
     ):
         """Using the registrations_page_with_draft fixture that already has a draft
         registration created for the temporary project, verify that the draft
-        registration is visble on the Draft registrations tab of the Project
+        registration is visible on the Draft registrations tab of the Project
         Registrations page.  Then click the Review button and verify that you are
         redirected to the Draft Registration Review page.
         """
@@ -207,7 +207,7 @@ class TestProjectRegistrationsPage:
     ):
         """Using the registrations_page_with_draft fixture that already has a draft
         registration created for the temporary project, verify that the draft
-        registration is visble on the Draft registrations tab of the Project
+        registration is visible on the Draft registrations tab of the Project
         Registrations page.  Then click the Edit button and verify that you are
         redirected to the Draft Registration Metadata page.
         """
@@ -224,7 +224,7 @@ class TestProjectRegistrationsPage:
     ):
         """Using the registrations_page_with_draft fixture that already has a draft
         registration created for the temporary project, verify that the draft
-        registration is visble on the Draft registrations tab of the Project
+        registration is visible on the Draft registrations tab of the Project
         Registrations page.  Then verify that you can delete the draft registration
         using the Delete button on the page.
         """
@@ -234,13 +234,13 @@ class TestProjectRegistrationsPage:
             == 'OSF Test Project'
         )
         # Click the Delete button for the Draft Registration card and then click the
-        # Cancel button on the Comfirm Delete Draft Registration Modal and verify the
+        # Cancel button on the Confirm Delete Draft Registration Modal and verify the
         # Draft Registration card is still present.
         registrations_page_with_draft.delete_draft_button.click()
         registrations_page_with_draft.delete_draft_registration_modal.cancel_button.click()
         assert registrations_page_with_draft.draft_registration_card.present()
         # Now click the Delete button for the Draft Registration card again and this
-        # time click the Delete button on the Comfirm Delete Draft Registration Modal.
+        # time click the Delete button on the Confirm Delete Draft Registration Modal.
         # Then verify that the Draft Registration is no longer visible on the Draft
         # Registrations tab.
         registrations_page_with_draft.delete_draft_button.click()


### PR DESCRIPTION
<!-- Before you submit your Pull Request, please confirm that:

     - Any test that will create public data either has the `QAtest` tag or the `dont_run_on_production` marker
     - `core_functionality` is marked as such
     - Your tests will be able to run on *all* servers (all stagings, test)
 -->


## Purpose
To expand the Selenium testing suite by adding a new test for the Project Registrations page.


## Summary of Changes

- api/osf_api.py - add 2 new functions: get_registration_schemas_for_provider and create_draft_registration
- components/project.py - add definitions for 2 new modal windows opened from the Project Registrations page: CreateRegistrationModal and ConfirmDeleteDraftRegistrationModal
- pages/project.py - add new page class definition: RegistrationsPage
- pages/registries.py - add 2 new more specific Draft Registration page definitions: DraftRegistrationMetadataPage and DraftRegistrationReviewPage
- tests/test_project_registrations.py - new test file with 7 new test steps to regression test the various parts of the Project Registrations page.


## Reviewer's Actions
`git fetch <remote> pull/199/head:newTest/project-registrations`

Run this test using
`tests/test_project_registrations.py -s -v`

## Testing Changes Moving Forward
N/A


## Ticket
ENG-3715: SEL: New Test - Project Registrations Page
https://openscience.atlassian.net/browse/ENG-3715
