### PR TITLE
[ENG-3927] - Update File List bulk option button locators

### DIFF
--- a/pages/project.py
+++ b/pages/project.py
@@ -141,14 +141,10 @@ class FilesPage(GuidBasePage):
     file_rows = GroupLocator(By.CSS_SELECTOR, '[data-test-file-list-item]')
     loading_indicator = Locator(By.CSS_SELECTOR, '.ball-pulse')
     file_selected_text = Locator(By.CSS_SELECTOR, '[data-test-file-selected-count]')
-    file_list_move_button = Locator(
-        By.CSS_SELECTOR, 'div._OptionBar__right_1qi2e2 > button:nth-child(1)'
-    )
-    file_list_copy_button = Locator(
-        By.CSS_SELECTOR, 'div._OptionBar__right_1qi2e2 > button:nth-child(2)'
-    )
+    file_list_move_button = Locator(By.CSS_SELECTOR, '[data-test-bulk-move-trigger]')
+    file_list_copy_button = Locator(By.CSS_SELECTOR, '[data-test-bulk-copy-trigger]')
     file_list_delete_button = Locator(
-        By.CSS_SELECTOR, 'div._OptionBar__right_1qi2e2 > button:nth-child(3)'
+        By.CSS_SELECTOR, '[data-test-bulk-delete-trigger]'
     )
     leftnav_osfstorage_link = Locator(
         By.CSS_SELECTOR, '[data-test-files-provider-link="osfstorage"]'

--- a/tests/test_project_files.py
+++ b/tests/test_project_files.py
@@ -391,8 +391,8 @@ class TestFilesPage:
                 '[data-test-file-download-share-trigger]'
             )
             menu_button.click()
-            move_button = row.find_element_by_css_selector('[data-test-copy-button]')
-            move_button.click()
+            copy_button = row.find_element_by_css_selector('[data-test-copy-button]')
+            copy_button.click()
             # Click the Project link on the Copy modal to go up a level and then click
             # the OSF Storage link. Then click the Copy button on the modal to copy
             # the file to OSF Storage.
@@ -533,10 +533,10 @@ class TestFilesPage:
                 '[data-test-file-download-share-trigger]'
             )
             menu_button.click()
-            move_button = row.find_element_by_css_selector(
+            download_button = row.find_element_by_css_selector(
                 '[data-test-download-button]'
             )
-            move_button.click()
+            download_button.click()
             # The actual file download usually takes a second or two, so instead of
             # using time.sleep() here we will just reload the page and wait for the
             # list items to reappear. That should be plenty of time.


### PR DESCRIPTION
<!-- Before you submit your Pull Request, please confirm that:

     - Any test that will create public data either has the `QAtest` tag or the `dont_run_on_production` marker
     - `core_functionality` is marked as such
     - Your tests will be able to run on *all* servers (all stagings, test)
 -->


## Purpose
To update locators for the Project Files List page bulk option buttons (move, copy, delete) to use data-test attributes instead of long css selectors.  Also correcting a few copy and paste errors of variable names.


## Summary of Changes

- pages/project.py - updating the locators for the move, copy, and delete buttons in the FilesPage class.
- tests/test_project_files.py - correcting a few copy/paste errors of variable names


## Reviewer's Actions
`git fetch <remote> pull/<PR_number>/head:testFix/project-files-data-test-attr`

Run this test using
`tests/test_project_files.py -s -v`

## Testing Changes Moving Forward
N/A


## Ticket
ENG-3927: SEL: Project Files Test - Update Files List Page Elements to Use data-test attributes
https://openscience.atlassian.net/browse/ENG-3927
