### PR TITLE
[ENG-3959] - Add new tests for User Settings Developer Apps

### DIFF
--- a/api/osf_api.py
+++ b/api/osf_api.py
@@ -732,3 +732,57 @@ def create_preprint_withdrawal_request(session=None, preprint_node=None):
         item_type='preprint-requests',
         raw_body=json.dumps(request_payload),
     )
+
+
+def create_user_developer_app(
+    session,
+    name='OSF Test Dev App',
+    description=None,
+    home_url=settings.OSF_HOME,
+    callback_url=settings.OSF_HOME,
+):
+    """Create a Developer Application for the user that is currently logged in to OSF
+    (via session object).
+    """
+    if not session:
+        session = get_default_session()
+    url = '/v2/applications/'
+    raw_payload = {
+        'data': {
+            'type': 'applications',
+            'attributes': {
+                'name': name,
+                'description': description,
+                'home_url': home_url,
+                'callback_url': callback_url,
+            },
+        }
+    }
+    return_data = session.post(
+        url=url, item_type='applications', raw_body=json.dumps(raw_payload)
+    )
+    # Return the application id
+    if return_data:
+        return return_data['data']['id']
+    else:
+        return None
+
+
+def delete_user_developer_app(session, app_id=None):
+    """Delete a User's Developer Application as identified by its application id."""
+    if not session:
+        session = get_default_session()
+    url = '/v2/applications/{}/'.format(app_id)
+    session.delete(url=url, item_type='applications')
+
+
+def get_user_developer_app_data(session, app_id=None):
+    """Return User Developer Application data for a given application id."""
+    if not session:
+        session = get_default_session()
+    url = '/v2/applications/{}/'.format(app_id)
+    data = session.get(url)['data']
+    if data:
+        return data
+    else:
+        return None

--- a/api/osf_api.py
+++ b/api/osf_api.py
@@ -764,8 +764,7 @@ def create_user_developer_app(
     # Return the application id
     if return_data:
         return return_data['data']['id']
-    else:
-        return None
+    return None
 
 
 def delete_user_developer_app(session, app_id=None):
@@ -784,5 +783,4 @@ def get_user_developer_app_data(session, app_id=None):
     data = session.get(url)['data']
     if data:
         return data
-    else:
-        return None
+    return None

--- a/components/user.py
+++ b/components/user.py
@@ -7,11 +7,15 @@ from base.locators import (
 
 
 class SettingsSideNavigation(BaseElement):
-    profile_information_link = Locator(By.XPATH, '//a[text()="Profile information"]')
-    account_settings_link = Locator(By.XPATH, '//a[text()="Account settings"]')
-    configure_addons_link = Locator(By.XPATH, '//a[text()="Configure add-on accounts"]')
-    notifications_link = Locator(By.XPATH, '//a[text()="Notifications"]')
-    developer_apps_link = Locator(By.XPATH, '//a[text()="Developer apps"]')
-    personal_access_tokens_link = Locator(
-        By.XPATH, '//a[text()="Personal access tokens"]'
-    )
+    profile_information_link = Locator(By.LINK_TEXT, 'Profile information')
+    account_settings_link = Locator(By.LINK_TEXT, 'Account settings')
+    configure_addons_link = Locator(By.LINK_TEXT, 'Configure add-on accounts')
+    notifications_link = Locator(By.LINK_TEXT, 'Notifications')
+    developer_apps_link = Locator(By.LINK_TEXT, 'Developer apps')
+    personal_access_tokens_link = Locator(By.LINK_TEXT, 'Personal access tokens')
+
+
+class DeleteDevAppModal(BaseElement):
+    app_name = Locator(By.CSS_SELECTOR, 'div.modal-header > h3 > strong')
+    cancel_button = Locator(By.CSS_SELECTOR, 'button[data-test-cancel-delete]')
+    delete_button = Locator(By.CSS_SELECTOR, 'button[data-test-confirm-delete]')

--- a/pages/user.py
+++ b/pages/user.py
@@ -81,18 +81,66 @@ class NotificationsPage(BaseUserSettingsPage):
     identity = Locator(By.CSS_SELECTOR, '#notificationSettings')
 
 
-class EmberDeveloperAppsPage(BaseUserSettingsPage):
-    url = settings.OSF_HOME + '/settings/applications/'
-
-    identity = Locator(By.CSS_SELECTOR, '[data-test-create-app-link]')
-
-
 class DeveloperAppsPage(BaseUserSettingsPage):
-    waffle_override = {'ember_user_settings_apps_page': EmberDeveloperAppsPage}
-
     url = settings.OSF_HOME + '/settings/applications/'
 
     identity = Locator(By.CSS_SELECTOR, 'div[data-analytics-scope="Developer apps"')
+    create_dev_app_button = Locator(By.CSS_SELECTOR, '[data-test-create-app-link]')
+    loading_indicator = Locator(By.CSS_SELECTOR, '.ball-pulse', settings.LONG_TIMEOUT)
+
+    dev_app_cards = GroupLocator(By.CSS_SELECTOR, 'div[data-test-developer-app-card]')
+
+    def get_dev_app_card_by_app_name(self, app_name):
+        for dev_app_card in self.dev_app_cards:
+            dev_app_name = dev_app_card.find_element_by_css_selector(
+                '[data-analytics-name="App name"]'
+            )
+            if app_name in dev_app_name.text:
+                return dev_app_card
+
+
+class CreateDeveloperAppPage(BaseUserSettingsPage):
+    url = settings.OSF_HOME + '/settings/applications/create'
+
+    identity = Locator(By.CSS_SELECTOR, '[data-test-developer-app-name]')
+    app_name_input = Locator(By.NAME, 'name')
+    project_url_input = Locator(By.NAME, 'homeUrl')
+    app_description_textarea = Locator(
+        By.CSS_SELECTOR, 'div[data-test-developer-app-description] > div > textarea'
+    )
+    callback_url_input = Locator(By.NAME, 'callbackUrl')
+    create_dev_app_button = Locator(
+        By.CSS_SELECTOR, '[data-test-create-developer-app-button]'
+    )
+
+
+class EditDeveloperAppPage(BaseUserSettingsPage):
+    base_url = settings.OSF_HOME + '/settings/applications/'
+
+    identity = Locator(By.CSS_SELECTOR, '[data-test-client-id]')
+    client_id_input = Locator(By.CSS_SELECTOR, 'div[data-test-client-id] > input')
+    client_secret_input = Locator(
+        By.CSS_SELECTOR, 'div[data-test-client-secret] > input'
+    )
+    show_client_secret_button = Locator(
+        By.CSS_SELECTOR, '[data-test-toggle-client-secret]'
+    )
+    app_name_input = Locator(By.NAME, 'name')
+    project_url_input = Locator(By.NAME, 'homeUrl')
+    app_description_textarea = Locator(
+        By.CSS_SELECTOR, 'div[data-test-developer-app-description] > div > textarea'
+    )
+    callback_url_input = Locator(By.NAME, 'callbackUrl')
+    save_button = Locator(By.CSS_SELECTOR, '[data-test-save-developer-app-button]')
+    loading_indicator = Locator(By.CSS_SELECTOR, '.ball-pulse', settings.LONG_TIMEOUT)
+
+    def __init__(self, driver, verify=False, client_id=''):
+        self.client_id = client_id
+        super().__init__(driver, verify)
+
+    @property
+    def url(self):
+        return self.base_url + self.client_id
 
 
 class EmberPersonalAccessTokenPage(BaseUserSettingsPage):

--- a/pages/user.py
+++ b/pages/user.py
@@ -7,7 +7,10 @@ from base.locators import (
     GroupLocator,
     Locator,
 )
-from components.user import SettingsSideNavigation
+from components.user import (
+    DeleteDevAppModal,
+    SettingsSideNavigation,
+)
 from pages.base import (
     GuidBasePage,
     OSFBasePage,
@@ -89,6 +92,8 @@ class DeveloperAppsPage(BaseUserSettingsPage):
     loading_indicator = Locator(By.CSS_SELECTOR, '.ball-pulse', settings.LONG_TIMEOUT)
 
     dev_app_cards = GroupLocator(By.CSS_SELECTOR, 'div[data-test-developer-app-card]')
+
+    delete_dev_app_modal = ComponentLocator(DeleteDevAppModal)
 
     def get_dev_app_card_by_app_name(self, app_name):
         for dev_app_card in self.dev_app_cards:

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -107,6 +107,7 @@ class TestUserSettings:
             )
         )
 
+    @markers.dont_run_on_prod
     def test_user_settings_create_dev_app(self, driver, session, fake):
         """Create a Developer Application from the User Settings Developer Apps page
         in OSF. The test uses the OSF api to delete the developer app at the end of the
@@ -231,6 +232,7 @@ class TestUserSettings:
             # Lastly use the api to delete the dev app as cleanup
             osf_api.delete_user_developer_app(session, app_id=client_id)
 
+    @markers.dont_run_on_prod
     def test_user_settings_delete_dev_app(self, driver, session, fake):
         """Delete a Developer Application from the User Settings Developer Apps page
         in OSF. The test uses the OSF api to first create the developer application that
@@ -345,6 +347,7 @@ class TestUserSettings:
             if dev_app_data:
                 osf_api.delete_user_developer_app(session, app_id=app_id)
 
+    @markers.dont_run_on_prod
     def test_user_settings_edit_dev_app(self, driver, session, fake):
         """Edit a Developer Application from the User Settings Developer Apps page
         in OSF. The test uses the OSF api to first create the developer application that

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -1,9 +1,13 @@
+import os
+
 import pytest
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.support.ui import WebDriverWait
 
 import markers
+import settings
+from api import osf_api
 from pages import user
 
 
@@ -102,3 +106,127 @@ class TestUserSettings:
                 new_name,
             )
         )
+
+    def test_user_settings_create_dev_app(self, driver, session, fake):
+        """Create a Developer Application from the User Settings Developer Apps page
+        in OSF. The test uses the OSF api to delete the developer app at the end of the
+        test as cleanup.
+        """
+        dev_apps_page = user.DeveloperAppsPage(driver)
+        dev_apps_page.goto()
+        assert user.DeveloperAppsPage(driver, verify=True)
+        dev_apps_page.create_dev_app_button.click()
+        create_dev_app_page = user.CreateDeveloperAppPage(driver, verify=True)
+        # Complete the form fields and click the Create developer app button
+        app_name = fake.sentence(nb_words=3)
+        create_dev_app_page.app_name_input.send_keys(app_name)
+        create_dev_app_page.project_url_input.send_keys(settings.OSF_HOME)
+        create_dev_app_page.app_description_textarea.click()
+        create_dev_app_page.app_description_textarea.send_keys(
+            'Selenium test: ' + os.environ['PYTEST_CURRENT_TEST']
+        )
+        create_dev_app_page.callback_url_input.send_keys('https://www.google.com/')
+        create_dev_app_page.create_dev_app_button.click()
+        try:
+            # Verify that you are now on the Edit page for the newly created Developer
+            # app
+            edit_dev_app_page = user.EditDeveloperAppPage(driver, verify=True)
+            edit_dev_app_page.loading_indicator.here_then_gone()
+            # Get client id from the input box and verify that it is also in the page's
+            # url
+            client_id = edit_dev_app_page.client_id_input.get_attribute('value')
+            assert client_id in driver.current_url
+            # Verify other info on this page - we need to use up 2 minutes before
+            # attempting to delete the dev app using the api, since CAS only refreshes
+            # its db connection every 2 minutes.
+            edit_dev_app_page.show_client_secret_button.click()
+            # Get the dev app data from the api and verify client secret
+            dev_app_data = osf_api.get_user_developer_app_data(
+                session, app_id=client_id
+            )
+            client_secret = dev_app_data['attributes']['client_secret']
+            assert (
+                edit_dev_app_page.client_secret_input.get_attribute('value')
+                == client_secret
+            )
+            edit_dev_app_page.scroll_into_view(edit_dev_app_page.app_name_input.element)
+            assert edit_dev_app_page.app_name_input.get_attribute('value') == app_name
+            edit_dev_app_page.scroll_into_view(
+                edit_dev_app_page.project_url_input.element
+            )
+            assert (
+                edit_dev_app_page.project_url_input.get_attribute('value')
+                == settings.OSF_HOME
+            )
+            edit_dev_app_page.scroll_into_view(
+                edit_dev_app_page.app_description_textarea.element
+            )
+            assert (
+                edit_dev_app_page.app_description_textarea.get_attribute('value')
+                == 'Selenium test: ' + os.environ['PYTEST_CURRENT_TEST']
+            )
+            edit_dev_app_page.scroll_into_view(
+                edit_dev_app_page.callback_url_input.element
+            )
+            assert (
+                edit_dev_app_page.callback_url_input.get_attribute('value')
+                == 'https://www.google.com/'
+            )
+            # Click the Save button to go back to the Dev Apps list page
+            edit_dev_app_page.scroll_into_view(edit_dev_app_page.save_button.element)
+            edit_dev_app_page.save_button.click()
+            dev_apps_page = user.DeveloperAppsPage(driver, verify=True)
+            dev_apps_page.loading_indicator.here_then_gone()
+            # Go through the list of developer apps listed on the page to find the one
+            # that was just added
+            dev_app_card = dev_apps_page.get_dev_app_card_by_app_name(app_name)
+            app_link = dev_app_card.find_element_by_css_selector('a')
+            link_url = app_link.get_attribute('href')
+            link_client_id = link_url.split('applications/', 1)[1]
+            assert link_client_id == client_id
+            # Now click the app name link to go back to Edit Dev App page and verify
+            # the data again - just trying to waste more time before we can delete
+            # the app
+            app_link.click()
+            edit_dev_app_page = user.EditDeveloperAppPage(driver, verify=True)
+            edit_dev_app_page.loading_indicator.here_then_gone()
+            # Click the Show client secret button to unveil the client secret
+            edit_dev_app_page.show_client_secret_button.click()
+            # Verify text on the button has changed to 'Hide client secret'
+            assert (
+                edit_dev_app_page.show_client_secret_button.text == 'Hide client secret'
+            )
+            assert (
+                edit_dev_app_page.client_secret_input.get_attribute('value')
+                == client_secret
+            )
+            edit_dev_app_page.scroll_into_view(edit_dev_app_page.app_name_input.element)
+            assert edit_dev_app_page.app_name_input.get_attribute('value') == app_name
+            edit_dev_app_page.scroll_into_view(
+                edit_dev_app_page.project_url_input.element
+            )
+            assert (
+                edit_dev_app_page.project_url_input.get_attribute('value')
+                == settings.OSF_HOME
+            )
+            edit_dev_app_page.scroll_into_view(
+                edit_dev_app_page.app_description_textarea.element
+            )
+            assert (
+                edit_dev_app_page.app_description_textarea.get_attribute('value')
+                == 'Selenium test: ' + os.environ['PYTEST_CURRENT_TEST']
+            )
+            edit_dev_app_page.scroll_into_view(
+                edit_dev_app_page.callback_url_input.element
+            )
+            assert (
+                edit_dev_app_page.callback_url_input.get_attribute('value')
+                == 'https://www.google.com/'
+            )
+            edit_dev_app_page.scroll_into_view(edit_dev_app_page.save_button.element)
+            edit_dev_app_page.save_button.click()
+            dev_apps_page = user.DeveloperAppsPage(driver, verify=True)
+            dev_apps_page.loading_indicator.here_then_gone()
+        finally:
+            # Lastly use the api to delete the dev app as cleanup
+            osf_api.delete_user_developer_app(session, app_id=client_id)

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -107,7 +107,10 @@ class TestUserSettings:
             )
         )
 
-    @markers.dont_run_on_prod
+
+@markers.dont_run_on_prod
+@pytest.mark.usefixtures('must_be_logged_in')
+class TestUserDeveloperApps:
     def test_user_settings_create_dev_app(self, driver, session, fake):
         """Create a Developer Application from the User Settings Developer Apps page
         in OSF. The test uses the OSF api to delete the developer app at the end of the
@@ -117,67 +120,62 @@ class TestUserSettings:
         dev_apps_page.goto()
         assert user.DeveloperAppsPage(driver, verify=True)
         dev_apps_page.create_dev_app_button.click()
-        create_dev_app_page = user.CreateDeveloperAppPage(driver, verify=True)
+        create_page = user.CreateDeveloperAppPage(driver, verify=True)
+
         # Complete the form fields and click the Create developer app button
         app_name = fake.sentence(nb_words=3)
-        create_dev_app_page.app_name_input.send_keys(app_name)
-        create_dev_app_page.project_url_input.send_keys(settings.OSF_HOME)
-        create_dev_app_page.app_description_textarea.click()
-        create_dev_app_page.app_description_textarea.send_keys(
+        create_page.app_name_input.send_keys(app_name)
+        create_page.project_url_input.send_keys(settings.OSF_HOME)
+        create_page.app_description_textarea.click()
+        create_page.app_description_textarea.send_keys(
             'Selenium test: ' + os.environ['PYTEST_CURRENT_TEST']
         )
-        create_dev_app_page.callback_url_input.send_keys('https://www.google.com/')
-        create_dev_app_page.create_dev_app_button.click()
+        create_page.callback_url_input.send_keys('https://www.google.com/')
+        create_page.create_dev_app_button.click()
         try:
             # Verify that you are now on the Edit page for the newly created Developer
             # app
-            edit_dev_app_page = user.EditDeveloperAppPage(driver, verify=True)
-            edit_dev_app_page.loading_indicator.here_then_gone()
+            edit_page = user.EditDeveloperAppPage(driver, verify=True)
+            edit_page.loading_indicator.here_then_gone()
+
             # Get client id from the input box and verify that it is also in the page's
             # url
-            client_id = edit_dev_app_page.client_id_input.get_attribute('value')
+            client_id = edit_page.client_id_input.get_attribute('value')
             assert client_id in driver.current_url
+
             # Verify other info on this page - we need to use up 2 minutes before
             # attempting to delete the dev app using the api, since CAS only refreshes
             # its db connection every 2 minutes.
-            edit_dev_app_page.show_client_secret_button.click()
+            edit_page.show_client_secret_button.click()
             # Get the dev app data from the api and verify client secret
             dev_app_data = osf_api.get_user_developer_app_data(
                 session, app_id=client_id
             )
             client_secret = dev_app_data['attributes']['client_secret']
+            assert edit_page.client_secret_input.get_attribute('value') == client_secret
+            edit_page.scroll_into_view(edit_page.app_name_input.element)
+            assert edit_page.app_name_input.get_attribute('value') == app_name
+            edit_page.scroll_into_view(edit_page.project_url_input.element)
             assert (
-                edit_dev_app_page.client_secret_input.get_attribute('value')
-                == client_secret
+                edit_page.project_url_input.get_attribute('value') == settings.OSF_HOME
             )
-            edit_dev_app_page.scroll_into_view(edit_dev_app_page.app_name_input.element)
-            assert edit_dev_app_page.app_name_input.get_attribute('value') == app_name
-            edit_dev_app_page.scroll_into_view(
-                edit_dev_app_page.project_url_input.element
-            )
+            edit_page.scroll_into_view(edit_page.app_description_textarea.element)
             assert (
-                edit_dev_app_page.project_url_input.get_attribute('value')
-                == settings.OSF_HOME
-            )
-            edit_dev_app_page.scroll_into_view(
-                edit_dev_app_page.app_description_textarea.element
-            )
-            assert (
-                edit_dev_app_page.app_description_textarea.get_attribute('value')
+                edit_page.app_description_textarea.get_attribute('value')
                 == 'Selenium test: ' + os.environ['PYTEST_CURRENT_TEST']
             )
-            edit_dev_app_page.scroll_into_view(
-                edit_dev_app_page.callback_url_input.element
-            )
+            edit_page.scroll_into_view(edit_page.callback_url_input.element)
             assert (
-                edit_dev_app_page.callback_url_input.get_attribute('value')
+                edit_page.callback_url_input.get_attribute('value')
                 == 'https://www.google.com/'
             )
+
             # Click the Save button to go back to the Dev Apps list page
-            edit_dev_app_page.scroll_into_view(edit_dev_app_page.save_button.element)
-            edit_dev_app_page.save_button.click()
+            edit_page.scroll_into_view(edit_page.save_button.element)
+            edit_page.save_button.click()
             dev_apps_page = user.DeveloperAppsPage(driver, verify=True)
             dev_apps_page.loading_indicator.here_then_gone()
+
             # Go through the list of developer apps listed on the page to find the one
             # that was just added
             dev_app_card = dev_apps_page.get_dev_app_card_by_app_name(app_name)
@@ -185,54 +183,43 @@ class TestUserSettings:
             link_url = app_link.get_attribute('href')
             link_client_id = link_url.split('applications/', 1)[1]
             assert link_client_id == client_id
+
             # Now click the app name link to go back to Edit Dev App page and verify
             # the data again - just trying to waste more time before we can delete
             # the app
             app_link.click()
-            edit_dev_app_page = user.EditDeveloperAppPage(driver, verify=True)
-            edit_dev_app_page.loading_indicator.here_then_gone()
-            # Click the Show client secret button to unveil the client secret
-            edit_dev_app_page.show_client_secret_button.click()
-            # Verify text on the button has changed to 'Hide client secret'
+            edit_page = user.EditDeveloperAppPage(driver, verify=True)
+            edit_page.loading_indicator.here_then_gone()
+
+            # Click the Show client secret button to unveil the client secret and verify
+            # the text on the button has changed to 'Hide client secret'
+            edit_page.show_client_secret_button.click()
+            assert edit_page.show_client_secret_button.text == 'Hide client secret'
+            assert edit_page.client_secret_input.get_attribute('value') == client_secret
+            edit_page.scroll_into_view(edit_page.app_name_input.element)
+            assert edit_page.app_name_input.get_attribute('value') == app_name
+            edit_page.scroll_into_view(edit_page.project_url_input.element)
             assert (
-                edit_dev_app_page.show_client_secret_button.text == 'Hide client secret'
+                edit_page.project_url_input.get_attribute('value') == settings.OSF_HOME
             )
+            edit_page.scroll_into_view(edit_page.app_description_textarea.element)
             assert (
-                edit_dev_app_page.client_secret_input.get_attribute('value')
-                == client_secret
-            )
-            edit_dev_app_page.scroll_into_view(edit_dev_app_page.app_name_input.element)
-            assert edit_dev_app_page.app_name_input.get_attribute('value') == app_name
-            edit_dev_app_page.scroll_into_view(
-                edit_dev_app_page.project_url_input.element
-            )
-            assert (
-                edit_dev_app_page.project_url_input.get_attribute('value')
-                == settings.OSF_HOME
-            )
-            edit_dev_app_page.scroll_into_view(
-                edit_dev_app_page.app_description_textarea.element
-            )
-            assert (
-                edit_dev_app_page.app_description_textarea.get_attribute('value')
+                edit_page.app_description_textarea.get_attribute('value')
                 == 'Selenium test: ' + os.environ['PYTEST_CURRENT_TEST']
             )
-            edit_dev_app_page.scroll_into_view(
-                edit_dev_app_page.callback_url_input.element
-            )
+            edit_page.scroll_into_view(edit_page.callback_url_input.element)
             assert (
-                edit_dev_app_page.callback_url_input.get_attribute('value')
+                edit_page.callback_url_input.get_attribute('value')
                 == 'https://www.google.com/'
             )
-            edit_dev_app_page.scroll_into_view(edit_dev_app_page.save_button.element)
-            edit_dev_app_page.save_button.click()
+            edit_page.scroll_into_view(edit_page.save_button.element)
+            edit_page.save_button.click()
             dev_apps_page = user.DeveloperAppsPage(driver, verify=True)
             dev_apps_page.loading_indicator.here_then_gone()
         finally:
             # Lastly use the api to delete the dev app as cleanup
             osf_api.delete_user_developer_app(session, app_id=client_id)
 
-    @markers.dont_run_on_prod
     def test_user_settings_delete_dev_app(self, driver, session, fake):
         """Delete a Developer Application from the User Settings Developer Apps page
         in OSF. The test uses the OSF api to first create the developer application that
@@ -246,6 +233,7 @@ class TestUserSettings:
             home_url=settings.OSF_HOME,
             callback_url='https://www.google.com/',
         )
+
         # Note: We need to use up 2 minutes before attempting to delete the dev app
         # since CAS only refreshes its db connection every 2 minutes.
         try:
@@ -257,6 +245,7 @@ class TestUserSettings:
             profile_settings_page.side_navigation.developer_apps_link.click()
             dev_apps_page = user.DeveloperAppsPage(driver, verify=True)
             dev_apps_page.loading_indicator.here_then_gone()
+
             # Go through the list of developer apps listed on the page to find the one
             # that was just added via the api
             dev_app_card = dev_apps_page.get_dev_app_card_by_app_name(app_name)
@@ -264,50 +253,44 @@ class TestUserSettings:
             link_url = app_link.get_attribute('href')
             link_client_id = link_url.split('applications/', 1)[1]
             assert link_client_id == app_id
+
             # Now click the app name link to go to the Edit Dev App page and verify the
             # data
             app_link.click()
-            edit_dev_app_page = user.EditDeveloperAppPage(driver, verify=True)
-            edit_dev_app_page.loading_indicator.here_then_gone()
+            edit_page = user.EditDeveloperAppPage(driver, verify=True)
+            edit_page.loading_indicator.here_then_gone()
+
             # Verify that the app_id is also in the page's url
             assert app_id in driver.current_url
-            assert edit_dev_app_page.client_id_input.get_attribute('value') == app_id
-            edit_dev_app_page.show_client_secret_button.click()
+            assert edit_page.client_id_input.get_attribute('value') == app_id
+            edit_page.show_client_secret_button.click()
+
             # Get the dev app data from the api and verify client secret
             dev_app_data = osf_api.get_user_developer_app_data(session, app_id=app_id)
             client_secret = dev_app_data['attributes']['client_secret']
+            assert edit_page.client_secret_input.get_attribute('value') == client_secret
+            edit_page.scroll_into_view(edit_page.app_name_input.element)
+            assert edit_page.app_name_input.get_attribute('value') == app_name
+            edit_page.scroll_into_view(edit_page.project_url_input.element)
             assert (
-                edit_dev_app_page.client_secret_input.get_attribute('value')
-                == client_secret
+                edit_page.project_url_input.get_attribute('value') == settings.OSF_HOME
             )
-            edit_dev_app_page.scroll_into_view(edit_dev_app_page.app_name_input.element)
-            assert edit_dev_app_page.app_name_input.get_attribute('value') == app_name
-            edit_dev_app_page.scroll_into_view(
-                edit_dev_app_page.project_url_input.element
-            )
+            edit_page.scroll_into_view(edit_page.app_description_textarea.element)
             assert (
-                edit_dev_app_page.project_url_input.get_attribute('value')
-                == settings.OSF_HOME
-            )
-            edit_dev_app_page.scroll_into_view(
-                edit_dev_app_page.app_description_textarea.element
-            )
-            assert (
-                edit_dev_app_page.app_description_textarea.get_attribute('value')
+                edit_page.app_description_textarea.get_attribute('value')
                 == 'a developer application created using the OSF api'
             )
-            edit_dev_app_page.scroll_into_view(
-                edit_dev_app_page.callback_url_input.element
-            )
+            edit_page.scroll_into_view(edit_page.callback_url_input.element)
             assert (
-                edit_dev_app_page.callback_url_input.get_attribute('value')
+                edit_page.callback_url_input.get_attribute('value')
                 == 'https://www.google.com/'
             )
+
             # Note: The Delete button on the Edit Dev App page does not actually do
             # anything - this is a known bug. So click the Save button to go back to
             # the Dev Apps List page and delete the app from there.
-            edit_dev_app_page.scroll_into_view(edit_dev_app_page.save_button.element)
-            edit_dev_app_page.save_button.click()
+            edit_page.scroll_into_view(edit_page.save_button.element)
+            edit_page.save_button.click()
             dev_apps_page = user.DeveloperAppsPage(driver, verify=True)
             dev_apps_page.loading_indicator.here_then_gone()
             dev_app_card = dev_apps_page.get_dev_app_card_by_app_name(app_name)
@@ -315,15 +298,18 @@ class TestUserSettings:
                 '[data-test-delete-button]'
             )
             delete_button.click()
+
             # Verify the Delete Dev App Modal is displayed
             delete_modal = dev_apps_page.delete_dev_app_modal
             assert delete_modal.app_name.text == app_name
+
             # Click the Cancel button first and verify that the Dev App is not
             # actually deleted
             delete_modal.cancel_button.click()
             dev_apps_page.reload()
             dev_apps_page = user.DeveloperAppsPage(driver, verify=True)
             dev_apps_page.loading_indicator.here_then_gone()
+
             # Find the Dev App card again and click the Delete button again
             dev_app_card = dev_apps_page.get_dev_app_card_by_app_name(app_name)
             delete_button = dev_app_card.find_element_by_css_selector(
@@ -332,12 +318,14 @@ class TestUserSettings:
             delete_button.click()
             delete_modal = dev_apps_page.delete_dev_app_modal
             assert delete_modal.app_name.text == app_name
+
             # This time click the Delete button to actually delete the Dev App
             delete_modal.delete_button.click()
             dev_apps_page.reload()
             dev_apps_page = user.DeveloperAppsPage(driver, verify=True)
             dev_apps_page.loading_indicator.here_then_gone()
             dev_app_card = dev_apps_page.get_dev_app_card_by_app_name(app_name)
+
             # Verify that we don't find the dev app card this time since it was deleted
             assert not dev_app_card
         except Exception:
@@ -347,7 +335,6 @@ class TestUserSettings:
             if dev_app_data:
                 osf_api.delete_user_developer_app(session, app_id=app_id)
 
-    @markers.dont_run_on_prod
     def test_user_settings_edit_dev_app(self, driver, session, fake):
         """Edit a Developer Application from the User Settings Developer Apps page
         in OSF. The test uses the OSF api to first create the developer application that
@@ -362,6 +349,7 @@ class TestUserSettings:
             home_url=settings.OSF_HOME,
             callback_url='https://www.google.com/',
         )
+
         # Note: We need to use up 2 minutes before attempting to delete the dev app
         # since CAS only refreshes its db connection every 2 minutes.
         try:
@@ -373,6 +361,7 @@ class TestUserSettings:
             profile_settings_page.side_navigation.developer_apps_link.click()
             dev_apps_page = user.DeveloperAppsPage(driver, verify=True)
             dev_apps_page.loading_indicator.here_then_gone()
+
             # Go through the list of developer apps listed on the page to find the one
             # that was just added via the api
             dev_app_card = dev_apps_page.get_dev_app_card_by_app_name(app_name)
@@ -380,57 +369,50 @@ class TestUserSettings:
             link_url = app_link.get_attribute('href')
             link_client_id = link_url.split('applications/', 1)[1]
             assert link_client_id == app_id
+
             # Now click the app name link to go to the Edit Dev App page and verify the
             # data
             app_link.click()
-            edit_dev_app_page = user.EditDeveloperAppPage(driver, verify=True)
-            edit_dev_app_page.loading_indicator.here_then_gone()
+            edit_page = user.EditDeveloperAppPage(driver, verify=True)
+            edit_page.loading_indicator.here_then_gone()
+
             # Verify that the app_id is also in the page's url
             assert app_id in driver.current_url
-            assert edit_dev_app_page.client_id_input.get_attribute('value') == app_id
-            edit_dev_app_page.show_client_secret_button.click()
+            assert edit_page.client_id_input.get_attribute('value') == app_id
+            edit_page.show_client_secret_button.click()
+
             # Get the dev app data from the api and verify client secret
             dev_app_data = osf_api.get_user_developer_app_data(session, app_id=app_id)
             client_secret = dev_app_data['attributes']['client_secret']
+            assert edit_page.client_secret_input.get_attribute('value') == client_secret
+            edit_page.scroll_into_view(edit_page.app_name_input.element)
+            assert edit_page.app_name_input.get_attribute('value') == app_name
+            edit_page.scroll_into_view(edit_page.project_url_input.element)
             assert (
-                edit_dev_app_page.client_secret_input.get_attribute('value')
-                == client_secret
+                edit_page.project_url_input.get_attribute('value') == settings.OSF_HOME
             )
-            edit_dev_app_page.scroll_into_view(edit_dev_app_page.app_name_input.element)
-            assert edit_dev_app_page.app_name_input.get_attribute('value') == app_name
-            edit_dev_app_page.scroll_into_view(
-                edit_dev_app_page.project_url_input.element
-            )
+            edit_page.scroll_into_view(edit_page.app_description_textarea.element)
             assert (
-                edit_dev_app_page.project_url_input.get_attribute('value')
-                == settings.OSF_HOME
-            )
-            edit_dev_app_page.scroll_into_view(
-                edit_dev_app_page.app_description_textarea.element
-            )
-            assert (
-                edit_dev_app_page.app_description_textarea.get_attribute('value')
+                edit_page.app_description_textarea.get_attribute('value')
                 == 'a developer application created using the OSF api'
             )
-            edit_dev_app_page.scroll_into_view(
-                edit_dev_app_page.callback_url_input.element
-            )
+            edit_page.scroll_into_view(edit_page.callback_url_input.element)
             assert (
-                edit_dev_app_page.callback_url_input.get_attribute('value')
+                edit_page.callback_url_input.get_attribute('value')
                 == 'https://www.google.com/'
             )
+
             # Now update some of the data fields and Save the changes
             new_app_name = app_name + ' edited'
-            edit_dev_app_page.app_name_input.clear()
-            edit_dev_app_page.app_name_input.send_keys_deliberately(new_app_name)
-            edit_dev_app_page.app_description_textarea.click()
-            edit_dev_app_page.app_description_textarea.send_keys_deliberately(
-                ' and edited'
-            )
-            edit_dev_app_page.scroll_into_view(edit_dev_app_page.save_button.element)
-            edit_dev_app_page.save_button.click()
+            edit_page.app_name_input.clear()
+            edit_page.app_name_input.send_keys_deliberately(new_app_name)
+            edit_page.app_description_textarea.click()
+            edit_page.app_description_textarea.send_keys_deliberately(' and edited')
+            edit_page.scroll_into_view(edit_page.save_button.element)
+            edit_page.save_button.click()
             dev_apps_page = user.DeveloperAppsPage(driver, verify=True)
             dev_apps_page.loading_indicator.here_then_gone()
+
             # Go through the list of developer apps listed on the page to find the one
             # that was just edited
             dev_app_card = dev_apps_page.get_dev_app_card_by_app_name(new_app_name)
@@ -438,49 +420,37 @@ class TestUserSettings:
             link_url = app_link.get_attribute('href')
             link_client_id = link_url.split('applications/', 1)[1]
             assert link_client_id == app_id
+
             # Now click the app name link to go back to Edit Dev App page and verify
             # the data again - just trying to waste more time before we can delete
             # the app
             app_link.click()
-            edit_dev_app_page = user.EditDeveloperAppPage(driver, verify=True)
-            edit_dev_app_page.loading_indicator.here_then_gone()
-            # Click the Show client secret button to unveil the client secret
-            edit_dev_app_page.show_client_secret_button.click()
-            # Verify text on the button has changed to 'Hide client secret'
+            edit_page = user.EditDeveloperAppPage(driver, verify=True)
+            edit_page.loading_indicator.here_then_gone()
+
+            # Click the Show client secret button to unveil the client secret and verify
+            # the text on the button has changed to 'Hide client secret'
+            edit_page.show_client_secret_button.click()
+            assert edit_page.show_client_secret_button.text == 'Hide client secret'
+            assert edit_page.client_secret_input.get_attribute('value') == client_secret
+            edit_page.scroll_into_view(edit_page.app_name_input.element)
+            assert edit_page.app_name_input.get_attribute('value') == new_app_name
+            edit_page.scroll_into_view(edit_page.project_url_input.element)
             assert (
-                edit_dev_app_page.show_client_secret_button.text == 'Hide client secret'
+                edit_page.project_url_input.get_attribute('value') == settings.OSF_HOME
             )
+            edit_page.scroll_into_view(edit_page.app_description_textarea.element)
             assert (
-                edit_dev_app_page.client_secret_input.get_attribute('value')
-                == client_secret
-            )
-            edit_dev_app_page.scroll_into_view(edit_dev_app_page.app_name_input.element)
-            assert (
-                edit_dev_app_page.app_name_input.get_attribute('value') == new_app_name
-            )
-            edit_dev_app_page.scroll_into_view(
-                edit_dev_app_page.project_url_input.element
-            )
-            assert (
-                edit_dev_app_page.project_url_input.get_attribute('value')
-                == settings.OSF_HOME
-            )
-            edit_dev_app_page.scroll_into_view(
-                edit_dev_app_page.app_description_textarea.element
-            )
-            assert (
-                edit_dev_app_page.app_description_textarea.get_attribute('value')
+                edit_page.app_description_textarea.get_attribute('value')
                 == 'a developer application created using the OSF api and edited'
             )
-            edit_dev_app_page.scroll_into_view(
-                edit_dev_app_page.callback_url_input.element
-            )
+            edit_page.scroll_into_view(edit_page.callback_url_input.element)
             assert (
-                edit_dev_app_page.callback_url_input.get_attribute('value')
+                edit_page.callback_url_input.get_attribute('value')
                 == 'https://www.google.com/'
             )
-            edit_dev_app_page.scroll_into_view(edit_dev_app_page.save_button.element)
-            edit_dev_app_page.save_button.click()
+            edit_page.scroll_into_view(edit_page.save_button.element)
+            edit_page.save_button.click()
             dev_apps_page = user.DeveloperAppsPage(driver, verify=True)
             dev_apps_page.loading_indicator.here_then_gone()
             dev_app_card = dev_apps_page.get_dev_app_card_by_app_name(new_app_name)

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -344,3 +344,144 @@ class TestUserSettings:
             dev_app_data = osf_api.get_user_developer_app_data(session, app_id=app_id)
             if dev_app_data:
                 osf_api.delete_user_developer_app(session, app_id=app_id)
+
+    def test_user_settings_edit_dev_app(self, driver, session, fake):
+        """Edit a Developer Application from the User Settings Developer Apps page
+        in OSF. The test uses the OSF api to first create the developer application that
+        will then be edited using the Front End interface. After the test is complete
+        the developer app will then be deleted using the OSF api as cleanup.
+        """
+        app_name = 'Dev App via api ' + fake.sentence(nb_words=1)
+        app_id = osf_api.create_user_developer_app(
+            session,
+            name=app_name,
+            description='a developer application created using the OSF api',
+            home_url=settings.OSF_HOME,
+            callback_url='https://www.google.com/',
+        )
+        # Note: We need to use up 2 minutes before attempting to delete the dev app
+        # since CAS only refreshes its db connection every 2 minutes.
+        try:
+            # Go to the Profile Information page first and use the side navigation bar
+            # to then go to the Developer Apps page.
+            profile_settings_page = user.ProfileInformationPage(driver)
+            profile_settings_page.goto()
+            assert user.ProfileInformationPage(driver, verify=True)
+            profile_settings_page.side_navigation.developer_apps_link.click()
+            dev_apps_page = user.DeveloperAppsPage(driver, verify=True)
+            dev_apps_page.loading_indicator.here_then_gone()
+            # Go through the list of developer apps listed on the page to find the one
+            # that was just added via the api
+            dev_app_card = dev_apps_page.get_dev_app_card_by_app_name(app_name)
+            app_link = dev_app_card.find_element_by_css_selector('a')
+            link_url = app_link.get_attribute('href')
+            link_client_id = link_url.split('applications/', 1)[1]
+            assert link_client_id == app_id
+            # Now click the app name link to go to the Edit Dev App page and verify the
+            # data
+            app_link.click()
+            edit_dev_app_page = user.EditDeveloperAppPage(driver, verify=True)
+            edit_dev_app_page.loading_indicator.here_then_gone()
+            # Verify that the app_id is also in the page's url
+            assert app_id in driver.current_url
+            assert edit_dev_app_page.client_id_input.get_attribute('value') == app_id
+            edit_dev_app_page.show_client_secret_button.click()
+            # Get the dev app data from the api and verify client secret
+            dev_app_data = osf_api.get_user_developer_app_data(session, app_id=app_id)
+            client_secret = dev_app_data['attributes']['client_secret']
+            assert (
+                edit_dev_app_page.client_secret_input.get_attribute('value')
+                == client_secret
+            )
+            edit_dev_app_page.scroll_into_view(edit_dev_app_page.app_name_input.element)
+            assert edit_dev_app_page.app_name_input.get_attribute('value') == app_name
+            edit_dev_app_page.scroll_into_view(
+                edit_dev_app_page.project_url_input.element
+            )
+            assert (
+                edit_dev_app_page.project_url_input.get_attribute('value')
+                == settings.OSF_HOME
+            )
+            edit_dev_app_page.scroll_into_view(
+                edit_dev_app_page.app_description_textarea.element
+            )
+            assert (
+                edit_dev_app_page.app_description_textarea.get_attribute('value')
+                == 'a developer application created using the OSF api'
+            )
+            edit_dev_app_page.scroll_into_view(
+                edit_dev_app_page.callback_url_input.element
+            )
+            assert (
+                edit_dev_app_page.callback_url_input.get_attribute('value')
+                == 'https://www.google.com/'
+            )
+            # Now update some of the data fields and Save the changes
+            new_app_name = app_name + ' edited'
+            edit_dev_app_page.app_name_input.clear()
+            edit_dev_app_page.app_name_input.send_keys_deliberately(new_app_name)
+            edit_dev_app_page.app_description_textarea.click()
+            edit_dev_app_page.app_description_textarea.send_keys_deliberately(
+                ' and edited'
+            )
+            edit_dev_app_page.scroll_into_view(edit_dev_app_page.save_button.element)
+            edit_dev_app_page.save_button.click()
+            dev_apps_page = user.DeveloperAppsPage(driver, verify=True)
+            dev_apps_page.loading_indicator.here_then_gone()
+            # Go through the list of developer apps listed on the page to find the one
+            # that was just edited
+            dev_app_card = dev_apps_page.get_dev_app_card_by_app_name(new_app_name)
+            app_link = dev_app_card.find_element_by_css_selector('a')
+            link_url = app_link.get_attribute('href')
+            link_client_id = link_url.split('applications/', 1)[1]
+            assert link_client_id == app_id
+            # Now click the app name link to go back to Edit Dev App page and verify
+            # the data again - just trying to waste more time before we can delete
+            # the app
+            app_link.click()
+            edit_dev_app_page = user.EditDeveloperAppPage(driver, verify=True)
+            edit_dev_app_page.loading_indicator.here_then_gone()
+            # Click the Show client secret button to unveil the client secret
+            edit_dev_app_page.show_client_secret_button.click()
+            # Verify text on the button has changed to 'Hide client secret'
+            assert (
+                edit_dev_app_page.show_client_secret_button.text == 'Hide client secret'
+            )
+            assert (
+                edit_dev_app_page.client_secret_input.get_attribute('value')
+                == client_secret
+            )
+            edit_dev_app_page.scroll_into_view(edit_dev_app_page.app_name_input.element)
+            assert (
+                edit_dev_app_page.app_name_input.get_attribute('value') == new_app_name
+            )
+            edit_dev_app_page.scroll_into_view(
+                edit_dev_app_page.project_url_input.element
+            )
+            assert (
+                edit_dev_app_page.project_url_input.get_attribute('value')
+                == settings.OSF_HOME
+            )
+            edit_dev_app_page.scroll_into_view(
+                edit_dev_app_page.app_description_textarea.element
+            )
+            assert (
+                edit_dev_app_page.app_description_textarea.get_attribute('value')
+                == 'a developer application created using the OSF api and edited'
+            )
+            edit_dev_app_page.scroll_into_view(
+                edit_dev_app_page.callback_url_input.element
+            )
+            assert (
+                edit_dev_app_page.callback_url_input.get_attribute('value')
+                == 'https://www.google.com/'
+            )
+            edit_dev_app_page.scroll_into_view(edit_dev_app_page.save_button.element)
+            edit_dev_app_page.save_button.click()
+            dev_apps_page = user.DeveloperAppsPage(driver, verify=True)
+            dev_apps_page.loading_indicator.here_then_gone()
+            dev_app_card = dev_apps_page.get_dev_app_card_by_app_name(new_app_name)
+            assert dev_app_card
+        finally:
+            # Lastly use the api to delete the dev app as cleanup
+            osf_api.delete_user_developer_app(session, app_id=app_id)


### PR DESCRIPTION
<!-- Before you submit your Pull Request, please confirm that:

     - Any test that will create public data either has the `QAtest` tag or the `dont_run_on_production` marker
     - `core_functionality` is marked as such
     - Your tests will be able to run on *all* servers (all stagings, test)
 -->


## Purpose
To expand selenium test coverage to include creating, deleting, and editing User Developer Apps.


## Summary of Changes

- api/osf_api.py - adding 3 new functions: create_user_developer_app, delete_user_developer_app, and get_user_developer_app_data
- components/user.py - adding new modal class: DeleteDevAppModal and updating locators in SettingsSideNavigation to use LINK_TEXT instead of XPATH
- pages/user.py - updating DeveloperAppsPage class, adding CreateDeveloperAppPage and EditDeveloperAppPage, and deleting no longer needed EmberDeveloperAppsPage
- tests/test_user.py - adding 3 new tests: test_user_settings_create_dev_app, test_user_settings_delete_dev_app, and test_user_settings_edit_dev_app


## Reviewer's Actions
`git fetch <remote> pull/<PR_number>/head:testFix/user-dev-apps`

Run this test using
`tests/test_user.py -s -v`

## Testing Changes Moving Forward
N/A


## Ticket
ENG-3959: SEL: User Test - Add New Tests for User Settings Developer Apps Page
https://openscience.atlassian.net/browse/ENG-3959
