### PR TITLE
[ENG-3802] - PROD Test Failure - Fix Institution Login test for UND

### DIFF
--- a/tests/test_login.py
+++ b/tests/test_login.py
@@ -1,5 +1,6 @@
 import pytest
 import requests
+from selenium.common.exceptions import NoSuchElementException
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.support.select import Select
@@ -418,14 +419,24 @@ class TestInstitutionLoginPage:
                     # password input field
                     assert GenericInstitutionLoginPage(driver, verify=True)
                 except PageException:
-                    try:
-                        # For a small number of institutions the initial login page
-                        # first asks for just an email without the passord field.
-                        assert GenericInstitutionEmailLoginPage(driver, verify=True)
-                    except PageException:
-                        # if there is a failure add the name of the institution to the
-                        # failed list
-                        failed_list.append(institution)
+                    # University of Notre Dame changed their login - now there is a Username
+                    # input box that is of type="text".
+                    if institution == 'University of Notre Dame':
+                        try:
+                            driver.find_element(
+                                By.CSS_SELECTOR, 'div.o-form-input > span > input'
+                            )
+                        except NoSuchElementException:
+                            failed_list.append(institution)
+                    else:
+                        try:
+                            # For a small number of institutions the initial login page
+                            # first asks for just an email without the passord field.
+                            assert GenericInstitutionEmailLoginPage(driver, verify=True)
+                        except PageException:
+                            # if there is a failure add the name of the institution to the
+                            # failed list
+                            failed_list.append(institution)
                 # Need to go back to the original OSF Institution Login page
                 institution_login_page.goto()
         # If there are any failed institutions then fail the test and print the list


### PR DESCRIPTION
<!-- Before you submit your Pull Request, please confirm that:

     - Any test that will create public data either has the `QAtest` tag or the `dont_run_on_production` marker
     - `core_functionality` is marked as such
     - Your tests will be able to run on *all* servers (all stagings, test)
 -->


## Purpose
To fix a test failure in the nightly Production Smoke Test run in tests/test_login.py::TestInstitutionLoginPage::test_individual_institution_login_pages


## Summary of Changes

- tests/test_login.py - add a specific check for the University of Notre Dame since they changed their login page to be just an input box for Username that is type="text".  The existing generic page definitions for institution login pages look for either a password input box (type="password") or an email input box (type="email").


## Reviewer's Actions
`git fetch <remote> pull/201/head:testFix/login-institution-und`

Run this test using
`tests/test_login.py -s -v -m smoke_test` **NOTE: TestInstitutionLoginPage::test_individual_institution_login_pages only runs in Production**

## Testing Changes Moving Forward
N/A


## Ticket
ENG-3802: SEL: Login Test - Individual Institution Login Pages Test - Prod Failure for U of Notre Dame
https://openscience.atlassian.net/browse/ENG-3802
