### PR TITLE
[Reference PR] [Django3 Upgrade] Increase `public_available_button` timeout during preprints creation

### DIFF
--- a/pages/preprints.py
+++ b/pages/preprints.py
@@ -98,8 +98,9 @@ class PreprintSubmitPage(BasePreprintPage):
     )
 
     # Author Assertions
+    # Note: Have to use TIMEOUT (10s) instead of QUICK_TIMEOUT (4s) due to slowness introduced by Django3 Upgrade.
     public_available_button = Locator(
-        By.ID, 'hasDataLinksAvailable', settings.QUICK_TIMEOUT
+        By.ID, 'hasDataLinksAvailable', settings.TIMEOUT
     )
     public_data_input = Locator(
         By.CSS_SELECTOR, '[data-test-multiple-textbox-index] > input'


### PR DESCRIPTION
## Purpose

Increase `public_available_button` timeout during preprints creation.

Note: I initially created the branch to run selenium tests on staging3. Now drafting a PR for reference, which may be turned into an actual fix later.

## Summary of Changes

TBD

## Reviewer's Actions

TBD

## Testing Changes Moving Forward

TBD

## Ticket

TBD
