### PR TITLE
[ENG-3716] - Refactor Project Files Test for Files Page Redesign Phase 2

### DIFF
--- a/components/project.py
+++ b/components/project.py
@@ -56,3 +56,44 @@ class CreateRegistrationModal(BaseElement):
 class ConfirmDeleteDraftRegistrationModal(BaseElement):
     cancel_button = Locator(By.CSS_SELECTOR, 'button[data-test-cancel-delete]')
     delete_button = Locator(By.CSS_SELECTOR, 'button[data-test-confirm-delete]')
+
+
+class ConfirmFileDeleteModal(BaseElement):
+    """There are actually multiple almost identical versions of the Confirm Delete Modal
+    on the Project Files page. So we use the GroupLocator to locate the Cancel and Delete
+    buttons which are identical, and then use indexing of these elements when interacting
+    with them in the tests.
+    """
+
+    heading = Locator(By.ID, 'osf-dialog-heading')
+    cancel_button = GroupLocator(
+        By.CSS_SELECTOR,
+        'button._Button_6kisxq._MediumButton_6kisxq._SecondaryButton_6kisxq',
+    )
+    delete_button = GroupLocator(
+        By.CSS_SELECTOR,
+        'button._Button_6kisxq._MediumButton_6kisxq._DestroyButton_6kisxq',
+    )
+    done_button = Locator(By.CSS_SELECTOR, 'div._Footer_gyio2l > button')
+
+
+class MoveCopyFileModal(BaseElement):
+    project_link = Locator(
+        By.CSS_SELECTOR, '[data-test-go-to-current-node-file-providers]'
+    )
+    provider_osfstorage_link = Locator(
+        By.CSS_SELECTOR, '[data-test-move-to-folder="osfstorage"]'
+    )
+    loading_indicator = Locator(By.CSS_SELECTOR, '.ball-pulse')
+    cancel_button = Locator(
+        By.CSS_SELECTOR,
+        'div._Footer_gyio2l > button._Button_6kisxq._MediumButton_6kisxq._SecondaryButton_6kisxq',
+    )
+    move_copy_button = Locator(By.CSS_SELECTOR, '[data-test-move-files-button]')
+    in_process_ind = Locator(By.CSS_SELECTOR, '[data-icon="spinner"]')
+    done_button = Locator(By.CSS_SELECTOR, '[data-test-move-done-button]')
+
+
+class RenameFileModal(BaseElement):
+    rename_input_box = Locator(By.CSS_SELECTOR, '[data-test-user-input]')
+    save_button = Locator(By.CSS_SELECTOR, '[data-test-disabled-rename]')

--- a/pages/project.py
+++ b/pages/project.py
@@ -15,9 +15,12 @@ from components.dashboard import (
 )
 from components.project import (
     ConfirmDeleteDraftRegistrationModal,
+    ConfirmFileDeleteModal,
     CreateRegistrationModal,
     FileWidget,
     LogWidget,
+    MoveCopyFileModal,
+    RenameFileModal,
 )
 from pages.base import (
     GuidBasePage,
@@ -117,21 +120,46 @@ class ForksPage(GuidBasePage):
 
 
 class FilesPage(GuidBasePage):
-    base_url = settings.OSF_HOME + '/{guid}/files/'
+    base_url = settings.OSF_HOME + '/{guid}/files/{addon_provider}'
 
-    identity = Locator(By.CSS_SELECTOR, '#treeGrid')
+    def __init__(
+        self, driver, verify=False, guid='', addon_provider='', domain=settings.OSF_HOME
+    ):
+        super().__init__(driver, verify)
+        self.guid = guid
+        self.addon_provider = addon_provider
+
+    @property
+    def url(self):
+        if '{guid}' in self.base_url and '{addon_provider}' in self.base_url:
+            return self.base_url.format(
+                guid=self.guid, addon_provider=self.addon_provider
+            )
+        else:
+            raise ValueError('No GUID or Addon Provider specified in base_url.')
+
+    identity = Locator(By.CSS_SELECTOR, '[data-test-file-search]')
     session = osf_api.get_default_session()
-    fangorn_rows = GroupLocator(By.CSS_SELECTOR, '#tb-tbody .fg-file-links')
-    fangorn_addons = GroupLocator(By.CSS_SELECTOR, "div[data-level='2']")
-    file_action_buttons = GroupLocator(
-        By.CSS_SELECTOR, '#folderRow .fangorn-toolbar-icon'
+    file_rows = GroupLocator(By.CSS_SELECTOR, '[data-test-file-list-item]')
+    loading_indicator = Locator(By.CSS_SELECTOR, '.ball-pulse')
+    file_selected_text = Locator(By.CSS_SELECTOR, '[data-test-file-selected-count]')
+    file_list_move_button = Locator(
+        By.CSS_SELECTOR, 'div._OptionBar__right_1qi2e2 > button:nth-child(1)'
     )
-    delete_modal = Locator(By.CSS_SELECTOR, 'span.btn:nth-child(1)')
-    replace_modal = Locator(By.CSS_SELECTOR, '#tb-tbody > div.tb-modal-shade > div')
-    replace_modal_close_button = Locator(
-        By.CSS_SELECTOR,
-        '#tb-tbody > div.tb-modal-shade > div > div.modal-header > button.close',
+    file_list_copy_button = Locator(
+        By.CSS_SELECTOR, 'div._OptionBar__right_1qi2e2 > button:nth-child(2)'
     )
+    file_list_delete_button = Locator(
+        By.CSS_SELECTOR, 'div._OptionBar__right_1qi2e2 > button:nth-child(3)'
+    )
+    leftnav_osfstorage_link = Locator(
+        By.CSS_SELECTOR, '[data-test-files-provider-link="osfstorage"]'
+    )
+
+    # Components
+    delete_modal = ComponentLocator(ConfirmFileDeleteModal)
+    move_copy_modal = ComponentLocator(MoveCopyFileModal)
+    rename_file_modal = ComponentLocator(RenameFileModal)
 
 
 """Note that the class FilesPage in pages/project.py is used for test_project_files.py.

--- a/tests/test_project_files.py
+++ b/tests/test_project_files.py
@@ -268,8 +268,10 @@ class TestFilesPage:
             files_page.move_copy_modal.move_copy_button.click()
             # After the move process has finished click the Done button to go back to
             # the Files list page.
-            WebDriverWait(driver, 30).until(
-                EC.visibility_of(files_page.move_copy_modal.done_button)
+            WebDriverWait(driver, 60).until(
+                EC.element_to_be_clickable(
+                    (By.CSS_SELECTOR, '[data-test-move-done-button]')
+                )
             )
             files_page.move_copy_modal.done_button.click()
             files_page.loading_indicator.here_then_gone()
@@ -333,8 +335,10 @@ class TestFilesPage:
             files_page.move_copy_modal.move_copy_button.click()
             # After the move process has finished click the Done button to go back to
             # the Files list page.
-            WebDriverWait(driver, 120).until(
-                EC.visibility_of(files_page.move_copy_modal.done_button)
+            WebDriverWait(driver, 90).until(
+                EC.element_to_be_clickable(
+                    (By.CSS_SELECTOR, '[data-test-move-done-button]')
+                )
             )
             files_page.move_copy_modal.done_button.click()
             files_page.loading_indicator.here_then_gone()
@@ -397,8 +401,10 @@ class TestFilesPage:
             files_page.move_copy_modal.move_copy_button.click()
             # After the copy process has finished click the Done button to go back to
             # the Files list page.
-            WebDriverWait(driver, 30).until(
-                EC.visibility_of(files_page.move_copy_modal.done_button)
+            WebDriverWait(driver, 60).until(
+                EC.element_to_be_clickable(
+                    (By.CSS_SELECTOR, '[data-test-move-done-button]')
+                )
             )
             files_page.move_copy_modal.done_button.click()
             files_page.loading_indicator.here_then_gone()
@@ -462,8 +468,10 @@ class TestFilesPage:
             files_page.move_copy_modal.move_copy_button.click()
             # After the copy process has finished click the Done button to go back to
             # the Files list page.
-            WebDriverWait(driver, 30).until(
-                EC.visibility_of(files_page.move_copy_modal.done_button)
+            WebDriverWait(driver, 90).until(
+                EC.element_to_be_clickable(
+                    (By.CSS_SELECTOR, '[data-test-move-done-button]')
+                )
             )
             files_page.move_copy_modal.done_button.click()
             files_page.loading_indicator.here_then_gone()

--- a/tests/test_project_files.py
+++ b/tests/test_project_files.py
@@ -92,16 +92,14 @@ class TestFilesPage:
                 new_name
             )
             files_page.rename_file_modal.save_button.click()
-            # Need to wait for the Rename modal to disappear before reloading the page
+            # Need to wait for the Rename modal to disappear
             WebDriverWait(driver, 5).until(
                 EC.invisibility_of_element_located(
                     (By.CSS_SELECTOR, '[data-test-file-rename-modal]')
                 )
             )
-            # The actual file rename usually takes about a second, so instead of using
-            # time.sleep() here we will just reload the page and wait for the list items
-            # to reappear. That should be plenty of time.
-            files_page.reload()
+            # The page is automatically reloaded with the new file name, so wait for the
+            # list items to reappear.
             WebDriverWait(driver, 5).until(
                 EC.visibility_of_element_located(
                     (By.CSS_SELECTOR, '[data-test-file-list-item]')
@@ -270,7 +268,7 @@ class TestFilesPage:
             files_page.move_copy_modal.move_copy_button.click()
             # After the move process has finished click the Done button to go back to
             # the Files list page.
-            WebDriverWait(driver, 15).until(
+            WebDriverWait(driver, 30).until(
                 EC.visibility_of(files_page.move_copy_modal.done_button)
             )
             files_page.move_copy_modal.done_button.click()
@@ -335,7 +333,7 @@ class TestFilesPage:
             files_page.move_copy_modal.move_copy_button.click()
             # After the move process has finished click the Done button to go back to
             # the Files list page.
-            WebDriverWait(driver, 15).until(
+            WebDriverWait(driver, 120).until(
                 EC.visibility_of(files_page.move_copy_modal.done_button)
             )
             files_page.move_copy_modal.done_button.click()
@@ -399,7 +397,7 @@ class TestFilesPage:
             files_page.move_copy_modal.move_copy_button.click()
             # After the copy process has finished click the Done button to go back to
             # the Files list page.
-            WebDriverWait(driver, 15).until(
+            WebDriverWait(driver, 30).until(
                 EC.visibility_of(files_page.move_copy_modal.done_button)
             )
             files_page.move_copy_modal.done_button.click()
@@ -464,7 +462,7 @@ class TestFilesPage:
             files_page.move_copy_modal.move_copy_button.click()
             # After the copy process has finished click the Done button to go back to
             # the Files list page.
-            WebDriverWait(driver, 15).until(
+            WebDriverWait(driver, 30).until(
                 EC.visibility_of(files_page.move_copy_modal.done_button)
             )
             files_page.move_copy_modal.done_button.click()

--- a/tests/test_project_files.py
+++ b/tests/test_project_files.py
@@ -1,10 +1,7 @@
 import datetime
 import os
-import time
 
 import pytest
-from selenium.common.exceptions import TimeoutException
-from selenium.webdriver import ActionChains
 from selenium.webdriver.common.by import By
 from selenium.webdriver.common.keys import Keys
 from selenium.webdriver.support import expected_conditions as EC
@@ -25,404 +22,487 @@ authorized in user settings, or else the test will fail to run:
 """
 
 
-def format_provider_name(row):
-    if row.text.startswith('Box:'):
-        provider = 'box'
-    elif row.text.startswith('Dropbox:'):
-        provider = 'dropbox'
-    elif row.text.startswith('Amazon S3:'):
-        provider = 's3'
-    elif row.text.startswith('ownCloud'):
-        provider = 'owncloud'
-    elif row.text.startswith('osfstorage'):
-        provider = 'osf'
-    elif row.text.startswith('OSF'):
-        provider = 'osf'
-    else:
-        provider = 'provider name not found :('
-    return provider
-
-
-def create_dictionary(driver):
-    # Wait until fangorn has loaded all files in the tree before testing
-    WebDriverWait(driver, 10).until(
-        EC.presence_of_element_located(
-            (By.CSS_SELECTOR, '#tb-tbody div[data-level="3"]')
-        )
-    )
-    WebDriverWait(driver, 10).until(
-        EC.invisibility_of_element_located((By.CSS_SELECTOR, '#tb-tbody .fa-refresh'))
-    )
-
-    all_fangorn_rows = driver.find_elements_by_css_selector(
-        '#treeGrid .tb-table .tb-tbody-inner > div > div'
-    )
-    fangorn_dictionary = {}
-    key = ''
-
-    for row in all_fangorn_rows:
-        data_level = row.get_attribute('data-level')
-        if data_level == '2':
-            key = format_provider_name(row)
-            fangorn_dictionary[key] = []
-        elif data_level == '3':
-            file_name = row.find_element_by_css_selector('.td-title .title-text')
-            # Create sub-dictionary entries for each provider
-            # Each sub-dictionary contains name of the row and the row object
-            fangorn_dictionary[key].append(
-                {'file_name': file_name.text, 'row_object': row}
-            )
-
-    return fangorn_dictionary
-
-
-def find_row_by_name(driver, provider, row_name):
-    all_files = create_dictionary(driver)
-    for x in all_files[provider]:
-        if x['file_name'] == row_name:
-            return x['row_object']
+def find_row_by_name(files_page, file_name):
+    all_files = files_page.file_rows
+    for file_row in all_files:
+        if file_name in file_row.text:
+            return file_row
     return
 
 
-# Click a button in the toolbar, just pass in the button name
-def find_toolbar_button_by_name(driver, button_name):
-    file_action_buttons = driver.find_elements_by_css_selector(
-        '#folderRow .fangorn-toolbar-icon'
+def connect_addon_to_node(session, provider, node_id):
+    """Use the api to connect a storage addon provider to a project node."""
+    addon = osf_api.get_user_addon(session, provider)
+    addon_account_id = list(addon['data']['links']['accounts'])[0]
+    osf_api.connect_provider_root_to_node(
+        session, provider, addon_account_id, node_id=node_id
     )
-    for button in file_action_buttons:
-        if button.text == button_name:
-            return button
-    return
 
 
 @markers.dont_run_on_prod
 @pytest.mark.usefixtures('must_be_logged_in')
 class TestFilesPage:
-    """We want to wrap all of our tests with try/finally so we can delete leftover files after failures.
-    Decorators did not work here because we would need to pull out node_id from each test.
+    """We want to wrap all of our tests with try/finally so we can delete leftover files
+    after failures. Decorators did not work here because we would need to pull out
+    node_id from each test.
     """
 
-    @pytest.mark.parametrize('provider', ['box', 'dropbox', 'owncloud', 's3'])
+    @pytest.mark.parametrize(
+        'provider', ['box', 'dropbox', 'osfstorage', 'owncloud', 's3']
+    )
     def test_rename_file(self, driver, default_project, session, provider):
+        """Test that renames a single file from one of the storage providers on the
+        Project Files List page.
+        """
         current_browser = find_current_browser(driver)
         node_id = default_project.id
-
-        # Connect addon to node, upload a single test file
-        node = osf_api.get_node(session, node_id=node_id)
         if provider != 'osfstorage':
-            addon = osf_api.get_user_addon(session, provider)
-            addon_account_id = list(addon['data']['links']['accounts'])[0]
-            osf_api.connect_provider_root_to_node(
-                session, provider, addon_account_id, node_id=node_id
-            )
-
+            connect_addon_to_node(session, provider, node_id)
+        node = osf_api.get_node(session, node_id=node_id)
+        # Upload a single test file to be renamed
         file_name = 'rename_' + current_browser + '_' + provider + '.txt'
         new_file, metadata = osf_api.upload_fake_file(
             session=session, node=node, name=file_name, provider=provider
         )
-
         try:
-            files_page = FilesPage(driver, guid=node_id)
+            files_page = FilesPage(driver, guid=node_id, addon_provider=provider)
             files_page.goto()
-
-            row = find_row_by_name(driver, provider, new_file)
-            row.click()
-            rename_button = find_toolbar_button_by_name(driver, 'Rename')
+            # Wait for File List items to load
+            WebDriverWait(driver, 5).until(
+                EC.visibility_of_element_located(
+                    (By.CSS_SELECTOR, '[data-test-file-list-item]')
+                )
+            )
+            row = find_row_by_name(files_page, new_file)
+            # Once we have found the right row we need to click the File Action menu
+            # button at the far right side of the row to show the menu options. Then we
+            # can click the Rename option from this menu.
+            menu_button = row.find_element_by_css_selector(
+                '[data-test-file-download-share-trigger]'
+            )
+            menu_button.click()
+            rename_button = row.find_element_by_css_selector('[data-test-rename-link]')
             rename_button.click()
-            rename_text_box = driver.find_element_by_id('renameInput')
-
+            # Delete the old file name from the input box
             for _ in range(len(new_file)):
-                rename_text_box.send_keys(Keys.BACKSPACE)
-
+                files_page.rename_file_modal.rename_input_box.send_keys(Keys.BACKSPACE)
+            # Enter new file name in input box and click Save button
             new_name = current_browser + '_' + provider + '_renamed.txt'
-            rename_text_box.send_keys(new_name)
-            rename_text_box.send_keys(Keys.RETURN)
-
-            # Wait for 5 seconds for Rename message to show
+            files_page.rename_file_modal.rename_input_box.send_keys_deliberately(
+                new_name
+            )
+            files_page.rename_file_modal.save_button.click()
+            # Need to wait for the Rename modal to disappear before reloading the page
             WebDriverWait(driver, 5).until(
-                EC.visibility_of_element_located((By.CLASS_NAME, 'text-muted'))
+                EC.invisibility_of_element_located(
+                    (By.CSS_SELECTOR, '[data-test-file-rename-modal]')
+                )
             )
-            # Wait a maximum of 20 seconds for Rename message to resolve
-            WebDriverWait(driver, 20).until(
-                EC.invisibility_of_element_located((By.CLASS_NAME, 'text-muted'))
+            # The actual file rename usually takes about a second, so instead of using
+            # time.sleep() here we will just reload the page and wait for the list items
+            # to reappear. That should be plenty of time.
+            files_page.reload()
+            WebDriverWait(driver, 5).until(
+                EC.visibility_of_element_located(
+                    (By.CSS_SELECTOR, '[data-test-file-list-item]')
+                )
             )
-
-            files_page.goto()
             # Test old file name does not exist
-            old_file = find_row_by_name(driver, provider, file_name)
+            old_file = find_row_by_name(files_page, new_file)
             assert old_file is None
-
             # Test that new file name is present and visible
-            renamed_file = find_row_by_name(driver, provider, new_name)
+            renamed_file = find_row_by_name(files_page, new_name)
             assert new_name in renamed_file.text
-
-        finally:
-            osf_api.delete_addon_files(session, provider, current_browser, guid=node_id)
-
-    @markers.core_functionality
-    def test_checkout_file(self, driver, default_project, session):
-        current_browser = driver.desired_capabilities.get('browserName')
-        node_id = default_project.id
-        provider = 'osfstorage'
-
-        # Connect add-on to node, upload a single test file
-        node = osf_api.get_node(session, node_id=node_id)
-        file_name = 'checkout_' + find_current_browser(driver) + '.txt'
-        new_file, metadata = osf_api.upload_fake_file(
-            session=session, node=node, name=file_name, provider=provider
-        )
-
-        try:
-            files_page = FilesPage(driver, guid=node_id)
-            files_page.goto()
-
-            row = find_row_by_name(driver, 'osf', new_file)
-            row.click()
-            checkout_button = find_toolbar_button_by_name(driver, 'Check out file')
-            checkout_button.click()
-            # Accept the confirmation modal
-            driver.find_element_by_css_selector('.btn-warning').click()
-
-            # Wait for delete modal to resolve
-            WebDriverWait(driver, 5).until(
-                EC.invisibility_of_element_located((By.CSS_SELECTOR, '.btn-warning'))
-            )
-            # Wait for 3rd fangorn row to load
-            WebDriverWait(driver, 5).until(
-                EC.visibility_of_element_located(
-                    (By.CSS_SELECTOR, '#tb-tbody > div > div > div:nth-child(3)')
-                )
-            )
-
-            # Test that Check Out button is no longer present
-            row = find_row_by_name(driver, 'osf', new_file)
-            row.click()
-            checkout_button = find_toolbar_button_by_name(driver, 'Check out file')
-            assert checkout_button is None
-
-            row = find_row_by_name(driver, 'osf', new_file)
-            row.click()
-            check_in_button = find_toolbar_button_by_name(driver, 'Check in file')
-            check_in_button.click()
-
-            # Wait for page to reload
-            WebDriverWait(driver, 5).until(
-                EC.invisibility_of_element_located(
-                    (By.CSS_SELECTOR, '#tb-tbody > div > div > div:nth-child(3)')
-                )
-            )
-            # Wait for 3rd fangorn row to load
-            WebDriverWait(driver, 10).until(
-                EC.visibility_of_element_located(
-                    (By.CSS_SELECTOR, '#tb-tbody > div > div > div:nth-child(3)')
-                )
-            )
-
-            # Test that Check In button is no longer present
-            row = find_row_by_name(driver, 'osf', new_file)
-            row.click()
-            check_in_button = find_toolbar_button_by_name(driver, 'Check in file')
-            assert check_in_button is None
-
-        finally:
-            osf_api.delete_addon_files(session, provider, current_browser, guid=node_id)
-
-    @markers.core_functionality
-    @pytest.mark.parametrize('provider', ['box', 'dropbox', 'owncloud', 's3'])
-    def test_delete_file(self, driver, default_project, session, provider):
-        current_browser = driver.desired_capabilities.get('browserName')
-        node_id = default_project.id
-
-        # Connect addon to node, upload a single test file
-        node = osf_api.get_node(session, node_id=node_id)
-        if provider != 'osfstorage':
-            addon = osf_api.get_user_addon(session, provider)
-            addon_account_id = list(addon['data']['links']['accounts'])[0]
-            osf_api.connect_provider_root_to_node(
-                session, provider, addon_account_id, node_id=node_id
-            )
-
-        file_name = 'delete_' + current_browser + '_' + provider + '.txt'
-        new_file, metadata = osf_api.upload_fake_file(
-            session=session, node=node, name=file_name, provider=provider
-        )
-
-        try:
-            files_page = FilesPage(driver, guid=node_id)
-            files_page.goto()
-
-            row = find_row_by_name(driver, provider, new_file)
-            row.click()
-            delete_button = find_toolbar_button_by_name(driver, 'Delete')
-            delete_button.click()
-
-            # Wait for the delete confirmation
-            files_page.delete_modal.present()
-
-            # Front End will show 'delete failed' message - still works as expected
-            driver.find_element_by_css_selector('.btn-danger').click()
-
-            # Wait for delete modal to resolve
-            WebDriverWait(driver, 5).until(
-                EC.invisibility_of_element_located(
-                    (By.CSS_SELECTOR, 'p[class="text-danger"]')
-                )
-            )
-
-            deleted_row = find_row_by_name(driver, provider, new_file)
-            assert deleted_row is None
-
         finally:
             osf_api.delete_addon_files(session, provider, current_browser, guid=node_id)
 
     @pytest.mark.parametrize(
-        'provider, modifier_key, action',
-        [
-            ['s3', 'none', 'move'],
-            ['s3', 'alt', 'copy'],
-            ['box', 'none', 'move'],
-            ['box', 'alt', 'copy'],
-            ['dropbox', 'none', 'move'],
-            ['dropbox', 'alt', 'copy'],
-            ['owncloud', 'none', 'move'],
-            ['owncloud', 'alt', 'copy'],
-        ],
+        'provider', ['box', 'dropbox', 'osfstorage', 'owncloud', 's3']
     )
-    def test_dragon_drop(
-        self, driver, default_project, session, provider, modifier_key, action
-    ):
+    def test_delete_single_file(self, driver, default_project, session, provider):
+        """Test that deletes a single file from one of the storage providers on the
+        Project Files List page.
+        """
         current_browser = driver.desired_capabilities.get('browserName')
         node_id = default_project.id
-
-        # Connect addon to node, upload a single test file
-        node = osf_api.get_node(session, node_id=node_id)
         if provider != 'osfstorage':
-            addon = osf_api.get_user_addon(session, provider)
-            addon_account_id = list(addon['data']['links']['accounts'])[0]
-            osf_api.connect_provider_root_to_node(
-                session, provider, addon_account_id, node_id=node_id
-            )
-        if modifier_key == 'alt':
-            file_name = 'copy_' + find_current_browser(driver) + '_' + provider + '.txt'
-            new_file, metadata = osf_api.upload_fake_file(
-                session=session, node=node, name=file_name, provider=provider
-            )
-        else:
-            file_name = 'move_' + current_browser + '_' + provider + '.txt'
-            new_file, metadata = osf_api.upload_fake_file(
-                session=session, node=node, name=file_name, provider=provider
-            )
-
+            connect_addon_to_node(session, provider, node_id)
+        node = osf_api.get_node(session, node_id=node_id)
+        # Upload a single test file to be deleted
+        file_name = 'delete_' + current_browser + '_' + provider + '.txt'
+        new_file, metadata = osf_api.upload_fake_file(
+            session=session, node=node, name=file_name, provider=provider
+        )
         try:
-            files_page = FilesPage(driver, guid=node_id)
+            files_page = FilesPage(driver, guid=node_id, addon_provider=provider)
             files_page.goto()
-
-            # Find the row that contains the new file
-            source_row = find_row_by_name(driver, provider, new_file)
-
-            # Find the row with the OSF storage
-            for row in files_page.fangorn_addons:
-                if row.text == 'OSF Storage (United States)':
-                    target = row
-                    break
-
-            action_chains = ActionChains(driver)
-            action_chains.reset_actions()
-
-            if 'firefox' in current_browser:
-                if modifier_key == 'alt':
-                    # Copy file
-                    action_chains.key_down(Keys.LEFT_ALT).perform()
-                    action_chains.drag_and_drop(source_row, target).perform()
-                else:
-                    # Move file
-                    action_chains.drag_and_drop(source_row, target).perform()
-            else:
-                # The sleeps in the following code block are needed for
-                # Chromium's virtual keyboard to work properly
-                if modifier_key == 'alt':
-                    # Copy file
-                    time.sleep(1)
-                    action_chains.key_down(Keys.ALT).perform()
-                    time.sleep(1)
-                    action_chains.click_and_hold(source_row).perform()
-                    time.sleep(1)
-                    action_chains.drag_and_drop(source_row, target).perform()
-                    time.sleep(1)
-                    action_chains.reset_actions()
-                    if 'chrome' in current_browser:
-                        # The ALT key_up seems to be necessary for Chrome. Without it
-                        # every other copy attempt actually becomes a move.
-                        action_chains.key_up(Keys.ALT).perform()
-                        time.sleep(1)
-                        # However, the ALT key_up can cause an unwanted repetition of
-                        # the drag and drop action which can cause a pop-up modal about
-                        # replacing the copied file. This seems to happen most often
-                        # on BrowserStack.  If we see this modal, then close it.
-                        if files_page.replace_modal.present():
-                            files_page.replace_modal_close_button.click()
-                else:
-                    # Move file
-                    action_chains.click_and_hold(source_row).perform()
-                    # Chrome -> will highlight multiple rows if you do not sleep here
-                    time.sleep(1)
-                    action_chains.drag_and_drop(source_row, target).perform()
-
-            try:
-                # Wait for 5 seconds for Copying message to show
-                WebDriverWait(driver, 5).until(
-                    EC.visibility_of_element_located((By.CLASS_NAME, 'text-muted'))
+            # Wait for File List items to load
+            WebDriverWait(driver, 5).until(
+                EC.visibility_of_element_located(
+                    (By.CSS_SELECTOR, '[data-test-file-list-item]')
                 )
-            except TimeoutException:
-                pass
-
-            try:
-                # Wait a maximum of 30 seconds for Copying message to resolve
-                WebDriverWait(driver, 30).until(
-                    EC.invisibility_of_element_located((By.CLASS_NAME, 'text-muted'))
-                )
-            except TimeoutException:
-                # Reload the page and continue test
-                pass
-
-            files_page.goto()
-            origin_file = find_row_by_name(driver, provider, new_file)
-            destination_file = find_row_by_name(driver, 'osf', new_file)
-
-            if modifier_key == 'alt':
-                # Test for copy
-                assert 'copy' in origin_file.text
-                assert 'copy' in destination_file.text
-
-                osf_api.delete_file(session, metadata['data']['links']['delete'])
-
-            else:
-                # Test for move
-                assert origin_file is None
-                assert 'move' in destination_file.text
-
+            )
+            row = find_row_by_name(files_page, new_file)
+            # Once we have found the right row we need to click the File Action menu
+            # button at the far right side of the row to show the menu options. Then we
+            # can click the Delete option from this menu.
+            menu_button = row.find_element_by_css_selector(
+                '[data-test-file-download-share-trigger]'
+            )
+            menu_button.click()
+            delete_button = row.find_element_by_css_selector(
+                '[data-test-delete-button]'
+            )
+            delete_button.click()
+            # Click the Delete button on the modal
+            files_page.delete_modal.delete_button[0].click()
+            files_page.loading_indicator.here_then_gone()
+            # Verify file has been deleted from the files list
+            deleted_row = find_row_by_name(files_page, new_file)
+            assert deleted_row is None
         finally:
             osf_api.delete_addon_files(session, provider, current_browser, guid=node_id)
 
-    @pytest.mark.parametrize('provider', ['s3', 'dropbox', 'box', 'owncloud'])
-    def test_download_file(self, driver, default_project, session, provider):
+    @pytest.mark.parametrize(
+        'provider', ['box', 'dropbox', 'osfstorage', 'owncloud', 's3']
+    )
+    def test_delete_multiple_files(self, driver, default_project, session, provider):
+        """Test that deletes multiple files (2) from one of the storage providers on the
+        Project Files List page.
+        """
         current_browser = driver.desired_capabilities.get('browserName')
         node_id = default_project.id
-
-        # Connect addon to node, upload a single test file
-        node = osf_api.get_node(session, node_id=node_id)
         if provider != 'osfstorage':
-            addon = osf_api.get_user_addon(session, provider)
-            addon_account_id = list(addon['data']['links']['accounts'])[0]
-            osf_api.connect_provider_root_to_node(
-                session, provider, addon_account_id, node_id=node_id
+            connect_addon_to_node(session, provider, node_id)
+        node = osf_api.get_node(session, node_id=node_id)
+        # Upload 2 separate test files to be deleted
+        file_name_1 = 'delete_1_' + current_browser + '_' + provider + '.txt'
+        new_file_1, metadata = osf_api.upload_fake_file(
+            session=session, node=node, name=file_name_1, provider=provider
+        )
+        file_name_2 = 'delete_2_' + current_browser + '_' + provider + '.txt'
+        new_file_2, metadata = osf_api.upload_fake_file(
+            session=session, node=node, name=file_name_2, provider=provider
+        )
+        try:
+            files_page = FilesPage(driver, guid=node_id, addon_provider=provider)
+            files_page.goto()
+            # Wait for File List items to load
+            WebDriverWait(driver, 5).until(
+                EC.visibility_of_element_located(
+                    (By.CSS_SELECTOR, '[data-test-file-list-item]')
+                )
             )
+            # Find the row for the 1st file to be deleted and click to select it
+            row_1 = find_row_by_name(files_page, new_file_1)
+            row_1.click()
+            # Next find the 2nd file row and click it as well.
+            row_2 = find_row_by_name(files_page, new_file_2)
+            row_2.click()
+            # Verify that 2 files have been selected
+            assert files_page.file_selected_text.text == '2 item(s) selected'
+            # Click the Delete button above the file list
+            files_page.file_list_delete_button.click()
+            # Click the Delete button on the modal
+            files_page.delete_modal.delete_button[1].click()
+            # Wait for Delete button to disappear
+            WebDriverWait(driver, 10).until(
+                EC.invisibility_of_element_located(
+                    (
+                        By.CSS_SELECTOR,
+                        'div._Footer_gyio2l > button._Button_6kisxq._MediumButton_6kisxq._DestroyButton_6kisxq',
+                    )
+                )
+            )
+            # Verify success message on modal and click the Done button
+            assert (
+                files_page.delete_modal.heading.text == '2 items deleted successfully'
+            )
+            files_page.delete_modal.done_button.click()
+            files_page.loading_indicator.here_then_gone()
+            # Verify both files have been deleted from the files list
+            deleted_row_1 = find_row_by_name(files_page, new_file_1)
+            assert deleted_row_1 is None
+            deleted_row_2 = find_row_by_name(files_page, new_file_2)
+            assert deleted_row_2 is None
+        finally:
+            osf_api.delete_addon_files(session, provider, current_browser, guid=node_id)
 
+    @pytest.mark.parametrize('provider', ['box', 'dropbox', 'owncloud', 's3'])
+    def test_move_single_file(self, driver, default_project, session, provider):
+        """Test that moves a single file from one of the storage providers on the
+        Project Files List page to OSF Storage.
+        """
+        current_browser = driver.desired_capabilities.get('browserName')
+        node_id = default_project.id
+        if provider != 'osfstorage':
+            connect_addon_to_node(session, provider, node_id)
+        node = osf_api.get_node(session, node_id=node_id)
+        # Upload a single test file to be moved
+        file_name = 'move_' + current_browser + '_' + provider + '.txt'
+        new_file, metadata = osf_api.upload_fake_file(
+            session=session, node=node, name=file_name, provider=provider
+        )
+        try:
+            files_page = FilesPage(driver, guid=node_id, addon_provider=provider)
+            files_page.goto()
+            # Wait for File List items to load
+            WebDriverWait(driver, 5).until(
+                EC.visibility_of_element_located(
+                    (By.CSS_SELECTOR, '[data-test-file-list-item]')
+                )
+            )
+            row = find_row_by_name(files_page, new_file)
+            # Once we have found the right row we need to click the File Action menu
+            # button at the far right side of the row to show the menu options. Then we
+            # can click the Move option from this menu.
+            menu_button = row.find_element_by_css_selector(
+                '[data-test-file-download-share-trigger]'
+            )
+            menu_button.click()
+            move_button = row.find_element_by_css_selector('[data-test-move-button]')
+            move_button.click()
+            # Click the Project link on the Move modal to go up a level and then click
+            # the OSF Storage link. Then click the Move button on the modal to move
+            # the file to OSF Storage.
+            files_page.move_copy_modal.project_link.click()
+            files_page.move_copy_modal.provider_osfstorage_link.click()
+            files_page.move_copy_modal.move_copy_button.click()
+            # After the move process has finished click the Done button to go back to
+            # the Files list page.
+            WebDriverWait(driver, 15).until(
+                EC.visibility_of(files_page.move_copy_modal.done_button)
+            )
+            files_page.move_copy_modal.done_button.click()
+            files_page.loading_indicator.here_then_gone()
+            # We should still be on the page for the provider, so check that the file
+            # is no longer listed here.
+            moved_row = find_row_by_name(files_page, new_file)
+            assert moved_row is None
+            # Click the link in the left navbar to switch to OSF Storage and verify the
+            # file has been moved there.
+            files_page.leftnav_osfstorage_link.click()
+            files_page.loading_indicator.here_then_gone()
+            moved_row = find_row_by_name(files_page, new_file)
+            assert new_file in moved_row.text
+        finally:
+            osf_api.delete_addon_files(session, provider, current_browser, guid=node_id)
+
+    @pytest.mark.parametrize('provider', ['box', 'dropbox', 'owncloud', 's3'])
+    def test_move_multiple_files(self, driver, default_project, session, provider):
+        """Test that moves multiple files from one of the storage providers on the
+        Project Files List page to OSF Storage.
+        """
+        current_browser = driver.desired_capabilities.get('browserName')
+        node_id = default_project.id
+        if provider != 'osfstorage':
+            connect_addon_to_node(session, provider, node_id)
+        node = osf_api.get_node(session, node_id=node_id)
+        # Upload 2 separate test files to be moved
+        file_name_1 = 'move_1_' + current_browser + '_' + provider + '.txt'
+        new_file_1, metadata = osf_api.upload_fake_file(
+            session=session, node=node, name=file_name_1, provider=provider
+        )
+        file_name_2 = 'move_2_' + current_browser + '_' + provider + '.txt'
+        new_file_2, metadata = osf_api.upload_fake_file(
+            session=session, node=node, name=file_name_2, provider=provider
+        )
+        try:
+            files_page = FilesPage(driver, guid=node_id, addon_provider=provider)
+            files_page.goto()
+            # Wait for File List items to load
+            WebDriverWait(driver, 5).until(
+                EC.visibility_of_element_located(
+                    (By.CSS_SELECTOR, '[data-test-file-list-item]')
+                )
+            )
+            # Find the row for the 1st file to be moved and click to select it
+            row_1 = find_row_by_name(files_page, new_file_1)
+            row_1.click()
+            # Next find the 2nd file row and click it as well.
+            row_2 = find_row_by_name(files_page, new_file_2)
+            row_2.click()
+            # Verify that 2 files have been selected
+            assert files_page.file_selected_text.text == '2 item(s) selected'
+            # Click the Move button above the file list
+            files_page.file_list_move_button.click()
+            # Click the Project link on the Move modal to go up a level and then click
+            # the OSF Storage link. Then click the Move button on the modal to move
+            # the file to OSF Storage.
+            files_page.move_copy_modal.project_link.click()
+            files_page.move_copy_modal.provider_osfstorage_link.click()
+            files_page.move_copy_modal.loading_indicator.here_then_gone()
+            files_page.move_copy_modal.move_copy_button.click()
+            # After the move process has finished click the Done button to go back to
+            # the Files list page.
+            WebDriverWait(driver, 15).until(
+                EC.visibility_of(files_page.move_copy_modal.done_button)
+            )
+            files_page.move_copy_modal.done_button.click()
+            files_page.loading_indicator.here_then_gone()
+            # We should still be on the page for the provider, so check that the files
+            # are no longer listed here.
+            moved_row_1 = find_row_by_name(files_page, new_file_1)
+            assert moved_row_1 is None
+            moved_row_2 = find_row_by_name(files_page, new_file_2)
+            assert moved_row_2 is None
+            # Click the link in the left navbar to switch to OSF Storage and verify the
+            # files have been moved there.
+            files_page.leftnav_osfstorage_link.click()
+            files_page.loading_indicator.here_then_gone()
+            moved_row_1 = find_row_by_name(files_page, new_file_1)
+            assert new_file_1 in moved_row_1.text
+            moved_row_2 = find_row_by_name(files_page, new_file_2)
+            assert new_file_2 in moved_row_2.text
+        finally:
+            osf_api.delete_addon_files(session, provider, current_browser, guid=node_id)
+
+    @pytest.mark.parametrize('provider', ['box', 'dropbox', 'owncloud', 's3'])
+    def test_copy_single_file(self, driver, default_project, session, provider):
+        """Test that copies a single file from one of the storage providers on the
+        Project Files List page to OSF Storage.
+        """
+        current_browser = driver.desired_capabilities.get('browserName')
+        node_id = default_project.id
+        if provider != 'osfstorage':
+            connect_addon_to_node(session, provider, node_id)
+        node = osf_api.get_node(session, node_id=node_id)
+        # Upload a single test file to be copied
+        file_name = 'copy_' + current_browser + '_' + provider + '.txt'
+        new_file, metadata = osf_api.upload_fake_file(
+            session=session, node=node, name=file_name, provider=provider
+        )
+        try:
+            files_page = FilesPage(driver, guid=node_id, addon_provider=provider)
+            files_page.goto()
+            # Wait for File List items to load
+            WebDriverWait(driver, 5).until(
+                EC.visibility_of_element_located(
+                    (By.CSS_SELECTOR, '[data-test-file-list-item]')
+                )
+            )
+            row = find_row_by_name(files_page, new_file)
+            # Once we have found the right row we need to click the File Action menu
+            # button at the far right side of the row to show the menu options. Then we
+            # can click the Copy option from this menu.
+            menu_button = row.find_element_by_css_selector(
+                '[data-test-file-download-share-trigger]'
+            )
+            menu_button.click()
+            move_button = row.find_element_by_css_selector('[data-test-copy-button]')
+            move_button.click()
+            # Click the Project link on the Copy modal to go up a level and then click
+            # the OSF Storage link. Then click the Copy button on the modal to copy
+            # the file to OSF Storage.
+            files_page.move_copy_modal.project_link.click()
+            files_page.move_copy_modal.provider_osfstorage_link.click()
+            files_page.move_copy_modal.move_copy_button.click()
+            # After the copy process has finished click the Done button to go back to
+            # the Files list page.
+            WebDriverWait(driver, 15).until(
+                EC.visibility_of(files_page.move_copy_modal.done_button)
+            )
+            files_page.move_copy_modal.done_button.click()
+            files_page.loading_indicator.here_then_gone()
+            # We should still be on the page for the provider, so check that the file
+            # is still listed here.
+            source_row = find_row_by_name(files_page, new_file)
+            assert new_file in source_row.text
+            # Click the link in the left navbar to switch to OSF Storage and verify the
+            # file has been copied there.
+            files_page.leftnav_osfstorage_link.click()
+            files_page.loading_indicator.here_then_gone()
+            destination_row = find_row_by_name(files_page, new_file)
+            assert new_file in destination_row.text
+        finally:
+            osf_api.delete_addon_files(session, provider, current_browser, guid=node_id)
+
+    @pytest.mark.parametrize('provider', ['box', 'dropbox', 'owncloud', 's3'])
+    def test_copy_multiple_files(self, driver, default_project, session, provider):
+        """Test that copies multiple files from one of the storage providers on the
+        Project Files List page to OSF Storage.
+        """
+        current_browser = driver.desired_capabilities.get('browserName')
+        node_id = default_project.id
+        if provider != 'osfstorage':
+            connect_addon_to_node(session, provider, node_id)
+        node = osf_api.get_node(session, node_id=node_id)
+        # Upload 2 separate test files to be moved
+        file_name_1 = 'copy_1_' + current_browser + '_' + provider + '.txt'
+        new_file_1, metadata = osf_api.upload_fake_file(
+            session=session, node=node, name=file_name_1, provider=provider
+        )
+        file_name_2 = 'copy_2_' + current_browser + '_' + provider + '.txt'
+        new_file_2, metadata = osf_api.upload_fake_file(
+            session=session, node=node, name=file_name_2, provider=provider
+        )
+        try:
+            files_page = FilesPage(driver, guid=node_id, addon_provider=provider)
+            files_page.goto()
+            # Wait for File List items to load
+            WebDriverWait(driver, 5).until(
+                EC.visibility_of_element_located(
+                    (By.CSS_SELECTOR, '[data-test-file-list-item]')
+                )
+            )
+            # Find the row for the 1st file to be copied and click to select it
+            row_1 = find_row_by_name(files_page, new_file_1)
+            row_1.click()
+            # Next find the 2nd file row and click it as well.
+            row_2 = find_row_by_name(files_page, new_file_2)
+            row_2.click()
+            # Verify that 2 files have been selected
+            assert files_page.file_selected_text.text == '2 item(s) selected'
+            # Click the Copy button above the file list
+            files_page.file_list_copy_button.click()
+            # Click the Project link on the Copy modal to go up a level and then click
+            # the OSF Storage link. Then click the Copy button on the modal to copy
+            # the file to OSF Storage.
+            files_page.move_copy_modal.project_link.click()
+            files_page.move_copy_modal.provider_osfstorage_link.click()
+            files_page.move_copy_modal.loading_indicator.here_then_gone()
+            files_page.move_copy_modal.move_copy_button.click()
+            # After the copy process has finished click the Done button to go back to
+            # the Files list page.
+            WebDriverWait(driver, 15).until(
+                EC.visibility_of(files_page.move_copy_modal.done_button)
+            )
+            files_page.move_copy_modal.done_button.click()
+            files_page.loading_indicator.here_then_gone()
+            # We should still be on the page for the provider, so check that the files
+            # are still listed here.
+            source_row_1 = find_row_by_name(files_page, new_file_1)
+            assert new_file_1 in source_row_1.text
+            source_row_2 = find_row_by_name(files_page, new_file_2)
+            assert new_file_2 in source_row_2.text
+            # Click the link in the left navbar to switch to OSF Storage and verify the
+            # files have been copied there.
+            files_page.leftnav_osfstorage_link.click()
+            files_page.loading_indicator.here_then_gone()
+            destination_row_1 = find_row_by_name(files_page, new_file_1)
+            assert new_file_1 in destination_row_1.text
+            destination_row_2 = find_row_by_name(files_page, new_file_2)
+            assert new_file_2 in destination_row_2.text
+        finally:
+            osf_api.delete_addon_files(session, provider, current_browser, guid=node_id)
+
+    @pytest.mark.parametrize(
+        'provider', ['box', 'dropbox', 'osfstorage', 'owncloud', 's3']
+    )
+    def test_download_file(self, driver, default_project, session, provider):
+        """Test that downloads a single file from one of the storage providers on the
+        Project Files List page.
+        """
+        current_browser = driver.desired_capabilities.get('browserName')
+        node_id = default_project.id
+        if provider != 'osfstorage':
+            connect_addon_to_node(session, provider, node_id)
+        node = osf_api.get_node(session, node_id=node_id)
+        # Upload a single test file to be downloaded
         file_name = 'download_' + current_browser + '_' + provider + '.txt'
         new_file, metadata = osf_api.upload_fake_file(
             session=session, node=node, name=file_name, provider=provider
         )
-
         try:
             # If running on local machine, first check if the download file already
             # exists in the Downloads folder. If so then delete the old copy before
@@ -431,24 +511,36 @@ class TestFilesPage:
                 file_path = os.path.expanduser('~/Downloads/' + file_name)
                 if os.path.exists(file_path):
                     os.remove(file_path)
-
-            files_page = FilesPage(driver, guid=node_id)
+            files_page = FilesPage(driver, guid=node_id, addon_provider=provider)
             files_page.goto()
-
-            row = find_row_by_name(driver, provider, new_file)
-            row.click()
-            download_button = find_toolbar_button_by_name(driver, 'Download')
-            download_button.click()
-            # Wait to see if error message appears -- for negative test
-            time.sleep(2)
-
-            # Negative test
-            assert (
-                'Could not retrieve file or directory'
-                not in driver.find_element_by_xpath('/html/body').text
+            # Wait for File List items to load
+            WebDriverWait(driver, 5).until(
+                EC.visibility_of_element_located(
+                    (By.CSS_SELECTOR, '[data-test-file-list-item]')
+                )
             )
-
-            # Positive Test: Verify that file is actually downloaded to user's machine
+            row = find_row_by_name(files_page, new_file)
+            # Once we have found the right row we need to click the File Action menu
+            # button at the far right side of the row to show the menu options. Then we
+            # can click the Download option from this menu.
+            menu_button = row.find_element_by_css_selector(
+                '[data-test-file-download-share-trigger]'
+            )
+            menu_button.click()
+            move_button = row.find_element_by_css_selector(
+                '[data-test-download-button]'
+            )
+            move_button.click()
+            # The actual file download usually takes a second or two, so instead of
+            # using time.sleep() here we will just reload the page and wait for the
+            # list items to reappear. That should be plenty of time.
+            files_page.reload()
+            WebDriverWait(driver, 5).until(
+                EC.visibility_of_element_located(
+                    (By.CSS_SELECTOR, '[data-test-file-list-item]')
+                )
+            )
+            # Verify that the file is actually downloaded to user's machine
             current_date = datetime.datetime.now()
             if settings.DRIVER == 'Remote':
                 # First verify the downloaded file exists on the virtual remote machine
@@ -472,7 +564,6 @@ class TestFilesPage:
                 file_mtime = os.path.getmtime(file_path)
                 file_mod_date = datetime.datetime.fromtimestamp(file_mtime)
                 assert file_mod_date.date() == current_date.date()
-
         finally:
             osf_api.delete_addon_files(session, provider, current_browser, guid=node_id)
 
@@ -486,4 +577,8 @@ Addons this test does not cover, and reasons:
     Github - requested add-on not currently configurable via API
     Dataverse - requested add-on not currently configurable via API
     Figshare - has a non-conventional file setup not suited for normal file actions
+    Bitbucket - Read-only
+    OneDrive - Similar issues to Google Drive. OneDrive is a special case that our API
+                cannot currently handle.
+    GitLab - Read-only
 """


### PR DESCRIPTION
<!-- Before you submit your Pull Request, please confirm that:

     - Any test that will create public data either has the `QAtest` tag or the `dont_run_on_production` marker
     - `core_functionality` is marked as such
     - Your tests will be able to run on *all* servers (all stagings, test)
 -->


## Purpose
To refactor the Project Files test to accommodate the changes made to the OSF Project Files page as a result of the Files Page Redesign Phase 2 project.


## Summary of Changes

- components/project.py - adding 3 new modal components: ConfirmFileDeleteModal, MoveCopyFileModal, and RenameFileModal
- pages/project.py - updates to page class: FilesPage to account for Project Files page changing from Legacy page to Ember page.
- tests/test_project_files.py - multiple refactoring including: 
    1. rewrite of existing tests: test_rename_file and test_download_file 
    2. elimination of test: test_checkout_file 
    3. replacement of test: test_delete_file with 2 new tests:  test_delete_single_file and test_delete_multiple_files
    4. replacement of test: test_dragon_drop with 4 new tests: test_move_single_file, test_move_multiple_files, test_copy_single_file, and test_copy_multiple_files


## Reviewer's Actions
`git fetch <remote> pull/<PR_number>/head:testFix/files-page-phase2`

Run this test using
`tests/test_project_files.py -s -v`

## Testing Changes Moving Forward
N/A


## Ticket
ENG-3716: SEL: Project Files Test - Refactor For Files Page Redesign Phase 2
https://openscience.atlassian.net/browse/ENG-3716
