### PR TITLE
Skip the My Projects test again.

### DIFF
--- a/tests/test_my_projects.py
+++ b/tests/test_my_projects.py
@@ -21,6 +21,9 @@ def my_projects_page(driver):
     return my_projects_page
 
 
+@pytest.mark.skip(
+    reason='Skip this test because it just takes toooo loong to do anything.'
+)
 @markers.dont_run_on_prod
 @pytest.mark.usefixtures('must_be_logged_in')
 class TestMyProjectsPage:

--- a/tests/test_my_projects.py
+++ b/tests/test_my_projects.py
@@ -22,7 +22,7 @@ def my_projects_page(driver):
 
 
 @pytest.mark.skip(
-    reason='Skip this test because it just takes toooo loong to do anything.'
+    reason='Skip this test because it just takes toooo loong to do anything. We can revisit this if/when the page is emberized.'
 )
 @markers.dont_run_on_prod
 @pytest.mark.usefixtures('must_be_logged_in')


### PR DESCRIPTION
<!-- Before you submit your Pull Request, please confirm that:

     - Any test that will create public data either has the `QAtest` tag or the `dont_run_on_production` marker
     - `core_functionality` is marked as such
     - Your tests will be able to run on *all* servers (all stagings, test)
 -->


## Purpose
To skip the My Projects page test again since it is consistently failing in the Test environment every night and the page will probably not be fixed anytime soon.


## Summary of Changes

- tests/test_my_projects.py - add pytest skip marker to TestMyProjectsPage class.


## Reviewer's Actions
`git fetch <remote> pull/<PR_number>/head:testFix/skip-my-projects`

Run this test using
`tests/test_my_projects.py -s -v`

## Testing Changes Moving Forward
N/A


## Ticket
No Ticket
