### PR TITLE
[ENG-3818] - Restore Institutions Login test

### DIFF
--- a/tests/test_login.py
+++ b/tests/test_login.py
@@ -1,7 +1,6 @@
 import pytest
 import requests
-
-# from selenium.common.exceptions import NoSuchElementException
+from selenium.common.exceptions import NoSuchElementException
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.support.select import Select
@@ -9,13 +8,14 @@ from selenium.webdriver.support.wait import WebDriverWait
 
 import markers
 import settings
-
-# from base.exceptions import PageException
+from base.exceptions import PageException
 from pages.landing import LandingPage
-from pages.login import (  # GenericInstitutionEmailLoginPage,; GenericInstitutionLoginPage,
+from pages.login import (
     CASAuthorizationPage,
     ForgotPasswordPage,
     GenericCASPage,
+    GenericInstitutionEmailLoginPage,
+    GenericInstitutionLoginPage,
     InstitutionalLoginPage,
     Login2FAPage,
     LoginPage,
@@ -385,67 +385,64 @@ class TestInstitutionLoginPage:
         institution_login_page.status_footer_link.click()
         assert driver.current_url == 'https://status.cos.io/'
 
-    # DC - Commenting out the Institutions Login test temporarily. As of 5/25/2022 a new
-    # institution was added - 'Erasmus University Rotterdam' - that is not actually ready
-    # so the test fails for this institution.
-    # @pytest.fixture()
-    # def institution_list(self, driver, institution_login_page):
-    #     """Get the list of institutions from the listbox on the Institution Login page
-    #     and store them in a list object to be used in the test below.
-    #     """
-    #     institution_select = Select(institution_login_page.institution_dropdown)
-    #     institution_list = []
-    #     for option in institution_select.options:
-    #         institution_list.append(option.text)
-    #     return institution_list
+    @pytest.fixture()
+    def institution_list(self, driver, institution_login_page):
+        """Get the list of institutions from the listbox on the Institution Login page
+        and store them in a list object to be used in the test below.
+        """
+        institution_select = Select(institution_login_page.institution_dropdown)
+        institution_list = []
+        for option in institution_select.options:
+            institution_list.append(option.text)
+        return institution_list
 
-    # @pytest.mark.skipif(
-    #     not settings.PRODUCTION,
-    #     reason='Most Institution Logins only work in Production',
-    # )
-    # def test_individual_institution_login_pages(
-    #     self, driver, institution_login_page, institution_list
-    # ):
-    #     """Tests that when we select an institution from the listbox and click the Sign
-    #     In button that we actually get navigated to a valid institution login page. This
-    #     test will only be run in the Production environment since most institutions do
-    #     not have working testing environments.
-    #     """
-    #     failed_list = []
-    #     for institution in institution_list:
-    #         if institution != '-- select an institution --':
-    #             institution_select = Select(institution_login_page.institution_dropdown)
-    #             institution_select.select_by_visible_text(institution)
-    #             institution_login_page.sign_in_button.click()
-    #             try:
-    #                 # Verify that we get to a valid login page by checking for a
-    #                 # password input field
-    #                 assert GenericInstitutionLoginPage(driver, verify=True)
-    #             except PageException:
-    #                 # University of Notre Dame changed their login - now there is a Username
-    #                 # input box that is of type="text".
-    #                 if institution == 'University of Notre Dame':
-    #                     try:
-    #                         driver.find_element(
-    #                             By.CSS_SELECTOR, 'div.o-form-input > span > input'
-    #                         )
-    #                     except NoSuchElementException:
-    #                         failed_list.append(institution)
-    #                 else:
-    #                     try:
-    #                         # For a small number of institutions the initial login page
-    #                         # first asks for just an email without the passord field.
-    #                         assert GenericInstitutionEmailLoginPage(driver, verify=True)
-    #                     except PageException:
-    #                         # if there is a failure add the name of the institution to the
-    #                         # failed list
-    #                         failed_list.append(institution)
-    #             # Need to go back to the original OSF Institution Login page
-    #             institution_login_page.goto()
-    #     # If there are any failed institutions then fail the test and print the list
-    #     assert len(failed_list) == 0, 'The following Institutions Failed: ' + str(
-    #         failed_list
-    #     )
+    @pytest.mark.skipif(
+        not settings.PRODUCTION,
+        reason='Most Institution Logins only work in Production',
+    )
+    def test_individual_institution_login_pages(
+        self, driver, institution_login_page, institution_list
+    ):
+        """Tests that when we select an institution from the listbox and click the Sign
+        In button that we actually get navigated to a valid institution login page. This
+        test will only be run in the Production environment since most institutions do
+        not have working testing environments.
+        """
+        failed_list = []
+        for institution in institution_list:
+            if institution != '-- select an institution --':
+                institution_select = Select(institution_login_page.institution_dropdown)
+                institution_select.select_by_visible_text(institution)
+                institution_login_page.sign_in_button.click()
+                try:
+                    # Verify that we get to a valid login page by checking for a
+                    # password input field
+                    assert GenericInstitutionLoginPage(driver, verify=True)
+                except PageException:
+                    # University of Notre Dame changed their login - now there is a Username
+                    # input box that is of type="text".
+                    if institution == 'University of Notre Dame':
+                        try:
+                            driver.find_element(
+                                By.CSS_SELECTOR, 'div.o-form-input > span > input'
+                            )
+                        except NoSuchElementException:
+                            failed_list.append(institution)
+                    else:
+                        try:
+                            # For a small number of institutions the initial login page
+                            # first asks for just an email without the passord field.
+                            assert GenericInstitutionEmailLoginPage(driver, verify=True)
+                        except PageException:
+                            # if there is a failure add the name of the institution to the
+                            # failed list
+                            failed_list.append(institution)
+                # Need to go back to the original OSF Institution Login page
+                institution_login_page.goto()
+        # If there are any failed institutions then fail the test and print the list
+        assert len(failed_list) == 0, 'The following Institutions Failed: ' + str(
+            failed_list
+        )
 
 
 @markers.dont_run_on_prod


### PR DESCRIPTION
<!-- Before you submit your Pull Request, please confirm that:

     - Any test that will create public data either has the `QAtest` tag or the `dont_run_on_production` marker
     - `core_functionality` is marked as such
     - Your tests will be able to run on *all* servers (all stagings, test)
 -->


## Purpose
To reverse the previously commented out Institutions Login test that had been failing in Production due to a new institution that was not ready. The new institution that caused the failure now has a valid login page.


## Summary of Changes

- tests/test_login.py - reversing the previously commented out "test_individual_institution_login_pages" and all of its associated code


## Reviewer's Actions
`git fetch <remote> pull/<PR_number>/head:testFix/login-institution-disable`

Run this test using
`tests/test_login.py -m smoke_test -s -v`

## Testing Changes Moving Forward
Hopefully nothing. I don't want to have to comment this test out again.


## Ticket
ENG-3818: SEL: Login Test - Individual Institution Login Pages Test - Prod Failure for Erasmus University Rotterdam
https://openscience.atlassian.net/browse/ENG-3818
