### PR TITLE
[ENG-3779] - Add tests for Edit Preprint and Withdraw Preprint

### DIFF
--- a/api/osf_api.py
+++ b/api/osf_api.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import os
+from datetime import datetime
 
 import requests
 from pythosf import client
@@ -461,24 +462,36 @@ def create_preprint(
     """
     if not session:
         session = get_default_session()
-    # Get the License Id for the license_name parameter
-    license_id = get_license_id(session, license_name=license_name)
-    # Get Subject Id for the subject_name parameter. NOTE: Currently we are creating
+    # Get the license id and any required fields for the license_name parameter
+    license_data = get_license_data_for_provider(
+        session,
+        provider_type='preprints',
+        provider_id=provider_id,
+        license_name=license_name,
+    )
+    license_id = license_data[0]
+    # If the particular license requires copyright holders then provide some test data
+    if 'copyrightHolders' in license_data[1]:
+        copyright_holders = ['OSF Selenium Tester', 'QA Guy']
+    else:
+        copyright_holders = []
+    # NOTE: In the preprint payload record below we are adding a license_record with
+    # year set to the current year even though in most cases we may be using a license
+    # that does not require the year value. There is a weird bug that occurs on the Edit
+    # Preprint page if the preprint does not have a value for year. If the year is null
+    # then the Edit Preprint page thinks that the preprint has unsaved changes even if
+    # you have made no changes on the form page. There is a ticket for this issue:
+    # ENG-3782.
+    current_year = datetime.now().year
+    # Get subject id for the subject_name parameter. NOTE: Currently we are creating
     # the preprint with only a single subject, which is the minimum required to publish.
-    subject_id = get_subject_for_provider(
+    subject_id = get_subject_id_for_provider(
         session,
         provider_type='preprints',
         provider_id=provider_id,
         subject_name=subject_name,
     )
     # Step 1: Create draft unpublished preprint without primary file
-    # NOTE: In the preprint payload record below we are adding a license_record
-    # with year set to 2022 even though in most cases we may be using a license
-    # that does not require the year value. There is a weird bug that occurs on
-    # the Edit Preprint page if the preprint does not have a value for year. If
-    # the year is null then the Edit Preprint page thinks that the preprint has
-    # unsaved changes even if you have made no changes on the form page. There
-    # is a ticket for this issue: ENG-3782.
     url = '/v2/preprints/'
     raw_payload = {
         'data': {
@@ -487,7 +500,10 @@ def create_preprint(
                 'title': title,
                 'description': 'Preprint created via the OSF api',
                 'subjects': [[subject_id]],
-                'license_record': {'year': '2022'},
+                'license_record': {
+                    'copyright_holders': copyright_holders,
+                    'year': current_year,
+                },
                 'tags': ['qatest', 'selenium'],
                 'has_coi': False,
                 'has_data_links': 'available',
@@ -504,25 +520,21 @@ def create_preprint(
     return_data = session.post(
         url=url, item_type='preprints', raw_body=json.dumps(raw_payload)
     )
-    preprint_node = return_data['data']['id']
+    preprint_node_id = return_data['data']['id']
     # Step 2: Create a test file in WaterButler and associate it with the preprint
-    wb_upload_url = '{}/v1/resources/{}/providers/{}/'.format(
-        settings.FILE_DOMAIN, preprint_node, 'osfstorage'
-    )
-    metadata = session.put(
-        url=wb_upload_url,
-        query_parameters={'kind': 'file', 'name': 'OSF Test File.txt'},
-        raw_body={},
+    preprint_node = get_node(session, node_id=preprint_node_id)
+    file_name, metadata = upload_fake_file(
+        session, node=preprint_node, name='OSF Test File.txt', provider='osfstorage'
     )
     # The id value from WB has the provider name and '/' at the beginning of it
     # (ex: 'osfstorage/627a5b3ab4f587000aa2725c').  So we need to parse out the
     # actual file id to use in the Preprint patch.
     file_id = metadata['data']['id'].split('/')[1]
     # Step 3: Attach the file to the Preprint and set it as Published
-    patch_url = '/v2/preprints/{}/'.format(preprint_node)
+    patch_url = '/v2/preprints/{}/'.format(preprint_node_id)
     patch_payload = {
         'data': {
-            'id': preprint_node,
+            'id': preprint_node_id,
             'type': 'preprints',
             'attributes': {
                 'is_published': True,
@@ -535,20 +547,28 @@ def create_preprint(
     return_data = session.patch(
         url=patch_url,
         item_type='preprints',
-        item_id=preprint_node,
+        item_id=preprint_node_id,
         raw_body=json.dumps(patch_payload),
     )
     # Return the Preprint Node Id
     return return_data['data']['id']
 
 
-def get_license_id(session=None, license_name='CC0 1.0 Universal'):
-    """Returns the license id for the given license name.  The default license_name is
+def get_license_data_for_provider(
+    session=None,
+    provider_type='preprints',
+    provider_id='osf',
+    license_name='CC0 1.0 Universal',
+):
+    """Returns the license id and any required fields for a given provider type, provider
+    id, and license name. Required fields may be 'year' and 'copyrightHolders' for some
+    licenses. The default provider_type is 'preprints' but this will also work for
+    'registrations'. The default provider_id is 'osf' and the default license_name is
     'CC0 1.0 Universal'.
     """
     if not session:
         session = get_default_session()
-    url = 'v2/licenses/'
+    url = 'v2/providers/{}/{}/licenses/'.format(provider_type, provider_id)
     # NOTE: Using '30' as the page size query parameter here. We don't actually have 30
     # total licenses. It's under 20 at this time, but using 30 here gives us plenty of
     # room to add more licenses without having to update this function.
@@ -556,11 +576,12 @@ def get_license_id(session=None, license_name='CC0 1.0 Universal'):
     for license in data:
         if license['attributes']['name'] == license_name:
             license_id = license['id']
+            required_fields = license['attributes']['required_fields']
             break
-    return license_id
+    return [license_id, required_fields]
 
 
-def get_subject_for_provider(
+def get_subject_id_for_provider(
     session=None,
     provider_type='preprints',
     provider_id='osf',

--- a/pages/preprints.py
+++ b/pages/preprints.py
@@ -158,6 +158,71 @@ class PreprintSubmitPage(BasePreprintPage):
     )
 
 
+class PreprintEditPage(GuidBasePage, BasePreprintPage):
+    url_base = urljoin(settings.OSF_HOME, '{guid}')
+    url_addition = '/edit'
+
+    identity = Locator(
+        By.CSS_SELECTOR, '.m-t-md.preprint-header-preview > p:nth-child(1) > em.m-r-md'
+    )
+    basics_section = Locator(By.ID, 'preprint-form-basics')
+    basics_tags_section = Locator(By.CSS_SELECTOR, '#preprint-form-basics .tagsinput')
+    basics_tags_input = Locator(
+        By.CSS_SELECTOR, '#preprint-form-basics .tagsinput input'
+    )
+    basics_save_button = Locator(By.CSS_SELECTOR, '#preprint-form-basics .btn-primary')
+    basics_section_changes_saved_indicator = Locator(
+        By.CSS_SELECTOR,
+        '#preprint-form-basics > header > div.preprint-section-status.pull-right > span.text-success.',
+    )
+    discipline_section = Locator(By.ID, 'preprint-form-subjects')
+    discipline_save_button = Locator(
+        By.CSS_SELECTOR, '#preprint-form-subjects .btn-primary'
+    )
+    authors_save_button = Locator(
+        By.CSS_SELECTOR, '#preprint-form-authors .btn-primary', settings.QUICK_TIMEOUT
+    )
+    return_to_preprint_button = Locator(
+        By.CSS_SELECTOR,
+        'div.submit-section > div > button.btn.btn-default.btn-md.m-t-md.pull-right',
+    )
+    withdraw_preprint_button = Locator(
+        By.CSS_SELECTOR,
+        'div.submit-section > div > button.btn.btn-danger.btn-md.m-t-md.pull-right',
+    )
+
+    # Group Locators
+    primary_subjects = GroupLocator(
+        By.CSS_SELECTOR,
+        '#preprint-form-subjects > div > div > div:nth-child(2) > div:nth-child(1) > ul > li',
+    )
+
+    def select_primary_subject_by_name(self, subject_name):
+        """Select a subject from the first box in the Discipline section (i.e. 'primary'
+        subject). This function would need to be modified or another separate function
+        created to select from either of the 2 secondary subject boxes.
+        """
+        for subject in self.primary_subjects:
+            if subject.text == subject_name:
+                subject.click()
+                break
+
+
+class PreprintWithdrawPage(GuidBasePage, BasePreprintPage):
+    url_base = urljoin(settings.OSF_HOME, '{guid}')
+    url_addition = '/withdraw'
+
+    identity = Locator(
+        By.CSS_SELECTOR,
+        'section.preprint-form-block.preprint-form-section-withdraw-comment',
+    )
+    reason_for_withdrawal_textarea = Locator(By.NAME, 'explanation')
+    request_withdrawal_button = Locator(
+        By.CSS_SELECTOR,
+        'div.submit-section > button.btn.btn-danger.btn-md.m-t-md.pull-right',
+    )
+
+
 @pytest.mark.usefixtures('must_be_logged_in')
 class PreprintDiscoverPage(BasePreprintPage):
     url_addition = 'discover'
@@ -187,6 +252,14 @@ class PreprintDetailPage(GuidBasePage, BasePreprintPage):
     download_button = Locator(
         By.CSS_SELECTOR, 'div.share-row.p-sm.osf-box-lt.clearfix > a'
     )
+    edit_preprint_button = Locator(By.LINK_TEXT, 'Edit preprint')
+
+    # Group Locators
+    subjects = GroupLocator(
+        By.CSS_SELECTOR,
+        '#view-page > div.container > div > div.col-md-5 > div:nth-child(6) > span',
+    )
+    tags = GroupLocator(By.CSS_SELECTOR, 'div.tag-section.p-t-xs > span')
 
 
 class ReviewsDashboardPage(OSFBasePage):


### PR DESCRIPTION
<!-- Before you submit your Pull Request, please confirm that:

     - Any test that will create public data either has the `QAtest` tag or the `dont_run_on_production` marker
     - `core_functionality` is marked as such
     - Your tests will be able to run on *all* servers (all stagings, test)
 -->


## Purpose
To expand the existing Preprints test to include more scenarios such as Editing a Preprint and Withdrawing a Preprint.


## Summary of Changes

- api/osf_api.py - adding 4 new api functions: create_preprint, get_license_id, get_subject_for_provider, and get_preprint_requests_records
- pages/preprints.py - adding 2 new page classes: PreprintEditPage and PreprintWithdrawPage; and adding new element locator definitions to PreprintDetailPage.
- tests/test_preprints.py - adding new fixture: preprint_detail_page; and 2 new test steps: test_edit_preprint and test_withdraw_preprint.


## Reviewer's Actions
`git fetch <remote> pull/200/head:feature/edit_withdraw_preprints`

Run this test using
`tests/test_preprints.py -s -v`

## Testing Changes Moving Forward
N/A


## Ticket
ENG-3779: SEL: Preprints Test - Add tests for Edit Preprint and Withdraw Preprint
https://openscience.atlassian.net/browse/ENG-3779
