### PR TITLE
[ENG-3855] - Remove deactivated institution: WUSTL from custom domains list

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -51,7 +51,6 @@ domains = {
             'https://osf.usc.edu',
             'https://osf.ucla.edu',
             'https://osf.ucr.edu',
-            'https://osf.wustl.edu',
             'https://osf.research.vcu.edu',
         ],
     },


### PR DESCRIPTION
<!-- Before you submit your Pull Request, please confirm that:

     - Any test that will create public data either has the `QAtest` tag or the `dont_run_on_production` marker
     - `core_functionality` is marked as such
     - Your tests will be able to run on *all* servers (all stagings, test)
 -->


## Purpose
To fix a failing test in Production due to the fact that the institution: WUSTL has been deactivated.


## Summary of Changes

- settings.py - removing 'https://osf.wustl.edu' from 'custom_institution_domains' for Production.


## Reviewer's Actions
`git fetch <remote> pull/204/head:testFix/institutions-wustl`

Run this test using
`tests/test_institutions.py -s -v`

## Testing Changes Moving Forward
N/A


## Ticket
ENG-3855: SEL: Institutions Test - Production Failure - TestCustomDomains::test_arrive_at_myprojects_page[https://osf.wustl.edu]
https://openscience.atlassian.net/browse/ENG-3855
