### PR TITLE
[ENG-3973] - Fix Preprints Custom Domain Test - Set Firefox Cookie Preference to level 4

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -47,6 +47,9 @@ def launch_driver(driver_name=settings.DRIVER, desired_capabilities=None):
             'text/plain, application/octet-stream, application/binary, text/csv, application/csv, '
             'application/excel, text/comma-separated-values, text/xml, application/xml, binary/octet-stream',
         )
+        # Block Third Party Tracking Cookies (Default in Firefox is now 5 which blocks
+        # all Cross-site cookies)
+        ffp.set_preference('network.cookie.cookieBehavior', 4)
         driver = driver_cls(
             command_executor=command_executor,
             desired_capabilities=desired_capabilities,
@@ -82,6 +85,9 @@ def launch_driver(driver_name=settings.DRIVER, desired_capabilities=None):
             'text/plain, application/octet-stream, application/binary, text/csv, application/csv, '
             'application/excel, text/comma-separated-values, text/xml, application/xml, binary/octet-stream',
         )
+        # Block Third Party Tracking Cookies (Default in Firefox is now 5 which blocks
+        # all Cross-site cookies)
+        ffp.set_preference('network.cookie.cookieBehavior', 4)
         driver = driver_cls(firefox_profile=ffp)
     elif driver_name == 'Edge' and not settings.HEADLESS:
         from msedge.selenium_tools import Edge


### PR DESCRIPTION
<!-- Before you submit your Pull Request, please confirm that:

     - Any test that will create public data either has the `QAtest` tag or the `dont_run_on_production` marker
     - `core_functionality` is marked as such
     - Your tests will be able to run on *all* servers (all stagings, test)
 -->


## Purpose
To fix nightly test failure in the Preprints Custom Domain tests as a result of Firefox updating its default cookie behavior to blocking all cross-site cookies.


## Summary of Changes

- utils.py - setting the Firefox Preference for cookie behavior back to level 4 which was the previous default. This will still block Third Party Tracking cookies but not block the OSF login cookie.


## Reviewer's Actions
`git fetch <remote> pull/<PR_number>/head:testFix/firefox-cookies`

Run this test using
`tests/test_preprints.py -s -v`

## Testing Changes Moving Forward
N/A


## Ticket
ENG-3973: SEL: Preprints Test - Staging Tests Failure - Firefox - TestProvidersWithCustomDomains::test_submit_page_loads[marxiv]
https://openscience.atlassian.net/browse/ENG-3973
