### PR TITLE
[ENG-3792] - Add new tests for Preprints Moderation

### DIFF
--- a/api/osf_api.py
+++ b/api/osf_api.py
@@ -376,13 +376,15 @@ def update_node_public_attribute(session, node_id, status=False):
 
 
 def get_most_recent_preprint_node_id(session=None):
-    """Return the most recently submitted preprint node id"""
+    """Return the most recently published preprint node id"""
     if not session:
         session = get_default_session()
     url = '/v2/preprints/'
     data = session.get(url)['data']
     if data:
-        return data[0]['id']
+        for preprint in data:
+            if preprint['attributes']['is_published']:
+                return preprint['id']
     else:
         return None
 

--- a/api/osf_api.py
+++ b/api/osf_api.py
@@ -688,3 +688,53 @@ def get_preprint_publish_and_review_states(session=None, preprint_node=None):
         return [publish_state, review_state]
     else:
         return None
+
+
+def accept_moderated_preprint(session=None, preprint_node=None):
+    """Accept a moderated preprint by creating an 'accept' review_action record for a
+    given preprint node id.
+    """
+    if not session:
+        session = get_default_session()
+    review_url = '/v2/preprints/{}/review_actions/'.format(preprint_node)
+    review_payload = {
+        'data': {
+            'type': 'review_actions',
+            'attributes': {
+                'trigger': 'accept',
+                'comment': 'Preprint Accepted via OSF api',
+            },
+            'relationships': {
+                'target': {'data': {'id': preprint_node, 'type': 'preprints'}}
+            },
+        }
+    }
+    session.post(
+        url=review_url,
+        item_type='review-actions',
+        raw_body=json.dumps(review_payload),
+    )
+
+
+def create_preprint_withdrawal_request(session=None, preprint_node=None):
+    """Create a withdrawal request for a given preprint node id."""
+    if not session:
+        session = get_default_session()
+    url = '/v2/preprints/{}/requests/'.format(preprint_node)
+    request_payload = {
+        'data': {
+            'type': 'preprint-requests',
+            'attributes': {
+                'request_type': 'withdrawal',
+                'comment': 'Withdrawal Request via OSF api',
+            },
+            'relationships': {
+                'target': {'data': {'id': preprint_node, 'type': 'preprints'}}
+            },
+        }
+    }
+    session.post(
+        url=url,
+        item_type='preprint-requests',
+        raw_body=json.dumps(request_payload),
+    )

--- a/api/osf_api.py
+++ b/api/osf_api.py
@@ -19,6 +19,13 @@ def get_default_session():
     )
 
 
+def get_user_two_session():
+    return client.Session(
+        api_base_url=settings.API_DOMAIN,
+        auth=(settings.USER_TWO, settings.USER_TWO_PASSWORD),
+    )
+
+
 def create_project(session, title='osf selenium test', tags=None, **kwargs):
     """Create a project for your current user through the OSF api.
 
@@ -663,5 +670,19 @@ def get_moderation_type_for_provider(
     data = session.get(url)['data']
     if data:
         return data['attributes']['reviews_workflow']
+    else:
+        return None
+
+
+def get_preprint_publish_and_review_states(session=None, preprint_node=None):
+    """Return the publish and review states for the given preprint node id"""
+    if not session:
+        session = get_default_session()
+    url = '/v2/preprints/{}/'.format(preprint_node)
+    data = session.get(url)['data']
+    if data:
+        publish_state = data['attributes']['is_published']
+        review_state = data['attributes']['reviews_state']
+        return [publish_state, review_state]
     else:
         return None

--- a/pages/preprints.py
+++ b/pages/preprints.py
@@ -246,11 +246,13 @@ class PreprintDetailPage(GuidBasePage, BasePreprintPage):
     identity = Locator(By.ID, 'preprintTitle', settings.LONG_TIMEOUT)
     title = Locator(By.ID, 'preprintTitle', settings.LONG_TIMEOUT)
     status = Locator(By.CSS_SELECTOR, 'span._status-badge_7ivjq4')
+    status_explanation = Locator(By.CSS_SELECTOR, 'div.status-explanation')
     make_decision_button = Locator(
         By.CSS_SELECTOR, 'button.btn.dropdown-toggle.btn-success'
     )
     accept_radio_button = Locator(By.CSS_SELECTOR, 'input[value="accepted"]')
     reject_radio_button = Locator(By.CSS_SELECTOR, 'input[value="rejected"]')
+    withdraw_radio_button = Locator(By.CSS_SELECTOR, 'input[value="withdrawn"]')
     reason_textarea = Locator(By.CSS_SELECTOR, 'textarea.form-control.ember-text-area')
     submit_decision_button = Locator(By.ID, 'submit-btn')
     view_page = Locator(By.ID, 'view-page')

--- a/pages/preprints.py
+++ b/pages/preprints.py
@@ -245,6 +245,14 @@ class PreprintDetailPage(GuidBasePage, BasePreprintPage):
 
     identity = Locator(By.ID, 'preprintTitle', settings.LONG_TIMEOUT)
     title = Locator(By.ID, 'preprintTitle', settings.LONG_TIMEOUT)
+    status = Locator(By.CSS_SELECTOR, 'span._status-badge_7ivjq4')
+    make_decision_button = Locator(
+        By.CSS_SELECTOR, 'button.btn.dropdown-toggle.btn-success'
+    )
+    accept_radio_button = Locator(By.CSS_SELECTOR, 'input[value="accepted"]')
+    reject_radio_button = Locator(By.CSS_SELECTOR, 'input[value="rejected"]')
+    reason_textarea = Locator(By.CSS_SELECTOR, 'textarea.form-control.ember-text-area')
+    submit_decision_button = Locator(By.ID, 'submit-btn')
     view_page = Locator(By.ID, 'view-page')
     views_downloads_counts = Locator(
         By.CSS_SELECTOR, 'div.share-row.p-sm.osf-box-lt.clearfix > div'
@@ -265,3 +273,87 @@ class PreprintDetailPage(GuidBasePage, BasePreprintPage):
 class ReviewsDashboardPage(OSFBasePage):
     url = settings.OSF_HOME + '/reviews'
     identity = Locator(By.CLASS_NAME, '_reviews-dashboard-header_jdu5ey')
+    loading_indicator = Locator(By.CSS_SELECTOR, '.ball-scale')
+    provider_group_links = GroupLocator(
+        By.CSS_SELECTOR, 'li._provider-links-component_gp8jcl'
+    )
+
+    def click_provider_group_link(self, provider_name, link_name):
+        """Search through the Provider Groups in the sidebar on the right side of the
+        Reviews Dashboard page to find the group with the given provider_name.  When
+        the provider group is found, then search through the links in the group for the
+        given link_name. Click this link when found.
+        """
+        for provider_group in self.provider_group_links:
+            group_name = provider_group.find_element_by_css_selector(
+                'span._provider-name_gp8jcl'
+            )
+            if provider_name == group_name.text:
+                links = provider_group.find_elements_by_css_selector(
+                    'ul._provider-links_gp8jcl > li > a'
+                )
+                for link in links:
+                    if link_name in link.text:
+                        link.click()
+                        break
+                break
+
+
+class BaseReviewsPage(OSFBasePage):
+    """The base page from which all preprint provider review pages inherit."""
+
+    base_url = settings.OSF_HOME + '/reviews/preprints/'
+    url_addition = ''
+    navbar = ComponentLocator(PreprintsNavbar)
+    title = Locator(By.CLASS_NAME, '_provider-title_hcnzoe')
+
+    def __init__(self, driver, verify=False, provider=None):
+        self.provider = provider
+        if provider:
+            self.provider_id = provider['id']
+            self.provider_name = provider['attributes']['name']
+
+        super().__init__(driver, verify)
+
+    @property
+    def url(self):
+        """Set the URL based on the provider domain."""
+        return urljoin(self.base_url, self.provider_id) + '/' + self.url_addition
+
+    def verify(self):
+        """Return true if you are on the expected page.
+        Checks both the general page identity and the branding.
+        """
+        if self.provider:
+            return super().verify() and self.provider_name in self.title.text
+        return super().verify()
+
+
+class ReviewsSubmissionsPage(BaseReviewsPage):
+    identity = Locator(By.CLASS_NAME, '_reviews-list-heading_k45x8p')
+    no_submissions = Locator(
+        By.CSS_SELECTOR,
+        'div._reviews-list-body_k45x8p > div.text-center.p-v-md._moderation-list-row_xkm0pa',
+    )
+    loading_indicator = Locator(By.CSS_SELECTOR, '.ball-scale')
+    submissions = GroupLocator(By.CSS_SELECTOR, 'div._moderation-list-row_xkm0pa')
+
+    def click_submission_row(self, provider_id, preprint_id):
+        """Search through the rows of submitted preprints on the Reviews Submissions
+        page to find the preprint that has the given preprint_id in its url. When the
+        row is found click it to open the Preprint Detail page for that preprint.
+        """
+        for row in self.submissions:
+            url = row.find_element_by_css_selector('a').get_attribute('href')
+            node_id = url.split(provider_id + '/', 1)[1]
+            if node_id == preprint_id:
+                row.click()
+                break
+
+
+class PreprintPageNotFoundPage(OSFBasePage):
+    identity = Locator(By.CSS_SELECTOR, 'div.preprint-header.preprint-header-error')
+    page_header = Locator(
+        By.CSS_SELECTOR,
+        'div.preprint-header.preprint-header-error > div > div > div > h1',
+    )

--- a/pages/preprints.py
+++ b/pages/preprints.py
@@ -338,6 +338,10 @@ class ReviewsSubmissionsPage(BaseReviewsPage):
         'div._reviews-list-body_k45x8p > div.text-center.p-v-md._moderation-list-row_xkm0pa',
     )
     loading_indicator = Locator(By.CSS_SELECTOR, '.ball-scale')
+    withdrawal_requests_tab = Locator(
+        By.CSS_SELECTOR,
+        'div._flex-container_hcnzoe > div:nth-child(3) > ul > li:nth-child(2) > a',
+    )
     submissions = GroupLocator(By.CSS_SELECTOR, 'div._moderation-list-row_xkm0pa')
 
     def click_submission_row(self, provider_id, preprint_id):
@@ -346,6 +350,25 @@ class ReviewsSubmissionsPage(BaseReviewsPage):
         row is found click it to open the Preprint Detail page for that preprint.
         """
         for row in self.submissions:
+            url = row.find_element_by_css_selector('a').get_attribute('href')
+            node_id = url.split(provider_id + '/', 1)[1]
+            if node_id == preprint_id:
+                row.click()
+                break
+
+
+class ReviewsWithdrawalsPage(BaseReviewsPage):
+    url_addition = 'withdrawals'
+    identity = Locator(By.CLASS_NAME, '_reviews-list-heading_k45x8p')
+    loading_indicator = Locator(By.CSS_SELECTOR, '.ball-scale')
+    requests = GroupLocator(By.CSS_SELECTOR, 'div._moderation-list-row_17iwzt')
+
+    def click_requests_row(self, provider_id, preprint_id):
+        """Search through the rows of requests on the Reviews Withdrawal Requests
+        page to find the preprint that has the given preprint_id in its url. When the
+        row is found click it to open the Preprint Detail page for that preprint.
+        """
+        for row in self.requests:
             url = row.find_element_by_css_selector('a').get_attribute('href')
             node_id = url.split(provider_id + '/', 1)[1]
             if node_id == preprint_id:

--- a/tests/test_preprints.py
+++ b/tests/test_preprints.py
@@ -14,13 +14,17 @@ from selenium.webdriver.support.ui import WebDriverWait
 import markers
 import settings
 from api import osf_api
+from pages.login import logout
 from pages.preprints import (
     PreprintDetailPage,
     PreprintDiscoverPage,
     PreprintEditPage,
     PreprintLandingPage,
+    PreprintPageNotFoundPage,
     PreprintSubmitPage,
     PreprintWithdrawPage,
+    ReviewsDashboardPage,
+    ReviewsSubmissionsPage,
 )
 from utils import find_current_browser
 
@@ -304,6 +308,197 @@ class TestPreprintWorkflow:
                     preprint_detail_page.guid
                 )
             )
+
+
+@markers.dont_run_on_prod
+class TestPreprintModeration:
+    def test_accept_pre_moderated_preprint(self, session, driver, must_be_logged_in):
+        """Test the acceptance of a preprint submission to a Preprint Provider with a
+        Pre-moderation workflow. In this workflow a preprint is submitted to the
+        preprint service provider but is not yet published. A moderator must then
+        'accept' the preprint submission before it is published and publicly accessible.
+        NOTE: In this test case User One is used to login to OSF and must therefore be
+        setup through the admin app as a moderator or admin for the Preprint Provider
+        being used.  The test will use the OSF api to create a submitted preprint, but
+        the preprint will be submitted using the session credentials of User Two so
+        that the preprint submitter and moderator are different users.
+        """
+        # The following Preprint Provider must be setup in each testing environment.
+        provider_id = 'selpremod'
+        provider_name = 'Selenium Pre-moderation'
+        preprint_title = 'OSF Selenium Pre-moderation Preprint'
+
+        # NOTE: Using User Two to create the preprint through the api so that the user
+        # that submits the preprint is different from the user that accepts or rejects
+        # it.
+        session_user_two = osf_api.get_user_two_session()
+        preprint_node = osf_api.create_preprint(
+            session_user_two,
+            provider_id=provider_id,
+            title=preprint_title,
+            license_name='CC0 1.0 Universal',
+            subject_name='Engineering',
+        )
+        # Use the api to verify that the Preprint is not yet published and that its
+        # review status is 'pending'.
+        assert not (
+            osf_api.get_preprint_publish_and_review_states(preprint_node=preprint_node)[
+                0
+            ]
+        )
+        assert (
+            osf_api.get_preprint_publish_and_review_states(preprint_node=preprint_node)[
+                1
+            ]
+            == 'pending'
+        )
+        # Load Reviews Dashboard page first and then click the Submissions link for the
+        # Pre-moderation provider to go to that page.
+        reviews_dashboard_page = ReviewsDashboardPage(driver)
+        reviews_dashboard_page.goto()
+        assert ReviewsDashboardPage(driver, verify=True)
+        reviews_dashboard_page.loading_indicator.here_then_gone()
+        reviews_dashboard_page.click_provider_group_link(provider_name, 'Submissions')
+        submissions_page = ReviewsSubmissionsPage(driver, verify=True)
+        submissions_page.loading_indicator.here_then_gone()
+        # On the Reviews Submissions page, click the row for the preprint that was just
+        # submitted above. It should be the first in the list since they are sorted
+        # newest to oldest.
+        submissions_page.click_submission_row(provider_id, preprint_node)
+        preprint_detail_page = PreprintDetailPage(driver, verify=True)
+        WebDriverWait(driver, 5).until(
+            EC.element_to_be_clickable(
+                (By.CSS_SELECTOR, 'button.btn.dropdown-toggle.btn-success')
+            )
+        )
+        # Verify that the Preprint has a Pending status in the status bar
+        assert preprint_detail_page.status.text == 'pending'
+        # Click the Make decision button to reveal the review options. Then click
+        # the Accept radio button, enter a reason in the text box and click the
+        # Submit decision button to complete the review.
+        preprint_detail_page.make_decision_button.click()
+        preprint_detail_page.accept_radio_button.click()
+        preprint_detail_page.reason_textarea.send_keys_deliberately(
+            'Selenium Testing - Accepting Pre-Moderated Preprint'
+        )
+        preprint_detail_page.submit_decision_button.click()
+        # Should end up back on the Reviews Submission page
+        assert ReviewsSubmissionsPage(driver, verify=True)
+        # Use the api to verify that the Preprint is now published and that its review
+        # status is now 'accepted'.
+        assert osf_api.get_preprint_publish_and_review_states(
+            preprint_node=preprint_node
+        )[0]
+        assert (
+            osf_api.get_preprint_publish_and_review_states(preprint_node=preprint_node)[
+                1
+            ]
+            == 'accepted'
+        )
+        # Logout and navigate to the Preprint Detail page since it is now public.
+        logout(driver)
+        preprint_page = PreprintDetailPage(driver, guid=preprint_node)
+        preprint_page.goto()
+        assert PreprintDetailPage(driver, verify=True)
+        WebDriverWait(driver, 5).until(EC.visibility_of(preprint_page.title))
+        assert preprint_page.title.text == preprint_title
+        assert provider_id in driver.current_url
+
+    def test_reject_pre_moderated_preprint(
+        self, session, driver, log_in_if_not_already
+    ):
+        """Test the rejection of a preprint submission to a Preprint Provider with a
+        Pre-moderation workflow. In this workflow a preprint is submitted to the
+        preprint service provider but is not yet published. A moderator will then
+        'reject' the preprint submission.  The rejected preprint will never become
+        published or publicly accessible.
+        NOTE: In this test case User One is used to login to OSF and must therefore be
+        setup through the admin app as a moderator or admin for the Preprint Provider
+        being used.  The test will use the OSF api to create a submitted preprint, but
+        the preprint will be submitted using the session credentials of User Two so
+        that the preprint submitter and moderator are different users.
+        """
+        # The following Preprint Provider must be setup in each testing environment.
+        provider_id = 'selpremod'
+        provider_name = 'Selenium Pre-moderation'
+        preprint_title = 'OSF Selenium Pre-moderation Preprint'
+
+        # NOTE: Using User Two to create the preprint through the api so that the user
+        # that submits the preprint is different from the user that accepts or rejects
+        # it.
+        session_user_two = osf_api.get_user_two_session()
+        preprint_node = osf_api.create_preprint(
+            session_user_two,
+            provider_id=provider_id,
+            title=preprint_title,
+            license_name='CC0 1.0 Universal',
+            subject_name='Engineering',
+        )
+        # Use the api to verify that the Preprint is not yet published and that its
+        # review status is 'pending'.
+        assert not (
+            osf_api.get_preprint_publish_and_review_states(preprint_node=preprint_node)[
+                0
+            ]
+        )
+        assert (
+            osf_api.get_preprint_publish_and_review_states(preprint_node=preprint_node)[
+                1
+            ]
+            == 'pending'
+        )
+        # Load Reviews Dashboard page first and then click the Submissions link for the
+        # Pre-moderation provider to go to that page.
+        reviews_dashboard_page = ReviewsDashboardPage(driver)
+        reviews_dashboard_page.goto()
+        assert ReviewsDashboardPage(driver, verify=True)
+        reviews_dashboard_page.loading_indicator.here_then_gone()
+        reviews_dashboard_page.click_provider_group_link(provider_name, 'Submissions')
+        submissions_page = ReviewsSubmissionsPage(driver, verify=True)
+        submissions_page.loading_indicator.here_then_gone()
+        # On the Reviews Submissions page, click the row for the preprint that was just
+        # submitted above. It should be the first in the list since they are sorted
+        # newest to oldest.
+        submissions_page.click_submission_row(provider_id, preprint_node)
+        preprint_detail_page = PreprintDetailPage(driver, verify=True)
+        WebDriverWait(driver, 5).until(
+            EC.element_to_be_clickable(
+                (By.CSS_SELECTOR, 'button.btn.dropdown-toggle.btn-success')
+            )
+        )
+        # Verify that the Preprint has a Pending status in the status bar
+        assert preprint_detail_page.status.text == 'pending'
+        # Click the Make decision button to reveal the review options. Then click
+        # the Reject radio button, enter a reason in the text box and click the
+        # Submit decision button to complete the review.
+        preprint_detail_page.make_decision_button.click()
+        preprint_detail_page.reject_radio_button.click()
+        preprint_detail_page.reason_textarea.send_keys_deliberately(
+            'Selenium Testing - Rejecting Pre-Moderated Preprint'
+        )
+        preprint_detail_page.submit_decision_button.click()
+        # Should end up back on the Reviews Submission page
+        assert ReviewsSubmissionsPage(driver, verify=True)
+        # Use the api to verify that the Preprint is still not published and that its
+        # review status is now 'rejected'.
+        assert not (
+            osf_api.get_preprint_publish_and_review_states(preprint_node=preprint_node)[
+                0
+            ]
+        )
+        assert (
+            osf_api.get_preprint_publish_and_review_states(preprint_node=preprint_node)[
+                1
+            ]
+            == 'rejected'
+        )
+        # Logout and attempt to navigate to the Preprint Detail page. We should get a
+        # Page Not Found page since the rejected preprint is not public.
+        logout(driver)
+        preprint_page = PreprintDetailPage(driver, guid=preprint_node)
+        preprint_page.goto(expect_redirect_to=PreprintPageNotFoundPage)
+        page_not_found_page = PreprintPageNotFoundPage(driver, verify=True)
+        assert page_not_found_page.page_header.text == 'Page not found'
 
 
 @markers.core_functionality

--- a/tests/test_preprints.py
+++ b/tests/test_preprints.py
@@ -25,6 +25,7 @@ from pages.preprints import (
     PreprintWithdrawPage,
     ReviewsDashboardPage,
     ReviewsSubmissionsPage,
+    ReviewsWithdrawalsPage,
 )
 from utils import find_current_browser
 
@@ -500,6 +501,200 @@ class TestPreprintModeration:
         page_not_found_page = PreprintPageNotFoundPage(driver, verify=True)
         assert page_not_found_page.page_header.text == 'Page not found'
 
+    def test_approve_withdrawal_request_pre_moderated_preprint(
+        self, session, driver, log_in_if_not_already
+    ):
+        """Test the approval of a Withdrawal Request for a preprint submitted and
+        accepted by a preprint provider with a Pre-moderation workflow. In this
+        workflow the moderator will approve/accept the withdrawal request and the
+        public preprint will be replaced with a Withdrawn tombstone page in OSF. The
+        test will use the OSF api to create a submitted preprint and to accept the
+        preprint and create the withdrawal request record. The actual test steps will
+        thus start at the point where the moderator takes action from the Reviews
+        Dashboard page to approve the withdrawal request.
+        NOTE: In this test case User One is used to login to OSF and must therefore be
+        setup through the admin app as a moderator or admin for the Preprint Provider
+        being used.
+        """
+        # The following Preprint Provider must be setup in each testing environment.
+        provider_id = 'selpremod'
+        provider_name = 'Selenium Pre-moderation'
+        preprint_title = 'OSF Selenium Pre-moderation Preprint'
+
+        # NOTE: Using User Two to create the preprint through the api so that the user
+        # that submits the preprint is different from the user that accepts or rejects
+        # it.
+        session_user_two = osf_api.get_user_two_session()
+        preprint_node = osf_api.create_preprint(
+            session_user_two,
+            provider_id=provider_id,
+            title=preprint_title,
+            license_name='CC0 1.0 Universal',
+            subject_name='Engineering',
+        )
+        # Set session to None before calling accept_preprint so that the api function
+        # will use the default User One session which should have the permissions as
+        # a moderator to be able to accept the preprint.
+        osf_api.accept_moderated_preprint(session=None, preprint_node=preprint_node)
+        # Next use the api to create a withdrawal request (using User Two again)
+        osf_api.create_preprint_withdrawal_request(
+            session=session_user_two, preprint_node=preprint_node
+        )
+        # Load Reviews Dashboard page first and then click the Submissions link for the
+        # Pre-moderation provider to go to that page.
+        reviews_dashboard_page = ReviewsDashboardPage(driver)
+        reviews_dashboard_page.goto()
+        assert ReviewsDashboardPage(driver, verify=True)
+        reviews_dashboard_page.loading_indicator.here_then_gone()
+        reviews_dashboard_page.click_provider_group_link(provider_name, 'Submissions')
+        submissions_page = ReviewsSubmissionsPage(driver, verify=True)
+        # Click the Withdrawal Requests tab
+        submissions_page.withdrawal_requests_tab.click()
+        withdrawals_page = ReviewsWithdrawalsPage(driver, verify=True)
+        withdrawals_page.loading_indicator.here_then_gone()
+        # On the Withdrawal Requests page, click the row for the preprint that was just
+        # submitted above. It should be the first in the list since they are sorted
+        # newest to oldest.
+        withdrawals_page.click_requests_row(provider_id, preprint_node)
+        preprint_detail_page = PreprintDetailPage(driver, verify=True)
+        WebDriverWait(driver, 5).until(
+            EC.element_to_be_clickable(
+                (By.CSS_SELECTOR, 'button.btn.dropdown-toggle.btn-success')
+            )
+        )
+        # Verify that the Preprint has a Pending status in the status bar
+        assert preprint_detail_page.status.text == 'pending'
+        # Click the Make decision button to reveal the review options. Then click
+        # the Approve radio button, enter a reason in the text box and click the
+        # Submit decision button to complete the review.
+        preprint_detail_page.make_decision_button.click()
+        preprint_detail_page.accept_radio_button.click()
+        preprint_detail_page.reason_textarea.clear()
+        preprint_detail_page.reason_textarea.send_keys_deliberately(
+            'Selenium Testing - Approving Withdrawal Request of Pre-Moderated Preprint'
+        )
+        preprint_detail_page.submit_decision_button.click()
+        # Should end up back on the Reviews Submission page
+        assert ReviewsSubmissionsPage(driver, verify=True)
+        # Use the api to verify that the Preprint is not published and that its review
+        # status is now 'withdrawn'.
+        assert not osf_api.get_preprint_publish_and_review_states(
+            preprint_node=preprint_node
+        )[0]
+        assert (
+            osf_api.get_preprint_publish_and_review_states(preprint_node=preprint_node)[
+                1
+            ]
+            == 'withdrawn'
+        )
+        # Logout and navigate to the Preprint Detail page. We should see a Withdrawn
+        # tombstone page.
+        logout(driver)
+        preprint_page = PreprintDetailPage(driver, guid=preprint_node)
+        preprint_page.goto()
+        assert PreprintDetailPage(driver, verify=True)
+        WebDriverWait(driver, 5).until(EC.visibility_of(preprint_page.title))
+        assert preprint_page.title.text == preprint_title
+        assert (
+            preprint_page.status_explanation.text == 'This preprint has been withdrawn.'
+        )
+
+    def test_decline_withdrawal_request_pre_moderated_preprint(
+        self, session, driver, log_in_if_not_already
+    ):
+        """Test the declining of a Withdrawal Request for a preprint submitted and
+        accepted by a preprint provider with a Pre-moderation workflow. In this
+        workflow the moderator will decline the withdrawal request and the preprint
+        will remain accepted and publicly accessible. The test will use the OSF api
+        to create a submitted preprint and to accept the preprint and create the
+        withdrawal request record. The actual test steps will thus start at the point
+        where the moderator takes action from the Reviews Dashboard page to decline
+        the withdrawal request.
+        NOTE: In this test case User One is used to login to OSF and must therefore be
+        setup through the admin app as a moderator or admin for the Preprint Provider
+        being used.
+        """
+        # The following Preprint Provider must be setup in each testing environment.
+        provider_id = 'selpremod'
+        provider_name = 'Selenium Pre-moderation'
+        preprint_title = 'OSF Selenium Pre-moderation Preprint'
+
+        # NOTE: Using User Two to create the preprint through the api so that the user
+        # that submits the preprint is different from the user that accepts or rejects
+        # it.
+        session_user_two = osf_api.get_user_two_session()
+        preprint_node = osf_api.create_preprint(
+            session_user_two,
+            provider_id=provider_id,
+            title=preprint_title,
+            license_name='CC0 1.0 Universal',
+            subject_name='Engineering',
+        )
+        # Set session to None before calling accept_preprint so that the api function
+        # will use the default User One session which should have the permissions as
+        # a moderator to be able to accept the preprint.
+        osf_api.accept_moderated_preprint(session=None, preprint_node=preprint_node)
+        # Next use the api to create a withdrawal request (using User Two again)
+        osf_api.create_preprint_withdrawal_request(
+            session=session_user_two, preprint_node=preprint_node
+        )
+        # Load Reviews Dashboard page first and then click the Submissions link for the
+        # Pre-moderation provider to go to that page.
+        reviews_dashboard_page = ReviewsDashboardPage(driver)
+        reviews_dashboard_page.goto()
+        assert ReviewsDashboardPage(driver, verify=True)
+        reviews_dashboard_page.loading_indicator.here_then_gone()
+        reviews_dashboard_page.click_provider_group_link(provider_name, 'Submissions')
+        submissions_page = ReviewsSubmissionsPage(driver, verify=True)
+        # Click the Withdrawal Requests tab
+        submissions_page.withdrawal_requests_tab.click()
+        withdrawals_page = ReviewsWithdrawalsPage(driver, verify=True)
+        withdrawals_page.loading_indicator.here_then_gone()
+        # On the Withdrawal Requests page, click the row for the preprint that was just
+        # submitted above. It should be the first in the list since they are sorted
+        # newest to oldest.
+        withdrawals_page.click_requests_row(provider_id, preprint_node)
+        preprint_detail_page = PreprintDetailPage(driver, verify=True)
+        WebDriverWait(driver, 5).until(
+            EC.element_to_be_clickable(
+                (By.CSS_SELECTOR, 'button.btn.dropdown-toggle.btn-success')
+            )
+        )
+        # Verify that the Preprint has a Pending status in the status bar
+        assert preprint_detail_page.status.text == 'pending'
+        # Click the Make decision button to reveal the review options. Then click
+        # the Decline radio button, enter a reason in the text box and click the
+        # Submit decision button to complete the review.
+        preprint_detail_page.make_decision_button.click()
+        preprint_detail_page.reject_radio_button.click()
+        preprint_detail_page.reason_textarea.clear()
+        preprint_detail_page.reason_textarea.send_keys_deliberately(
+            'Selenium Testing - Declining Withdrawal Request of Pre-Moderated Preprint'
+        )
+        preprint_detail_page.submit_decision_button.click()
+        # Should end up back on the Reviews Submission page
+        assert ReviewsSubmissionsPage(driver, verify=True)
+        # Use the api to verify that the Preprint is still published and that its review
+        # status is still 'accepted'.
+        assert osf_api.get_preprint_publish_and_review_states(
+            preprint_node=preprint_node
+        )[0]
+        assert (
+            osf_api.get_preprint_publish_and_review_states(preprint_node=preprint_node)[
+                1
+            ]
+            == 'accepted'
+        )
+        # Logout and navigate to the Preprint Detail page which should still be publicly
+        # accessible.
+        logout(driver)
+        preprint_page = PreprintDetailPage(driver, guid=preprint_node)
+        preprint_page.goto()
+        assert PreprintDetailPage(driver, verify=True)
+        WebDriverWait(driver, 5).until(EC.visibility_of(preprint_page.title))
+        assert preprint_page.title.text == preprint_title
+        assert provider_id in driver.current_url
+
     def test_accept_post_moderated_preprint(
         self, session, driver, log_in_if_not_already
     ):
@@ -689,6 +884,200 @@ class TestPreprintModeration:
         assert (
             preprint_page.status_explanation.text == 'This preprint has been withdrawn.'
         )
+
+    def test_approve_withdrawal_request_post_moderated_preprint(
+        self, session, driver, log_in_if_not_already
+    ):
+        """Test the approval of a Withdrawal Request for a preprint submitted and
+        accepted by a preprint provider with a Post-moderation workflow. In this
+        workflow the moderator will approve/accept the withdrawal request and the
+        public preprint will be replaced with a Withdrawn tombstone page in OSF. The
+        test will use the OSF api to create a submitted preprint and to accept the
+        preprint and create the withdrawal request record. The actual test steps will
+        thus start at the point where the moderator takes action from the Reviews
+        Dashboard page to approve the withdrawal request.
+        NOTE: In this test case User One is used to login to OSF and must therefore be
+        setup through the admin app as a moderator or admin for the Preprint Provider
+        being used.
+        """
+        # The following Preprint Provider must be setup in each testing environment.
+        provider_id = 'selpostmod'
+        provider_name = 'Selenium Post-moderation'
+        preprint_title = 'OSF Selenium Post-moderation Preprint'
+
+        # NOTE: Using User Two to create the preprint through the api so that the user
+        # that submits the preprint is different from the user that accepts or rejects
+        # it.
+        session_user_two = osf_api.get_user_two_session()
+        preprint_node = osf_api.create_preprint(
+            session_user_two,
+            provider_id=provider_id,
+            title=preprint_title,
+            license_name='CC0 1.0 Universal',
+            subject_name='Engineering',
+        )
+        # Set session to None before calling accept_preprint so that the api function
+        # will use the default User One session which should have the permissions as
+        # a moderator to be able to accept the preprint.
+        osf_api.accept_moderated_preprint(session=None, preprint_node=preprint_node)
+        # Next use the api to create a withdrawal request (using User Two again)
+        osf_api.create_preprint_withdrawal_request(
+            session=session_user_two, preprint_node=preprint_node
+        )
+        # Load Reviews Dashboard page first and then click the Submissions link for the
+        # Post-moderation provider to go to that page.
+        reviews_dashboard_page = ReviewsDashboardPage(driver)
+        reviews_dashboard_page.goto()
+        assert ReviewsDashboardPage(driver, verify=True)
+        reviews_dashboard_page.loading_indicator.here_then_gone()
+        reviews_dashboard_page.click_provider_group_link(provider_name, 'Submissions')
+        submissions_page = ReviewsSubmissionsPage(driver, verify=True)
+        # Click the Withdrawal Requests tab
+        submissions_page.withdrawal_requests_tab.click()
+        withdrawals_page = ReviewsWithdrawalsPage(driver, verify=True)
+        withdrawals_page.loading_indicator.here_then_gone()
+        # On the Withdrawal Requests page, click the row for the preprint that was just
+        # submitted above. It should be the first in the list since they are sorted
+        # newest to oldest.
+        withdrawals_page.click_requests_row(provider_id, preprint_node)
+        preprint_detail_page = PreprintDetailPage(driver, verify=True)
+        WebDriverWait(driver, 5).until(
+            EC.element_to_be_clickable(
+                (By.CSS_SELECTOR, 'button.btn.dropdown-toggle.btn-success')
+            )
+        )
+        # Verify that the Preprint has a Pending status in the status bar
+        assert preprint_detail_page.status.text == 'pending'
+        # Click the Make decision button to reveal the review options. Then click
+        # the Approve radio button, enter a reason in the text box and click the
+        # Submit decision button to complete the review.
+        preprint_detail_page.make_decision_button.click()
+        preprint_detail_page.accept_radio_button.click()
+        preprint_detail_page.reason_textarea.clear()
+        preprint_detail_page.reason_textarea.send_keys_deliberately(
+            'Selenium Testing - Approving Withdrawal Request of Post-Moderated Preprint'
+        )
+        preprint_detail_page.submit_decision_button.click()
+        # Should end up back on the Reviews Submission page
+        assert ReviewsSubmissionsPage(driver, verify=True)
+        # Use the api to verify that the Preprint is not published and that its review
+        # status is now 'withdrawn'.
+        assert not osf_api.get_preprint_publish_and_review_states(
+            preprint_node=preprint_node
+        )[0]
+        assert (
+            osf_api.get_preprint_publish_and_review_states(preprint_node=preprint_node)[
+                1
+            ]
+            == 'withdrawn'
+        )
+        # Logout and navigate to the Preprint Detail page. We should see a Withdrawn
+        # tombstone page.
+        logout(driver)
+        preprint_page = PreprintDetailPage(driver, guid=preprint_node)
+        preprint_page.goto()
+        assert PreprintDetailPage(driver, verify=True)
+        WebDriverWait(driver, 5).until(EC.visibility_of(preprint_page.title))
+        assert preprint_page.title.text == preprint_title
+        assert (
+            preprint_page.status_explanation.text == 'This preprint has been withdrawn.'
+        )
+
+    def test_decline_withdrawal_request_post_moderated_preprint(
+        self, session, driver, log_in_if_not_already
+    ):
+        """Test the declining of a Withdrawal Request for a preprint submitted and
+        accepted by a preprint provider with a Post-moderation workflow. In this
+        workflow the moderator will decline the withdrawal request and the preprint
+        will remain accepted and publicly accessible. The test will use the OSF api
+        to create a submitted preprint and to accept the preprint and create the
+        withdrawal request record. The actual test steps will thus start at the point
+        where the moderator takes action from the Reviews Dashboard page to decline
+        the withdrawal request.
+        NOTE: In this test case User One is used to login to OSF and must therefore be
+        setup through the admin app as a moderator or admin for the Preprint Provider
+        being used.
+        """
+        # The following Preprint Provider must be setup in each testing environment.
+        provider_id = 'selpostmod'
+        provider_name = 'Selenium Post-moderation'
+        preprint_title = 'OSF Selenium Post-moderation Preprint'
+
+        # NOTE: Using User Two to create the preprint through the api so that the user
+        # that submits the preprint is different from the user that accepts or rejects
+        # it.
+        session_user_two = osf_api.get_user_two_session()
+        preprint_node = osf_api.create_preprint(
+            session_user_two,
+            provider_id=provider_id,
+            title=preprint_title,
+            license_name='CC0 1.0 Universal',
+            subject_name='Engineering',
+        )
+        # Set session to None before calling accept_preprint so that the api function
+        # will use the default User One session which should have the permissions as
+        # a moderator to be able to accept the preprint.
+        osf_api.accept_moderated_preprint(session=None, preprint_node=preprint_node)
+        # Next use the api to create a withdrawal request (using User Two again)
+        osf_api.create_preprint_withdrawal_request(
+            session=session_user_two, preprint_node=preprint_node
+        )
+        # Load Reviews Dashboard page first and then click the Submissions link for the
+        # Pre-moderation provider to go to that page.
+        reviews_dashboard_page = ReviewsDashboardPage(driver)
+        reviews_dashboard_page.goto()
+        assert ReviewsDashboardPage(driver, verify=True)
+        reviews_dashboard_page.loading_indicator.here_then_gone()
+        reviews_dashboard_page.click_provider_group_link(provider_name, 'Submissions')
+        submissions_page = ReviewsSubmissionsPage(driver, verify=True)
+        # Click the Withdrawal Requests tab
+        submissions_page.withdrawal_requests_tab.click()
+        withdrawals_page = ReviewsWithdrawalsPage(driver, verify=True)
+        withdrawals_page.loading_indicator.here_then_gone()
+        # On the Withdrawal Requests page, click the row for the preprint that was just
+        # submitted above. It should be the first in the list since they are sorted
+        # newest to oldest.
+        withdrawals_page.click_requests_row(provider_id, preprint_node)
+        preprint_detail_page = PreprintDetailPage(driver, verify=True)
+        WebDriverWait(driver, 5).until(
+            EC.element_to_be_clickable(
+                (By.CSS_SELECTOR, 'button.btn.dropdown-toggle.btn-success')
+            )
+        )
+        # Verify that the Preprint has a Pending status in the status bar
+        assert preprint_detail_page.status.text == 'pending'
+        # Click the Make decision button to reveal the review options. Then click
+        # the Decline radio button, enter a reason in the text box and click the
+        # Submit decision button to complete the review.
+        preprint_detail_page.make_decision_button.click()
+        preprint_detail_page.reject_radio_button.click()
+        preprint_detail_page.reason_textarea.clear()
+        preprint_detail_page.reason_textarea.send_keys_deliberately(
+            'Selenium Testing - Declining Withdrawal Request of Post-Moderated Preprint'
+        )
+        preprint_detail_page.submit_decision_button.click()
+        # Should end up back on the Reviews Submission page
+        assert ReviewsSubmissionsPage(driver, verify=True)
+        # Use the api to verify that the Preprint is still published and that its review
+        # status is still 'accepted'.
+        assert osf_api.get_preprint_publish_and_review_states(
+            preprint_node=preprint_node
+        )[0]
+        assert (
+            osf_api.get_preprint_publish_and_review_states(preprint_node=preprint_node)[
+                1
+            ]
+            == 'accepted'
+        )
+        # Logout and navigate to the Preprint Detail page which should still be publicly
+        # accessible.
+        logout(driver)
+        preprint_page = PreprintDetailPage(driver, guid=preprint_node)
+        preprint_page.goto()
+        assert PreprintDetailPage(driver, verify=True)
+        WebDriverWait(driver, 5).until(EC.visibility_of(preprint_page.title))
+        assert preprint_page.title.text == preprint_title
+        assert provider_id in driver.current_url
 
 
 @markers.core_functionality

--- a/tests/test_preprints.py
+++ b/tests/test_preprints.py
@@ -342,17 +342,11 @@ class TestPreprintModeration:
         )
         # Use the api to verify that the Preprint is not yet published and that its
         # review status is 'pending'.
-        assert not (
-            osf_api.get_preprint_publish_and_review_states(preprint_node=preprint_node)[
-                0
-            ]
+        prep_attr = osf_api.get_preprint_publish_and_review_states(
+            preprint_node=preprint_node
         )
-        assert (
-            osf_api.get_preprint_publish_and_review_states(preprint_node=preprint_node)[
-                1
-            ]
-            == 'pending'
-        )
+        assert not prep_attr[0]
+        assert prep_attr[1] == 'pending'
         # Load Reviews Dashboard page first and then click the Submissions link for the
         # Pre-moderation provider to go to that page.
         reviews_dashboard_page = ReviewsDashboardPage(driver)
@@ -387,15 +381,11 @@ class TestPreprintModeration:
         assert ReviewsSubmissionsPage(driver, verify=True)
         # Use the api to verify that the Preprint is now published and that its review
         # status is now 'accepted'.
-        assert osf_api.get_preprint_publish_and_review_states(
+        prep_attr = osf_api.get_preprint_publish_and_review_states(
             preprint_node=preprint_node
-        )[0]
-        assert (
-            osf_api.get_preprint_publish_and_review_states(preprint_node=preprint_node)[
-                1
-            ]
-            == 'accepted'
         )
+        assert prep_attr[0]
+        assert prep_attr[1] == 'accepted'
         # Logout and navigate to the Preprint Detail page since it is now public.
         logout(driver)
         preprint_page = PreprintDetailPage(driver, guid=preprint_node)
@@ -437,17 +427,11 @@ class TestPreprintModeration:
         )
         # Use the api to verify that the Preprint is not yet published and that its
         # review status is 'pending'.
-        assert not (
-            osf_api.get_preprint_publish_and_review_states(preprint_node=preprint_node)[
-                0
-            ]
+        prep_attr = osf_api.get_preprint_publish_and_review_states(
+            preprint_node=preprint_node
         )
-        assert (
-            osf_api.get_preprint_publish_and_review_states(preprint_node=preprint_node)[
-                1
-            ]
-            == 'pending'
-        )
+        assert not prep_attr[0]
+        assert prep_attr[1] == 'pending'
         # Load Reviews Dashboard page first and then click the Submissions link for the
         # Pre-moderation provider to go to that page.
         reviews_dashboard_page = ReviewsDashboardPage(driver)
@@ -482,17 +466,11 @@ class TestPreprintModeration:
         assert ReviewsSubmissionsPage(driver, verify=True)
         # Use the api to verify that the Preprint is still not published and that its
         # review status is now 'rejected'.
-        assert not (
-            osf_api.get_preprint_publish_and_review_states(preprint_node=preprint_node)[
-                0
-            ]
+        prep_attr = osf_api.get_preprint_publish_and_review_states(
+            preprint_node=preprint_node
         )
-        assert (
-            osf_api.get_preprint_publish_and_review_states(preprint_node=preprint_node)[
-                1
-            ]
-            == 'rejected'
-        )
+        assert not prep_attr[0]
+        assert prep_attr[1] == 'rejected'
         # Logout and attempt to navigate to the Preprint Detail page. We should get a
         # Page Not Found page since the rejected preprint is not public.
         logout(driver)
@@ -548,6 +526,7 @@ class TestPreprintModeration:
         reviews_dashboard_page.loading_indicator.here_then_gone()
         reviews_dashboard_page.click_provider_group_link(provider_name, 'Submissions')
         submissions_page = ReviewsSubmissionsPage(driver, verify=True)
+        submissions_page.loading_indicator.here_then_gone()
         # Click the Withdrawal Requests tab
         submissions_page.withdrawal_requests_tab.click()
         withdrawals_page = ReviewsWithdrawalsPage(driver, verify=True)
@@ -578,15 +557,11 @@ class TestPreprintModeration:
         assert ReviewsSubmissionsPage(driver, verify=True)
         # Use the api to verify that the Preprint is not published and that its review
         # status is now 'withdrawn'.
-        assert not osf_api.get_preprint_publish_and_review_states(
+        prep_attr = osf_api.get_preprint_publish_and_review_states(
             preprint_node=preprint_node
-        )[0]
-        assert (
-            osf_api.get_preprint_publish_and_review_states(preprint_node=preprint_node)[
-                1
-            ]
-            == 'withdrawn'
         )
+        assert not prep_attr[0]
+        assert prep_attr[1] == 'withdrawn'
         # Logout and navigate to the Preprint Detail page. We should see a Withdrawn
         # tombstone page.
         logout(driver)
@@ -646,6 +621,7 @@ class TestPreprintModeration:
         reviews_dashboard_page.loading_indicator.here_then_gone()
         reviews_dashboard_page.click_provider_group_link(provider_name, 'Submissions')
         submissions_page = ReviewsSubmissionsPage(driver, verify=True)
+        submissions_page.loading_indicator.here_then_gone()
         # Click the Withdrawal Requests tab
         submissions_page.withdrawal_requests_tab.click()
         withdrawals_page = ReviewsWithdrawalsPage(driver, verify=True)
@@ -676,15 +652,11 @@ class TestPreprintModeration:
         assert ReviewsSubmissionsPage(driver, verify=True)
         # Use the api to verify that the Preprint is still published and that its review
         # status is still 'accepted'.
-        assert osf_api.get_preprint_publish_and_review_states(
+        prep_attr = osf_api.get_preprint_publish_and_review_states(
             preprint_node=preprint_node
-        )[0]
-        assert (
-            osf_api.get_preprint_publish_and_review_states(preprint_node=preprint_node)[
-                1
-            ]
-            == 'accepted'
         )
+        assert prep_attr[0]
+        assert prep_attr[1] == 'accepted'
         # Logout and navigate to the Preprint Detail page which should still be publicly
         # accessible.
         logout(driver)
@@ -726,15 +698,11 @@ class TestPreprintModeration:
         )
         # Use the api to verify that the Preprint is already published and that its
         # review status is 'pending'.
-        assert osf_api.get_preprint_publish_and_review_states(
+        prep_attr = osf_api.get_preprint_publish_and_review_states(
             preprint_node=preprint_node
-        )[0]
-        assert (
-            osf_api.get_preprint_publish_and_review_states(preprint_node=preprint_node)[
-                1
-            ]
-            == 'pending'
         )
+        assert prep_attr[0]
+        assert prep_attr[1] == 'pending'
         # Load Reviews Dashboard page first and then click the Submissions link for the
         # Post-moderation provider to go to that page.
         reviews_dashboard_page = ReviewsDashboardPage(driver)
@@ -769,15 +737,11 @@ class TestPreprintModeration:
         assert ReviewsSubmissionsPage(driver, verify=True)
         # Use the api to verify that the Preprint is still published and that its review
         # status is now 'accepted'.
-        assert osf_api.get_preprint_publish_and_review_states(
+        prep_attr = osf_api.get_preprint_publish_and_review_states(
             preprint_node=preprint_node
-        )[0]
-        assert (
-            osf_api.get_preprint_publish_and_review_states(preprint_node=preprint_node)[
-                1
-            ]
-            == 'accepted'
         )
+        assert prep_attr[0]
+        assert prep_attr[1] == 'accepted'
         # Logout and navigate to the Preprint Detail page since it is public.
         logout(driver)
         preprint_page = PreprintDetailPage(driver, guid=preprint_node)
@@ -819,15 +783,11 @@ class TestPreprintModeration:
         )
         # Use the api to verify that the Preprint is already published and that its
         # review status is 'pending'.
-        assert osf_api.get_preprint_publish_and_review_states(
+        prep_attr = osf_api.get_preprint_publish_and_review_states(
             preprint_node=preprint_node
-        )[0]
-        assert (
-            osf_api.get_preprint_publish_and_review_states(preprint_node=preprint_node)[
-                1
-            ]
-            == 'pending'
         )
+        assert prep_attr[0]
+        assert prep_attr[1] == 'pending'
         # Load Reviews Dashboard page first and then click the Submissions link for the
         # Post-moderation provider to go to that page.
         reviews_dashboard_page = ReviewsDashboardPage(driver)
@@ -862,17 +822,11 @@ class TestPreprintModeration:
         assert ReviewsSubmissionsPage(driver, verify=True)
         # Use the api to verify that the Preprint is now unpublished and that its
         # review status is now 'withdrawn'.
-        assert not (
-            osf_api.get_preprint_publish_and_review_states(preprint_node=preprint_node)[
-                0
-            ]
+        prep_attr = osf_api.get_preprint_publish_and_review_states(
+            preprint_node=preprint_node
         )
-        assert (
-            osf_api.get_preprint_publish_and_review_states(preprint_node=preprint_node)[
-                1
-            ]
-            == 'withdrawn'
-        )
+        assert not prep_attr[0]
+        assert prep_attr[1] == 'withdrawn'
         # Logout and navigate to the Preprint Detail page. We should see a Withdrawn
         # tombstone page.
         logout(driver)
@@ -932,6 +886,7 @@ class TestPreprintModeration:
         reviews_dashboard_page.loading_indicator.here_then_gone()
         reviews_dashboard_page.click_provider_group_link(provider_name, 'Submissions')
         submissions_page = ReviewsSubmissionsPage(driver, verify=True)
+        submissions_page.loading_indicator.here_then_gone()
         # Click the Withdrawal Requests tab
         submissions_page.withdrawal_requests_tab.click()
         withdrawals_page = ReviewsWithdrawalsPage(driver, verify=True)
@@ -962,15 +917,11 @@ class TestPreprintModeration:
         assert ReviewsSubmissionsPage(driver, verify=True)
         # Use the api to verify that the Preprint is not published and that its review
         # status is now 'withdrawn'.
-        assert not osf_api.get_preprint_publish_and_review_states(
+        prep_attr = osf_api.get_preprint_publish_and_review_states(
             preprint_node=preprint_node
-        )[0]
-        assert (
-            osf_api.get_preprint_publish_and_review_states(preprint_node=preprint_node)[
-                1
-            ]
-            == 'withdrawn'
         )
+        assert not prep_attr[0]
+        assert prep_attr[1] == 'withdrawn'
         # Logout and navigate to the Preprint Detail page. We should see a Withdrawn
         # tombstone page.
         logout(driver)
@@ -1030,6 +981,7 @@ class TestPreprintModeration:
         reviews_dashboard_page.loading_indicator.here_then_gone()
         reviews_dashboard_page.click_provider_group_link(provider_name, 'Submissions')
         submissions_page = ReviewsSubmissionsPage(driver, verify=True)
+        submissions_page.loading_indicator.here_then_gone()
         # Click the Withdrawal Requests tab
         submissions_page.withdrawal_requests_tab.click()
         withdrawals_page = ReviewsWithdrawalsPage(driver, verify=True)
@@ -1060,15 +1012,11 @@ class TestPreprintModeration:
         assert ReviewsSubmissionsPage(driver, verify=True)
         # Use the api to verify that the Preprint is still published and that its review
         # status is still 'accepted'.
-        assert osf_api.get_preprint_publish_and_review_states(
+        prep_attr = osf_api.get_preprint_publish_and_review_states(
             preprint_node=preprint_node
-        )[0]
-        assert (
-            osf_api.get_preprint_publish_and_review_states(preprint_node=preprint_node)[
-                1
-            ]
-            == 'accepted'
         )
+        assert prep_attr[0]
+        assert prep_attr[1] == 'accepted'
         # Logout and navigate to the Preprint Detail page which should still be publicly
         # accessible.
         logout(driver)

--- a/tests/test_preprints.py
+++ b/tests/test_preprints.py
@@ -500,6 +500,196 @@ class TestPreprintModeration:
         page_not_found_page = PreprintPageNotFoundPage(driver, verify=True)
         assert page_not_found_page.page_header.text == 'Page not found'
 
+    def test_accept_post_moderated_preprint(
+        self, session, driver, log_in_if_not_already
+    ):
+        """Test the acceptance of a preprint submission to a preprint provider with a
+        Post-moderation workflow. In this workflow a preprint is submitted to the
+        preprint service provider and is published and publicly accessible upon
+        submission.  A moderator can then 'accept' the preprint submission.
+        NOTE: In this test case User One is used to login to OSF and must therefore be
+        setup through the admin app as a moderator or admin for the Preprint Provider
+        being used.  The test will use the OSF api to create a submitted preprint, but
+        the preprint will be submitted using the session credentials of User Two so
+        that the preprint submitter and moderator are different users.
+        """
+        # The following Preprint Provider must be setup in each testing environment.
+        provider_id = 'selpostmod'
+        provider_name = 'Selenium Post-moderation'
+        preprint_title = 'OSF Selenium Post-moderation Preprint'
+
+        # NOTE: Using User Two to create the preprint through the api so that the user
+        # that submits the preprint is different from the user that accepts or rejects
+        # it.
+        session_user_two = osf_api.get_user_two_session()
+        preprint_node = osf_api.create_preprint(
+            session_user_two,
+            provider_id=provider_id,
+            title=preprint_title,
+            license_name='CC0 1.0 Universal',
+            subject_name='Engineering',
+        )
+        # Use the api to verify that the Preprint is already published and that its
+        # review status is 'pending'.
+        assert osf_api.get_preprint_publish_and_review_states(
+            preprint_node=preprint_node
+        )[0]
+        assert (
+            osf_api.get_preprint_publish_and_review_states(preprint_node=preprint_node)[
+                1
+            ]
+            == 'pending'
+        )
+        # Load Reviews Dashboard page first and then click the Submissions link for the
+        # Post-moderation provider to go to that page.
+        reviews_dashboard_page = ReviewsDashboardPage(driver)
+        reviews_dashboard_page.goto()
+        assert ReviewsDashboardPage(driver, verify=True)
+        reviews_dashboard_page.loading_indicator.here_then_gone()
+        reviews_dashboard_page.click_provider_group_link(provider_name, 'Submissions')
+        submissions_page = ReviewsSubmissionsPage(driver, verify=True)
+        submissions_page.loading_indicator.here_then_gone()
+        # On the Reviews Submissions page, click the row for the preprint that was just
+        # submitted above. It should be the first in the list since they are sorted
+        # newest to oldest.
+        submissions_page.click_submission_row(provider_id, preprint_node)
+        preprint_detail_page = PreprintDetailPage(driver, verify=True)
+        WebDriverWait(driver, 5).until(
+            EC.element_to_be_clickable(
+                (By.CSS_SELECTOR, 'button.btn.dropdown-toggle.btn-success')
+            )
+        )
+        # Verify that the Preprint has a Pending status in the status bar
+        assert preprint_detail_page.status.text == 'pending'
+        # Click the Make decision button to reveal the review options. Then click
+        # the Accept radio button, enter a reason in the text box and click the
+        # Submit decision button to complete the review.
+        preprint_detail_page.make_decision_button.click()
+        preprint_detail_page.accept_radio_button.click()
+        preprint_detail_page.reason_textarea.send_keys_deliberately(
+            'Selenium Testing - Accepting Post-Moderated Preprint'
+        )
+        preprint_detail_page.submit_decision_button.click()
+        # Should end up back on the Reviews Submission page
+        assert ReviewsSubmissionsPage(driver, verify=True)
+        # Use the api to verify that the Preprint is still published and that its review
+        # status is now 'accepted'.
+        assert osf_api.get_preprint_publish_and_review_states(
+            preprint_node=preprint_node
+        )[0]
+        assert (
+            osf_api.get_preprint_publish_and_review_states(preprint_node=preprint_node)[
+                1
+            ]
+            == 'accepted'
+        )
+        # Logout and navigate to the Preprint Detail page since it is public.
+        logout(driver)
+        preprint_page = PreprintDetailPage(driver, guid=preprint_node)
+        preprint_page.goto()
+        assert PreprintDetailPage(driver, verify=True)
+        WebDriverWait(driver, 5).until(EC.visibility_of(preprint_page.title))
+        assert preprint_page.title.text == preprint_title
+        assert provider_id in driver.current_url
+
+    def test_moderator_withdrawal_post_moderated_preprint(
+        self, session, driver, log_in_if_not_already
+    ):
+        """Test the moderator withdrawal of a preprint submission to a Preprint Provider
+        with a Post-moderation workflow. In this workflow a preprint is submitted to the
+        preprint service provider and is published and publicly accessible upon
+        submission.  A moderator can then 'withdraw' the preprint submission and it will
+        no longer be publicly accessible.
+        NOTE: In this test case User One is used to login to OSF and must therefore be
+        setup through the admin app as a moderator or admin for the Preprint Provider
+        being used.  The test will use the OSF api to create a submitted preprint, but
+        the preprint will be submitted using the session credentials of User Two so
+        that the preprint submitter and moderator are different users.
+        """
+        # The following Preprint Provider must be setup in each testing environment.
+        provider_id = 'selpostmod'
+        provider_name = 'Selenium Post-moderation'
+        preprint_title = 'OSF Selenium Post-moderation Preprint'
+
+        # NOTE: Using User Two to create the preprint through the api so that the user
+        # that submits the preprint is different from the user that accepts or rejects
+        # it.
+        session_user_two = osf_api.get_user_two_session()
+        preprint_node = osf_api.create_preprint(
+            session_user_two,
+            provider_id=provider_id,
+            title=preprint_title,
+            license_name='CC0 1.0 Universal',
+            subject_name='Engineering',
+        )
+        # Use the api to verify that the Preprint is already published and that its
+        # review status is 'pending'.
+        assert osf_api.get_preprint_publish_and_review_states(
+            preprint_node=preprint_node
+        )[0]
+        assert (
+            osf_api.get_preprint_publish_and_review_states(preprint_node=preprint_node)[
+                1
+            ]
+            == 'pending'
+        )
+        # Load Reviews Dashboard page first and then click the Submissions link for the
+        # Post-moderation provider to go to that page.
+        reviews_dashboard_page = ReviewsDashboardPage(driver)
+        reviews_dashboard_page.goto()
+        assert ReviewsDashboardPage(driver, verify=True)
+        reviews_dashboard_page.loading_indicator.here_then_gone()
+        reviews_dashboard_page.click_provider_group_link(provider_name, 'Submissions')
+        submissions_page = ReviewsSubmissionsPage(driver, verify=True)
+        submissions_page.loading_indicator.here_then_gone()
+        # On the Reviews Submissions page, click the row for the preprint that was just
+        # submitted above. It should be the first in the list since they are sorted
+        # newest to oldest.
+        submissions_page.click_submission_row(provider_id, preprint_node)
+        preprint_detail_page = PreprintDetailPage(driver, verify=True)
+        WebDriverWait(driver, 5).until(
+            EC.element_to_be_clickable(
+                (By.CSS_SELECTOR, 'button.btn.dropdown-toggle.btn-success')
+            )
+        )
+        # Verify that the Preprint has a Pending status in the status bar
+        assert preprint_detail_page.status.text == 'pending'
+        # Click the Make decision button to reveal the review options. Then click
+        # the Withdraw radio button, enter a reason in the text box and click the
+        # Submit decision button to complete the review.
+        preprint_detail_page.make_decision_button.click()
+        preprint_detail_page.withdraw_radio_button.click()
+        preprint_detail_page.reason_textarea.send_keys_deliberately(
+            'Selenium Testing - Withdrawal by Moderator of a Post-Moderated Preprint'
+        )
+        preprint_detail_page.submit_decision_button.click()
+        # Should end up back on the Reviews Submission page
+        assert ReviewsSubmissionsPage(driver, verify=True)
+        # Use the api to verify that the Preprint is now unpublished and that its
+        # review status is now 'withdrawn'.
+        assert not (
+            osf_api.get_preprint_publish_and_review_states(preprint_node=preprint_node)[
+                0
+            ]
+        )
+        assert (
+            osf_api.get_preprint_publish_and_review_states(preprint_node=preprint_node)[
+                1
+            ]
+            == 'withdrawn'
+        )
+        # Logout and navigate to the Preprint Detail page. We should see a Withdrawn
+        # tombstone page.
+        logout(driver)
+        preprint_page = PreprintDetailPage(driver, guid=preprint_node)
+        preprint_page.goto()
+        assert PreprintDetailPage(driver, verify=True)
+        WebDriverWait(driver, 5).until(EC.visibility_of(preprint_page.title))
+        assert preprint_page.title.text == preprint_title
+        assert (
+            preprint_page.status_explanation.text == 'This preprint has been withdrawn.'
+        )
+
 
 @markers.core_functionality
 class TestPreprintSearch:


### PR DESCRIPTION
<!-- Before you submit your Pull Request, please confirm that:

     - Any test that will create public data either has the `QAtest` tag or the `dont_run_on_production` marker
     - `core_functionality` is marked as such
     - Your tests will be able to run on *all* servers (all stagings, test)
 -->


## Purpose
To expand our selenium test suite to cover more Preprint workflows so that they will be more useful for regression testing.


## Summary of Changes

- api/osf_api.py - added new functions: get_user_two_session(), get_moderation_type_for_provider(), get_preprint_publish_and_review_states(), accept_moderated_preprint(), and create_preprint_withdrawal_request(). Also modified existing functions: get_most_recent_preprint_node_id() and create_preprint()
- pages/preprints.py - added new classes for pages: BaseReviewsPage, ReviewsSubmissionsPage, and ReviewsWithdrawalsPage. Also added element locators to existing page classes: PreprintDetailPage and ReviewsDashboardPage.
- tests/test_preprints - added new test class: TestPreprintModeration with 8 new tests: test_accept_pre_moderated_preprint, test_reject_pre_moderated_preprint, test_approve_withdrawal_request_pre_moderated_preprint, test_decline_withdrawal_request_pre_moderated_preprint, test_accept_post_moderated_preprint, test_moderator_withdrawal_post_moderated_preprint, test_approve_withdrawal_request_post_moderated_preprint, and test_decline_withdrawal_request_post_moderated_preprint.


## Reviewer's Actions
`git fetch <remote> pull/<PR_number>/head:feature/preprints-moderation`

Run this test using
`tests/test_preprints.py -s -v`

## Testing Changes Moving Forward
N/A


## Ticket
ENG-3792: SEL: Preprints Test - Add tests for Preprint Moderation
https://openscience.atlassian.net/browse/ENG-3792
