### PR TITLE
[ENG-4137] - Exclude ecoevorxiv from branded preprint providers test

### DIFF
--- a/tests/test_preprints.py
+++ b/tests/test_preprints.py
@@ -1211,7 +1211,10 @@ class TestBrandedProviders:
         # (i.e. end of March).  So to prevent this test from failing in Production
         # every night for 'engrxiv' we are going to skip the following steps for this
         # provider.
-        if 'engrxiv' not in provider['id']:
+        # UPDATE 10/26/2022 - the status of 'engrxiv' has not changed and now another
+        # provider - 'ecoevorxiv' is also leaving OSF.
+        providers_leaving_OSF = ['ecoevorxiv', 'engrxiv']
+        if provider['id'] not in providers_leaving_OSF:
             discover_page.goto()
             discover_page.verify()
             # add OSF consent cookie to get rid of the banner at the bottom of the page which can get in the way


### PR DESCRIPTION
<!-- Before you submit your Pull Request, please confirm that:

     - Any test that will create public data either has the `QAtest` tag or the `dont_run_on_production` marker
     - `core_functionality` is marked as such
     - Your tests will be able to run on *all* servers (all stagings, test)
 -->


## Purpose
To fix a Production Smoke Test failure since the 'ecoevorxiv' branded preprint provider is leaving OSF and no longer uses the OSF designed landing and discover pages.


## Summary of Changes

- tests/test_preprints.py - updated 'test_detail_page' in 'TestBrandedProviders' class to exclude 'ecoevorxiv' as well as 'engrxiv' as active branded providers that no longer use OSF.


## Reviewer's Actions
`git fetch <remote> pull/<PR_number>/head:testFix/preprints-ecoevorxiv`

Run this test using
`tests/test_preprints.py -s -v -m smoke_test`

## Testing Changes Moving Forward
N/A


## Ticket
ENG-4137: SEL: Preprints Test - Production Failure - TestBrandedProviders::test_detail_page for ecoevorxiv
https://openscience.atlassian.net/browse/ENG-4137
