### PR TITLE
[ENG-3247] Test registries versioning workflow

### DIFF
--- a/api/osf_api.py
+++ b/api/osf_api.py
@@ -856,4 +856,4 @@ def delete_registration_version_draft(session, draft_id):
     registration_version_url = '{}/v2/schema_responses/{}/'.format(
         session.api_base_url, draft_id
     )
-    session.delete(url=registration_version_url, item_type=None)
+    session.delete(url=registration_version_url, item_type='schema-responses')

--- a/api/osf_api.py
+++ b/api/osf_api.py
@@ -848,3 +848,12 @@ def get_user_pat_data(session, token_id=None):
     url = '/v2/tokens/{}/'.format(token_id)
     data = session.get(url)['data']
     return data or None
+
+
+def delete_registration_version_draft(session, draft_id):
+    """Delete 'in-progress' version update for a given registration."""
+
+    registration_version_url = '{}/v2/schema_responses/{}/'.format(
+        session.api_base_url, draft_id
+    )
+    session.delete(url=registration_version_url, item_type=None)

--- a/pages/registrations.py
+++ b/pages/registrations.py
@@ -30,3 +30,7 @@ class MyRegistrationsPage(OSFBasePage):
         By.CSS_SELECTOR, 'a[data-test-my-reg-registrations-add-new-button]'
     )
     public_registration_title = Locator(By.CSS_SELECTOR, 'a[data-test-node-title]')
+
+    update_button = Locator(By.CSS_SELECTOR, '[data-test-update-button]')
+    update_registration_dialogue = Locator(By.CSS_SELECTOR, '[data-test-new-update-dialog-main]')
+    update_registration_dialogue_next = Locator(By.CSS_SELECTOR, '[data-test-new-update-dialog-footer-next]')

--- a/pages/registrations.py
+++ b/pages/registrations.py
@@ -33,6 +33,7 @@ class MyRegistrationsPage(OSFBasePage):
 
     view_button = Locator(By.CSS_SELECTOR, '[data-test-view-button]')
     update_button = Locator(By.CSS_SELECTOR, '[data-test-update-button]')
+    continue_update_button = Locator(By.CSS_SELECTOR, '[data-test-view-changes-button]')
     update_registration_dialogue = Locator(
         By.CSS_SELECTOR, '[data-test-new-update-dialog-main]'
     )

--- a/pages/registrations.py
+++ b/pages/registrations.py
@@ -1,15 +1,21 @@
 from selenium.webdriver.common.by import By
 
 import settings
-from base.locators import Locator
+from base.locators import (
+    GroupLocator,
+    Locator,
+)
 from pages.base import OSFBasePage
 
 
 class MyRegistrationsPage(OSFBasePage):
     url = settings.OSF_HOME + '/registries/my-registrations/'
     identity = Locator(
-        By.CSS_SELECTOR, 'div[data-analytics-scope="My Registrations page"]'
+        By.CSS_SELECTOR,
+        'div[data-analytics-scope="My Registrations page"]',
+        settings.TIMEOUT,
     )
+    loading_indicator = Locator(By.CSS_SELECTOR, '.ball-pulse')
 
     drafts_tab = Locator(By.CSS_SELECTOR, '[data-test-my-registrations-nav="drafts"]')
     no_drafts_message = Locator(By.CSS_SELECTOR, 'p[data-test-draft-list-no-drafts]')
@@ -40,3 +46,14 @@ class MyRegistrationsPage(OSFBasePage):
     update_registration_dialogue_next = Locator(
         By.CSS_SELECTOR, '[data-test-new-update-dialog-footer-next]'
     )
+    registration_card = Locator(By.CSS_SELECTOR, 'div[data-test-node-card]')
+    registration_cards = GroupLocator(By.CSS_SELECTOR, 'div[data-test-node-card]')
+
+    def get_registration_card_by_title(self, title):
+        for registration_card in self.registration_cards:
+            node_title = registration_card.find_element_by_css_selector(
+                '[data-test-node-title]'
+            )
+
+            if title in node_title.text:
+                return registration_card

--- a/pages/registrations.py
+++ b/pages/registrations.py
@@ -36,10 +36,6 @@ class MyRegistrationsPage(OSFBasePage):
         By.CSS_SELECTOR, 'a[data-test-my-reg-registrations-add-new-button]'
     )
     public_registration_title = Locator(By.CSS_SELECTOR, 'a[data-test-node-title]')
-
-    view_button = Locator(By.CSS_SELECTOR, '[data-test-view-button]')
-    update_button = Locator(By.CSS_SELECTOR, '[data-test-update-button]')
-    continue_update_button = Locator(By.CSS_SELECTOR, '[data-test-view-changes-button]')
     update_registration_dialogue = Locator(
         By.CSS_SELECTOR, '[data-test-new-update-dialog-main]'
     )

--- a/pages/registrations.py
+++ b/pages/registrations.py
@@ -31,6 +31,7 @@ class MyRegistrationsPage(OSFBasePage):
     )
     public_registration_title = Locator(By.CSS_SELECTOR, 'a[data-test-node-title]')
 
+    view_button = Locator(By.CSS_SELECTOR, '[data-test-view-button]')
     update_button = Locator(By.CSS_SELECTOR, '[data-test-update-button]')
     update_registration_dialogue = Locator(By.CSS_SELECTOR, '[data-test-new-update-dialog-main]')
     update_registration_dialogue_next = Locator(By.CSS_SELECTOR, '[data-test-new-update-dialog-footer-next]')

--- a/pages/registrations.py
+++ b/pages/registrations.py
@@ -33,5 +33,9 @@ class MyRegistrationsPage(OSFBasePage):
 
     view_button = Locator(By.CSS_SELECTOR, '[data-test-view-button]')
     update_button = Locator(By.CSS_SELECTOR, '[data-test-update-button]')
-    update_registration_dialogue = Locator(By.CSS_SELECTOR, '[data-test-new-update-dialog-main]')
-    update_registration_dialogue_next = Locator(By.CSS_SELECTOR, '[data-test-new-update-dialog-footer-next]')
+    update_registration_dialogue = Locator(
+        By.CSS_SELECTOR, '[data-test-new-update-dialog-main]'
+    )
+    update_registration_dialogue_next = Locator(
+        By.CSS_SELECTOR, '[data-test-new-update-dialog-footer-next]'
+    )

--- a/pages/registries.py
+++ b/pages/registries.py
@@ -76,19 +76,28 @@ class RegistrationDetailPage(GuidBasePage):
 
     narrative_summary = Locator(By.CSS_SELECTOR, '[data-test-read-only-response]')
     updates_dropdown = Locator(By.CSS_SELECTOR, '[data-test-update-button]')
-    update_registration_button = Locator(By.CSS_SELECTOR, '[data-test-update-dropdown-create-new-revision]')
-    update_registration_dialogue = Locator(By.CSS_SELECTOR, '[data-test-new-update-dialog-main]')
-    update_registration_dialogue_next = Locator(By.CSS_SELECTOR, '[data-test-new-update-dialog-footer-next]')
-
+    update_registration_button = Locator(
+        By.CSS_SELECTOR, '[data-test-update-dropdown-create-new-revision]'
+    )
+    update_registration_dialogue = Locator(
+        By.CSS_SELECTOR, '[data-test-new-update-dialog-main]'
+    )
+    update_registration_dialogue_next = Locator(
+        By.CSS_SELECTOR, '[data-test-new-update-dialog-footer-next]'
+    )
 
 
 class RegistrationJustificationForm(GuidBasePage):
     identity = Locator(By.CSS_SELECTOR, '[data-test-link-back-to-registration]')
 
-    justification_textbox = Locator(By.CSS_SELECTOR, 'textarea[name="revisionJustification"]')
+    justification_textbox = Locator(
+        By.CSS_SELECTOR, 'textarea[name="revisionJustification"]'
+    )
     justification_next_button = Locator(By.CSS_SELECTOR, '[data-test-goto-next-page]')
     cancel_update_button = Locator(By.CSS_SELECTOR, '[data-test-delete-button]')
-    cancel_update_modal = Locator(By.CSS_SELECTOR, 'div[data-analytics-scope="Delete button modal"]')
+    cancel_update_modal = Locator(
+        By.CSS_SELECTOR, 'div[data-analytics-scope="Delete button modal"]'
+    )
     confirm_cancel_button = Locator(By.CSS_SELECTOR, '[data-test-confirm-delete]')
 
     navbar_justification = Locator(By.CSS_SELECTOR, '[data-test-link="justification"]')
@@ -104,11 +113,14 @@ class RegistrationJustificationForm(GuidBasePage):
 class JustificationReviewForm(GuidBasePage):
     identity = Locator(By.ID, 'JustificationPageLabel')
 
-    link_to_registration = Locator(By.CSS_SELECTOR, '[data-analytics-name="Go to registration"]')
+    link_to_registration = Locator(
+        By.CSS_SELECTOR, '[data-analytics-name="Go to registration"]'
+    )
 
 
 class RegistrationAddNewPage(BaseRegistriesPage):
     url_addition = 'new'
+    url = settings.OSF_HOME + '/registries/osf/new'
     identity = Locator(
         By.CSS_SELECTOR, 'form[data-test-new-registration-form]', settings.LONG_TIMEOUT
     )

--- a/pages/registries.py
+++ b/pages/registries.py
@@ -87,6 +87,9 @@ class RegistrationJustificationForm(GuidBasePage):
 
     justification_textbox = Locator(By.CSS_SELECTOR, 'textarea[name="revisionJustification"]')
     justification_next_button = Locator(By.CSS_SELECTOR, '[data-test-goto-next-page]')
+    cancel_update_button = Locator(By.CSS_SELECTOR, '[data-test-delete-button]')
+    cancel_update_modal = Locator(By.CSS_SELECTOR, 'div[data-analytics-scope="Delete button modal"]')
+    confirm_cancel_button = Locator(By.CSS_SELECTOR, '[data-test-confirm-delete]')
 
     navbar_justification = Locator(By.CSS_SELECTOR, '[data-test-link="justification"]')
     navbar_review = Locator(By.CSS_SELECTOR, '[data-test-link="review"]')

--- a/pages/registries.py
+++ b/pages/registries.py
@@ -125,7 +125,6 @@ class JustificationReviewForm(GuidBasePage):
 
 class RegistrationAddNewPage(BaseRegistriesPage):
     url_addition = 'new'
-    url = settings.OSF_HOME + '/registries/osf/new'
     identity = Locator(
         By.CSS_SELECTOR, 'form[data-test-new-registration-form]', settings.LONG_TIMEOUT
     )

--- a/pages/registries.py
+++ b/pages/registries.py
@@ -112,6 +112,7 @@ class RegistrationJustificationForm(GuidBasePage):
 
     submit_revision = Locator(By.CSS_SELECTOR, '[data-test-submit-revision]')
     accept_changes = Locator(By.CSS_SELECTOR, '[data-test-accept-changes]')
+    toast_message = Locator(By.ID, 'toast-container')
 
 
 class JustificationReviewForm(GuidBasePage):

--- a/pages/registries.py
+++ b/pages/registries.py
@@ -101,8 +101,12 @@ class RegistrationJustificationForm(GuidBasePage):
     confirm_cancel_button = Locator(By.CSS_SELECTOR, '[data-test-confirm-delete]')
 
     navbar_justification = Locator(By.CSS_SELECTOR, '[data-test-link="justification"]')
+    navbar_summary = Locator(By.CSS_SELECTOR, '[data-test-link="1-summary"]')
     navbar_review = Locator(By.CSS_SELECTOR, '[data-test-link="review"]')
 
+    summary_review_questions = Locator(
+        By.CSS_SELECTOR, 'p[data-test-revised-responses-list-no-update]'
+    )
     summary_textbox = Locator(By.CSS_SELECTOR, 'textarea[name="__responseKey_summary"]')
     summary_review_button = Locator(By.CSS_SELECTOR, '[data-test-goto-review]')
 

--- a/pages/registries.py
+++ b/pages/registries.py
@@ -74,6 +74,35 @@ class RegistriesDiscoverPage(BaseRegistriesPage):
 class RegistrationDetailPage(GuidBasePage):
     identity = Locator(By.CSS_SELECTOR, '[data-test-registration-title]')
 
+    narrative_summary = Locator(By.CSS_SELECTOR, '[data-test-read-only-response]')
+    updates_dropdown = Locator(By.CSS_SELECTOR, '[data-test-update-button]')
+    update_registration_button = Locator(By.CSS_SELECTOR, '[data-test-update-dropdown-create-new-revision]')
+    update_registration_dialogue = Locator(By.CSS_SELECTOR, '[data-test-new-update-dialog-main]')
+    update_registration_dialogue_next = Locator(By.CSS_SELECTOR, '[data-test-new-update-dialog-footer-next]')
+
+
+
+class RegistrationJustificationForm(GuidBasePage):
+    identity = Locator(By.CSS_SELECTOR, '[data-test-link-back-to-registration]')
+
+    justification_textbox = Locator(By.CSS_SELECTOR, 'textarea[name="revisionJustification"]')
+    justification_next_button = Locator(By.CSS_SELECTOR, '[data-test-goto-next-page]')
+
+    navbar_justification = Locator(By.CSS_SELECTOR, '[data-test-link="justification"]')
+    navbar_review = Locator(By.CSS_SELECTOR, '[data-test-link="review"]')
+
+    summary_textbox = Locator(By.CSS_SELECTOR, 'textarea[name="__responseKey_summary"]')
+    summary_review_button = Locator(By.CSS_SELECTOR, '[data-test-goto-review]')
+
+    submit_revision = Locator(By.CSS_SELECTOR, '[data-test-submit-revision]')
+    accept_changes = Locator(By.CSS_SELECTOR, '[data-test-accept-changes]')
+
+
+class JustificationReviewForm(GuidBasePage):
+    identity = Locator(By.ID, 'JustificationPageLabel')
+
+    link_to_registration = Locator(By.CSS_SELECTOR, '[data-analytics-name="Go to registration"]')
+
 
 class RegistrationAddNewPage(BaseRegistriesPage):
     url_addition = 'new'

--- a/tests/test_my_registrations.py
+++ b/tests/test_my_registrations.py
@@ -73,7 +73,6 @@ class TestMyRegistrationsUserTwo:
 
 
 @markers.dont_run_on_prod
-@markers.core_functionality
 class TestRegistrationsVersioning:
     """This test navigates the test user through the entire workflow for updating a registration by creating a new version"""
 
@@ -124,10 +123,10 @@ class TestRegistrationsVersioning:
         except AttributeError:
             pass
 
-        my_registrations_page.update_button = (
-            registration_card.find_element_by_css_selector('[data-test-update-button]')
+        update_button = registration_card.find_element_by_css_selector(
+            '[data-test-update-button]'
         )
-        my_registrations_page.update_button.click()
+        update_button.click()
         my_registrations_page.update_registration_dialogue.present()
         my_registrations_page.update_registration_dialogue_next.click()
 
@@ -210,10 +209,10 @@ class TestRegistrationsVersioning:
         except AttributeError:
             pass
 
-        my_registrations_page.view_button = (
-            registration_card.find_element_by_css_selector('[data-test-view-button]')
+        view_button = registration_card.find_element_by_css_selector(
+            '[data-test-view-button]'
         )
-        my_registrations_page.view_button.click()
+        view_button.click()
         registration_detail_page = RegistrationDetailPage(driver)
 
         # Store the narrative summary text of the most recent update

--- a/tests/test_my_registrations.py
+++ b/tests/test_my_registrations.py
@@ -82,7 +82,9 @@ class TestRegistrationsVersioning:
         RegistrationJustificationForm(driver, verify=True)
         justification_page = RegistrationJustificationForm(driver)
         justification_page.justification_textbox.click()
-        justification_page.justification_textbox.send_keys('This justification is provided by selenium test automation.')
+        justification_page.justification_textbox.send_keys(
+            'This justification is provided by selenium test automation.'
+        )
         justification_page.justification_next_button.click()
 
         fake = Faker()
@@ -95,7 +97,11 @@ class TestRegistrationsVersioning:
         # Wait for justification field to update from "No Justification provided." to summary_paragraph
         WebDriverWait(driver, 10).until(
             EC.text_to_be_present_in_element(
-                (By.CSS_SELECTOR, 'p[data-test-review-response="revisionJustification"]'), 'selenium'
+                (
+                    By.CSS_SELECTOR,
+                    'p[data-test-review-response="revisionJustification"]',
+                ),
+                'selenium',
             )
         )
         # After the justification field updates, the front end needs a second before becoming usable.

--- a/tests/test_my_registrations.py
+++ b/tests/test_my_registrations.py
@@ -1,4 +1,6 @@
 import pytest
+import ipdb
+from faker import Faker
 
 import markers
 from pages.registrations import MyRegistrationsPage
@@ -6,6 +8,8 @@ from pages.registries import (
     RegistrationAddNewPage,
     RegistrationDetailPage,
     RegistrationDraftPage,
+    RegistrationJustificationForm,
+    JustificationReviewForm,
 )
 
 
@@ -59,3 +63,40 @@ class TestMyRegistrationsUserTwo:
         registrations_page.submissions_tab.click()
         registrations_page.public_registration_title.click()
         RegistrationDetailPage(driver, verify=True)
+
+
+class TestRegistrationsVersioning:
+    """This test navigates the test user through the entire workflow for updating a registration by creating a new version"""
+
+    def test_versioning_workflow(self, driver, must_be_logged_in):
+        my_registrations_page = MyRegistrationsPage(driver)
+        my_registrations_page.goto()
+        my_registrations_page.update_button.click()
+        my_registrations_page.update_registration_dialogue.present()
+        my_registrations_page.update_registration_dialogue_next.click()
+
+        RegistrationJustificationForm(driver, verify=True)
+        justification_page = RegistrationJustificationForm(driver)
+        justification_page.justification_textbox.click()
+        justification_page.justification_textbox.send_keys('This justification is provided by selenium test automation.')
+        justification_page.justification_next_button.click()
+        fake = Faker()
+        summary_paragraph = fake.sentence(nb_words=20)
+        justification_page.summary_textbox.click()
+        justification_page.summary_textbox.clear()
+        justification_page.summary_textbox.send_keys(summary_paragraph)
+        justification_page.summary_review_button.click()
+
+        ### BUG HERE: User needs to return to justification page for validation ###
+        justification_page.navbar_justification.click()
+        justification_page.navbar_review.click()
+
+        justification_page.submit_revision.click()
+        justification_page.accept_changes.click()
+
+        JustificationReviewForm(driver, verify=True)
+        review_form = JustificationReviewForm(driver)
+        review_form.link_to_registration.click()
+
+        registration_detail_page = RegistrationDetailPage(driver)
+        assert summary_paragraph in registration_detail_page.narrative_summary.text

--- a/tests/test_my_registrations.py
+++ b/tests/test_my_registrations.py
@@ -72,6 +72,8 @@ class TestMyRegistrationsUserTwo:
         RegistrationDetailPage(driver, verify=True)
 
 
+@markers.dont_run_on_prod
+@markers.core_functionality
 class TestRegistrationsVersioning:
     """This test navigates the test user through the entire workflow for updating a registration by creating a new version"""
 

--- a/tests/test_my_registrations.py
+++ b/tests/test_my_registrations.py
@@ -29,6 +29,15 @@ def get_registration_version_draft_id(href):
     return match.group(2)
 
 
+def delete_registration_version_draft(my_registrations_page, session_user_two):
+    update_in_progress_url = my_registrations_page.continue_update_button.get_attribute(
+        'href'
+    )
+    draft_id = get_registration_version_draft_id(update_in_progress_url)
+    api.osf_api.delete_registration_version_draft(session_user_two, draft_id)
+    my_registrations_page.goto()
+
+
 @markers.smoke_test
 @markers.core_functionality
 class TestMyRegistrationsPageEmpty:
@@ -85,18 +94,14 @@ class TestRegistrationsVersioning:
     """This test navigates the test user through the entire workflow for updating a registration by creating a new version"""
 
     def test_versioning_workflow(self, driver, must_be_logged_in_as_user_two):
-        session_user_two = osf_api.get_user_two_session()
         my_registrations_page = MyRegistrationsPage(driver)
         my_registrations_page.goto()
 
-        # Delete leftover update in progress
+        # Delete leftover version update in progress
         if my_registrations_page.continue_update_button.present():
-            update_in_progress_url = (
-                my_registrations_page.continue_update_button.get_attribute('href')
+            delete_registration_version_draft(
+                my_registrations_page, osf_api.get_user_two_session()
             )
-            draft_id = get_registration_version_draft_id(update_in_progress_url)
-            api.osf_api.delete_registration_version_draft(session_user_two, draft_id)
-            my_registrations_page.goto()
 
         my_registrations_page.update_button.click()
         my_registrations_page.update_registration_dialogue.present()
@@ -154,18 +159,14 @@ class TestRegistrationsVersioning:
         assert summary_paragraph in registration_detail_page.narrative_summary.text
 
     def test_delete_versioning(self, driver, must_be_logged_in_as_user_two):
-        session_user_two = osf_api.get_user_two_session()
         my_registrations_page = MyRegistrationsPage(driver)
         my_registrations_page.goto()
 
-        # Delete leftover update in progress
+        # Delete leftover version update in progress
         if my_registrations_page.continue_update_button.present():
-            update_in_progress_url = (
-                my_registrations_page.continue_update_button.get_attribute('href')
+            delete_registration_version_draft(
+                my_registrations_page, osf_api.get_user_two_session()
             )
-            draft_id = get_registration_version_draft_id(update_in_progress_url)
-            api.osf_api.delete_registration_version_draft(session_user_two, draft_id)
-            my_registrations_page.goto()
 
         my_registrations_page.view_button.click()
         registration_detail_page = RegistrationDetailPage(driver)

--- a/tests/test_my_registrations.py
+++ b/tests/test_my_registrations.py
@@ -1,5 +1,3 @@
-import time
-
 import pytest
 from faker import Faker
 from selenium.webdriver.common.by import By
@@ -85,8 +83,21 @@ class TestRegistrationsVersioning:
         justification_page.justification_textbox.send_keys(
             'This justification is provided by selenium test automation.'
         )
-        justification_page.justification_next_button.click()
 
+        justification_page.navbar_review.click()
+
+        # Wait for justification field to update from "No Justification provided." to summary_paragraph
+        WebDriverWait(driver, 10).until(
+            EC.text_to_be_present_in_element(
+                (
+                    By.CSS_SELECTOR,
+                    'p[data-test-review-response="revisionJustification"]',
+                ),
+                'selenium',
+            )
+        )
+
+        justification_page.navbar_summary.click()
         fake = Faker()
         summary_paragraph = fake.sentence(nb_words=20)
         justification_page.summary_textbox.click()
@@ -99,15 +110,13 @@ class TestRegistrationsVersioning:
             EC.text_to_be_present_in_element(
                 (
                     By.CSS_SELECTOR,
-                    'p[data-test-review-response="revisionJustification"]',
+                    'p[data-test-revised-responses-list]',
                 ),
-                'selenium',
+                'Provide a narrative summary of what is contained in this registration or how it differs from prior '
+                'registrations. If this project contains documents for a preregistration, please note that here',
             )
         )
-        # After the justification field updates, the front end needs a second before becoming usable.
-        # If we click the submit button before background process have completed,
-        # we get a red toast message that reads 'Your decision was not recorded.'
-        time.sleep(2)
+
         justification_page.submit_revision.click()
         justification_page.accept_changes.click()
 


### PR DESCRIPTION
<!-- Before you submit your Pull Request, please confirm that:

     - Any test that will create public data either has the `QAtest` tag or the `dont_run_on_production` marker
     - `core_functionality` is marked as such
     - Your tests will be able to run on *all* servers (all stagings, test)
 -->


## Purpose
Test the registries versioning workflow. This test should be set up to skip on production and run on the staging environments. Our Firefox, Chrome, and Edge users will have no registrations or drafts associated with the test accounts. Our OSF_USER_TWO account will have seeded test registrations (Public/Draft) for test purposes. This test will always grab the first registration on the My Registrations page with "versioning" in the title. 


## Summary of Changes
- Make version updates to an existing workflow
- Start a version update and delete it halfway through
- This test always cleans up any leftover version updates prior to starting


## Reviewer's Actions
`git fetch <remote> pull/207/head:registries-versioning`

Run this test using
`tests/test_my_registrations.py -sv`

## Testing Changes Moving Forward
- Add automated test to verify versioning from the project overview page. Implement this when project page is emberized
- Possibly create a test registration on production to monitor this feature


## Ticket
https://openscience.atlassian.net/browse/ENG-3247

## Testing Changes Moving Forward
- Add automated test to verify versioning from the project overview page. 


## Ticket
https://openscience.atlassian.net/browse/ENG-3247