### PR TITLE
[ENG-3953] - Remove QUICK_TIMEOUT from custom colllection link

### DIFF
--- a/pages/project.py
+++ b/pages/project.py
@@ -71,9 +71,7 @@ class MyProjectsPage(OSFBasePage):
         By.CSS_SELECTOR,
         'div[data-rindex="0"] > div:first-child >' ' span:last-child > a:first-child',
     )
-    first_custom_collection = Locator(
-        By.CSS_SELECTOR, 'li[data-index="4"] span', settings.QUICK_TIMEOUT
-    )
+    first_custom_collection = Locator(By.CSS_SELECTOR, 'li[data-index="4"] span')
     first_collection_settings_button = Locator(
         By.CSS_SELECTOR, '.fa-ellipsis-v', settings.QUICK_TIMEOUT
     )


### PR DESCRIPTION
<!-- Before you submit your Pull Request, please confirm that:

     - Any test that will create public data either has the `QAtest` tag or the `dont_run_on_production` marker
     - `core_functionality` is marked as such
     - Your tests will be able to run on *all* servers (all stagings, test)
 -->


## Purpose
To fix test failures from the nightly Selenium Staging Tests test suite run in the my_projects.py tests for test_create_custom_collection and test_delete_custom_collection.


## Summary of Changes

- pages/project.py - deleting "settings.QUICK_TIMEOUT" from the "first_custom_collection" element in the MyProjectsPage class.  This will cause the wait for this element to default to the 10 second Timeout instead of the 4 second Quick Timeout wait.


## Reviewer's Actions
`git fetch <remote> pull/<PR_number>/head:testFix/my_projects_custom_collections`

Run this test using
`tests/test_my_projects.py -s -v`

## Testing Changes Moving Forward
N/A


## Ticket
ENG-3953: SEL: My Projects Page Test - Nightly Test Failures - Custom Collections
https://openscience.atlassian.net/browse/ENG-3953
