### PR TITLE
[ENG-3960] - Add New Tests for User Settings Personal Access Tokens

### DIFF
--- a/api/osf_api.py
+++ b/api/osf_api.py
@@ -784,3 +784,51 @@ def get_user_developer_app_data(session, app_id=None):
     if data:
         return data
     return None
+
+
+def create_personal_access_token(
+    session, name='OSF Test PAT', scopes='osf.nodes.full_read'
+):
+    """Create a Personal Access Token for the user that is currently logged in to OSF
+    (via session object). Default scope is 'osf.nodes.full_read'. The scopes parameter
+    is a string (not a list) with multiple scopes separated by a space.
+    EX: 'osf.users.profile_write osf.full_write osf.nodes.full_write'
+    """
+    if not session:
+        session = get_default_session()
+    url = '/v2/tokens/'
+    raw_payload = {
+        'data': {
+            'type': 'tokens',
+            'attributes': {
+                'name': name,
+                'scopes': scopes,
+            },
+        }
+    }
+    return_data = session.post(
+        url=url, item_type='tokens', raw_body=json.dumps(raw_payload)
+    )
+    # Return the token id
+    if return_data:
+        return return_data['data']['id']
+    return None
+
+
+def delete_personal_access_token(session, token_id=None):
+    """Delete a User's Personal Access Token as identified by its token id."""
+    if not session:
+        session = get_default_session()
+    url = '/v2/tokens/{}/'.format(token_id)
+    session.delete(url=url, item_type='tokens')
+
+
+def get_user_pat_data(session, token_id=None):
+    """Return User Personal Access Token data for a given token id."""
+    if not session:
+        session = get_default_session()
+    url = '/v2/tokens/{}/'.format(token_id)
+    data = session.get(url)['data']
+    if data:
+        return data
+    return None

--- a/api/osf_api.py
+++ b/api/osf_api.py
@@ -809,9 +809,11 @@ def create_personal_access_token(
     return_data = session.post(
         url=url, item_type='tokens', raw_body=json.dumps(raw_payload)
     )
-    # Return the token id
+    # Return the public id and the private token_id
     if return_data:
-        return return_data['data']['id']
+        public_id = return_data['data']['id']
+        token_id = return_data['data']['attributes']['token_id']
+        return [public_id, token_id]
     return None
 
 

--- a/api/osf_api.py
+++ b/api/osf_api.py
@@ -831,6 +831,4 @@ def get_user_pat_data(session, token_id=None):
         session = get_default_session()
     url = '/v2/tokens/{}/'.format(token_id)
     data = session.get(url)['data']
-    if data:
-        return data
-    return None
+    return data or None

--- a/components/user.py
+++ b/components/user.py
@@ -19,3 +19,9 @@ class DeleteDevAppModal(BaseElement):
     app_name = Locator(By.CSS_SELECTOR, 'div.modal-header > h3 > strong')
     cancel_button = Locator(By.CSS_SELECTOR, 'button[data-test-cancel-delete]')
     delete_button = Locator(By.CSS_SELECTOR, 'button[data-test-confirm-delete]')
+
+
+class DeletePATModal(BaseElement):
+    token_name = Locator(By.CSS_SELECTOR, 'div.modal-header > h3 > strong')
+    cancel_button = Locator(By.CSS_SELECTOR, 'button[data-test-cancel-delete]')
+    delete_button = Locator(By.CSS_SELECTOR, 'button[data-test-confirm-delete]')

--- a/pages/user.py
+++ b/pages/user.py
@@ -148,15 +148,126 @@ class EditDeveloperAppPage(BaseUserSettingsPage):
         return self.base_url + self.client_id
 
 
-class EmberPersonalAccessTokenPage(BaseUserSettingsPage):
-    url = settings.OSF_HOME + '/settings/tokens/'
-
-    identity = Locator(By.CSS_SELECTOR, '[data-test-create-token-link]')
-
-
 class PersonalAccessTokenPage(BaseUserSettingsPage):
-    waffle_override = {'ember_user_settings_tokens_page': EmberPersonalAccessTokenPage}
-
     url = settings.OSF_HOME + '/settings/tokens/'
 
-    identity = Locator(By.CSS_SELECTOR, 'a[data-analytics-name="Personal access"]')
+    identity = Locator(By.CSS_SELECTOR, 'h3[data-test-panel-title]')
+    loading_indicator = Locator(By.CSS_SELECTOR, '.ball-pulse')
+    create_token_button = Locator(By.CSS_SELECTOR, '[data-test-create-token-link]')
+
+    pat_cards = GroupLocator(By.CSS_SELECTOR, 'div[data-test-token-card]')
+
+    def get_pat_card_by_name(self, pat_name):
+        for pat_card in self.pat_cards:
+            token_name = pat_card.find_element_by_css_selector(
+                '[data-analytics-name="Token name"]'
+            )
+            if pat_name in token_name.text:
+                return pat_card
+
+
+class CreatePersonalAccessTokenPage(BaseUserSettingsPage):
+    url = settings.OSF_HOME + '/settings/tokens/create'
+
+    identity = Locator(By.CSS_SELECTOR, '[data-test-token-name]')
+    token_name_input = Locator(By.NAME, 'name')
+    osf_users_profile_write_checkbox = Locator(
+        By.CSS_SELECTOR, 'div[data-test-scope="osf.users.profile_write"] > input'
+    )
+    osf_full_write_checkbox = Locator(
+        By.CSS_SELECTOR, 'div[data-test-scope="osf.full_write"] > input'
+    )
+    osf_nodes_full_write_checkbox = Locator(
+        By.CSS_SELECTOR, 'div[data-test-scope="osf.nodes.full_write"] > input'
+    )
+    osf_nodes_full_read_checkbox = Locator(
+        By.CSS_SELECTOR, 'div[data-test-scope="osf.nodes.full_read"] > input'
+    )
+    osf_nodes_metadata_write_checkbox = Locator(
+        By.CSS_SELECTOR, 'div[data-test-scope="osf.nodes.metadata_write"] > input'
+    )
+    osf_full_read_checkbox = Locator(
+        By.CSS_SELECTOR, 'div[data-test-scope="osf.full_read"] > input'
+    )
+    osf_nodes_metadata_read_checkbox = Locator(
+        By.CSS_SELECTOR, 'div[data-test-scope="osf.nodes.metadata_read"] > input'
+    )
+    osf_nodes_access_read_checkbox = Locator(
+        By.CSS_SELECTOR, 'div[data-test-scope="osf.nodes.access_read"] > input'
+    )
+    osf_nodes_access_write_checkbox = Locator(
+        By.CSS_SELECTOR, 'div[data-test-scope="osf.nodes.access_write"] > input'
+    )
+    osf_nodes_data_read_checkbox = Locator(
+        By.CSS_SELECTOR, 'div[data-test-scope="osf.nodes.data_read"] > input'
+    )
+    osf_nodes_data_write_checkbox = Locator(
+        By.CSS_SELECTOR, 'div[data-test-scope="osf.nodes.data_write"] > input'
+    )
+    osf_users_email_read_checkbox = Locator(
+        By.CSS_SELECTOR, 'div[data-test-scope="osf.users.email_read"] > input'
+    )
+    osf_users_profile_read_checkbox = Locator(
+        By.CSS_SELECTOR, 'div[data-test-scope="osf.users.profile_read"] > input'
+    )
+    create_token_button = Locator(By.CSS_SELECTOR, '[data-test-create-token-button')
+
+
+class EditPersonalAccessTokenPage(BaseUserSettingsPage):
+    base_url = settings.OSF_HOME + '/settings/tokens/'
+
+    identity = Locator(By.CSS_SELECTOR, 'div[data-analytics-scope="Edit"]')
+    new_token_input = Locator(By.CSS_SELECTOR, 'div[data-test-new-token-value] > input')
+    back_to_list_of_tokens_link = Locator(
+        By.CSS_SELECTOR, 'a[data-test-back-to-tokens]'
+    )
+    token_name_input = Locator(By.NAME, 'name')
+    osf_users_profile_write_checkbox = Locator(
+        By.CSS_SELECTOR, 'div[data-test-scope="osf.users.profile_write"] > input'
+    )
+    osf_full_write_checkbox = Locator(
+        By.CSS_SELECTOR, 'div[data-test-scope="osf.full_write"] > input'
+    )
+    osf_nodes_full_write_checkbox = Locator(
+        By.CSS_SELECTOR, 'div[data-test-scope="osf.nodes.full_write"] > input'
+    )
+    osf_nodes_full_read_checkbox = Locator(
+        By.CSS_SELECTOR, 'div[data-test-scope="osf.nodes.full_read"] > input'
+    )
+    osf_nodes_metadata_write_checkbox = Locator(
+        By.CSS_SELECTOR, 'div[data-test-scope="osf.nodes.metadata_write"] > input'
+    )
+    osf_full_read_checkbox = Locator(
+        By.CSS_SELECTOR, 'div[data-test-scope="osf.full_read"] > input'
+    )
+    osf_nodes_metadata_read_checkbox = Locator(
+        By.CSS_SELECTOR, 'div[data-test-scope="osf.nodes.metadata_read"] > input'
+    )
+    osf_nodes_access_read_checkbox = Locator(
+        By.CSS_SELECTOR, 'div[data-test-scope="osf.nodes.access_read"] > input'
+    )
+    osf_nodes_access_write_checkbox = Locator(
+        By.CSS_SELECTOR, 'div[data-test-scope="osf.nodes.access_write"] > input'
+    )
+    osf_nodes_data_read_checkbox = Locator(
+        By.CSS_SELECTOR, 'div[data-test-scope="osf.nodes.data_read"] > input'
+    )
+    osf_nodes_data_write_checkbox = Locator(
+        By.CSS_SELECTOR, 'div[data-test-scope="osf.nodes.data_write"] > input'
+    )
+    osf_users_email_read_checkbox = Locator(
+        By.CSS_SELECTOR, 'div[data-test-scope="osf.users.email_read"] > input'
+    )
+    osf_users_profile_read_checkbox = Locator(
+        By.CSS_SELECTOR, 'div[data-test-scope="osf.users.profile_read"] > input'
+    )
+    delete_button = Locator(By.CSS_SELECTOR, '[data-test-delete-button')
+    save_button = Locator(By.CSS_SELECTOR, '[data-test-save-token-button')
+
+    def __init__(self, driver, verify=False, token_id=''):
+        self.token_id = token_id
+        super().__init__(driver, verify)
+
+    @property
+    def url(self):
+        return self.base_url + self.token_id

--- a/pages/user.py
+++ b/pages/user.py
@@ -9,6 +9,7 @@ from base.locators import (
 )
 from components.user import (
     DeleteDevAppModal,
+    DeletePATModal,
     SettingsSideNavigation,
 )
 from pages.base import (
@@ -157,6 +158,8 @@ class PersonalAccessTokenPage(BaseUserSettingsPage):
 
     pat_cards = GroupLocator(By.CSS_SELECTOR, 'div[data-test-token-card]')
 
+    delete_pat_modal = ComponentLocator(DeletePATModal)
+
     def get_pat_card_by_name(self, pat_name):
         for pat_card in self.pat_cards:
             token_name = pat_card.find_element_by_css_selector(
@@ -263,6 +266,8 @@ class EditPersonalAccessTokenPage(BaseUserSettingsPage):
     )
     delete_button = Locator(By.CSS_SELECTOR, '[data-test-delete-button')
     save_button = Locator(By.CSS_SELECTOR, '[data-test-save-token-button')
+
+    delete_pat_modal = ComponentLocator(DeletePATModal)
 
     def __init__(self, driver, verify=False, token_id=''):
         self.token_id = token_id

--- a/pages/user.py
+++ b/pages/user.py
@@ -221,6 +221,9 @@ class EditPersonalAccessTokenPage(BaseUserSettingsPage):
 
     identity = Locator(By.CSS_SELECTOR, 'div[data-analytics-scope="Edit"]')
     new_token_input = Locator(By.CSS_SELECTOR, 'div[data-test-new-token-value] > input')
+    copy_to_clipboard_button = Locator(
+        By.CSS_SELECTOR, 'div[data-test-new-token-value] > span > button'
+    )
     back_to_list_of_tokens_link = Locator(
         By.CSS_SELECTOR, 'a[data-test-back-to-tokens]'
     )

--- a/pages/user.py
+++ b/pages/user.py
@@ -220,6 +220,7 @@ class EditPersonalAccessTokenPage(BaseUserSettingsPage):
     base_url = settings.OSF_HOME + '/settings/tokens/'
 
     identity = Locator(By.CSS_SELECTOR, 'div[data-analytics-scope="Edit"]')
+    loading_indicator = Locator(By.CSS_SELECTOR, '.ball-pulse')
     new_token_input = Locator(By.CSS_SELECTOR, 'div[data-test-new-token-value] > input')
     copy_to_clipboard_button = Locator(
         By.CSS_SELECTOR, 'div[data-test-new-token-value] > span > button'

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -1,4 +1,5 @@
 import os
+import re
 
 import pytest
 from selenium.webdriver.common.by import By
@@ -106,6 +107,133 @@ class TestUserSettings:
                 new_name,
             )
         )
+
+    @markers.dont_run_on_prod
+    def test_user_settings_create_PAT(self, driver, session, fake):
+        """Create a Personal Access Token from the User Settings Personal Access Tokens
+        page in OSF. The test uses the OSF api to delete the personal access token at
+        the end of the test as cleanup.
+        """
+        pat_page = user.PersonalAccessTokenPage(driver)
+        pat_page.goto()
+        assert user.PersonalAccessTokenPage(driver, verify=True)
+        pat_page.loading_indicator.here_then_gone()
+        pat_page.create_token_button.click()
+        create_pat_page = user.CreatePersonalAccessTokenPage(driver, verify=True)
+        try:
+            # Complete the form fields and click the Create token button
+            token_name = fake.sentence(nb_words=3)
+            create_pat_page.token_name_input.send_keys(token_name)
+            # Check all the 'read' access checkboxes
+            create_pat_page.scroll_into_view(
+                create_pat_page.osf_nodes_full_read_checkbox.element
+            )
+            create_pat_page.osf_nodes_full_read_checkbox.click()
+            create_pat_page.scroll_into_view(
+                create_pat_page.osf_full_read_checkbox.element
+            )
+            create_pat_page.osf_full_read_checkbox.click()
+            create_pat_page.scroll_into_view(
+                create_pat_page.osf_nodes_metadata_read_checkbox.element
+            )
+            create_pat_page.osf_nodes_metadata_read_checkbox.click()
+            create_pat_page.scroll_into_view(
+                create_pat_page.osf_nodes_access_read_checkbox.element
+            )
+            create_pat_page.osf_nodes_access_read_checkbox.click()
+            create_pat_page.scroll_into_view(
+                create_pat_page.osf_nodes_data_read_checkbox.element
+            )
+            create_pat_page.osf_nodes_data_read_checkbox.click()
+            create_pat_page.scroll_into_view(
+                create_pat_page.osf_users_email_read_checkbox.element
+            )
+            create_pat_page.osf_users_email_read_checkbox.click()
+            create_pat_page.scroll_into_view(
+                create_pat_page.osf_users_profile_read_checkbox.element
+            )
+            create_pat_page.osf_users_profile_read_checkbox.click()
+            create_pat_page.scroll_into_view(
+                create_pat_page.create_token_button.element
+            )
+            create_pat_page.create_token_button.click()
+            # Should end up on Token Detail page with newly created token displayed
+            edit_pat_page = user.EditPersonalAccessTokenPage(driver, verify=True)
+            # Capture the token id from the url
+            match = re.search(r'tokens/([a-z0-9]{24})\?view_only=', driver.current_url)
+            token_id = match.group(1)
+            # Verify that New Token Input Box has a value
+            assert edit_pat_page.new_token_input.get_attribute('value') != ''
+            # Click the Back to list of tokens link
+            edit_pat_page.back_to_list_of_tokens_link.click()
+            pat_page = user.PersonalAccessTokenPage(driver, verify=True)
+            pat_page.loading_indicator.here_then_gone()
+            # Go through the list of PATs listed on the page to find the one that was
+            # just added
+            pat_card = pat_page.get_pat_card_by_name(token_name)
+            pat_link = pat_card.find_element_by_css_selector('a')
+            link_url = pat_link.get_attribute('href')
+            link_token_id = link_url.split('tokens/', 1)[1]
+            assert link_token_id == token_id
+            # Now click the PAT name link to go to the Edit PAT page and verify the
+            # data
+            pat_link.click()
+            edit_pat_page = user.EditPersonalAccessTokenPage(driver, verify=True)
+            assert edit_pat_page.token_name_input.get_attribute('value') == token_name
+            edit_pat_page.scroll_into_view(
+                edit_pat_page.osf_nodes_full_read_checkbox.element
+            )
+            assert edit_pat_page.osf_nodes_full_read_checkbox.is_selected()
+            edit_pat_page.scroll_into_view(edit_pat_page.osf_full_read_checkbox.element)
+            assert edit_pat_page.osf_full_read_checkbox.is_selected()
+            edit_pat_page.scroll_into_view(
+                edit_pat_page.osf_nodes_metadata_read_checkbox.element
+            )
+            assert edit_pat_page.osf_nodes_metadata_read_checkbox.is_selected()
+            edit_pat_page.scroll_into_view(
+                edit_pat_page.osf_nodes_access_read_checkbox.element
+            )
+            assert edit_pat_page.osf_nodes_access_read_checkbox.is_selected()
+            edit_pat_page.scroll_into_view(
+                edit_pat_page.osf_nodes_data_read_checkbox.element
+            )
+            assert edit_pat_page.osf_nodes_data_read_checkbox.is_selected()
+            edit_pat_page.scroll_into_view(
+                edit_pat_page.osf_users_email_read_checkbox.element
+            )
+            assert edit_pat_page.osf_users_email_read_checkbox.is_selected()
+            edit_pat_page.scroll_into_view(
+                edit_pat_page.osf_users_profile_read_checkbox.element
+            )
+            assert edit_pat_page.osf_users_profile_read_checkbox.is_selected()
+            edit_pat_page.scroll_into_view(
+                edit_pat_page.osf_users_profile_write_checkbox.element
+            )
+            assert not edit_pat_page.osf_users_profile_write_checkbox.is_selected()
+            edit_pat_page.scroll_into_view(
+                edit_pat_page.osf_full_write_checkbox.element
+            )
+            assert not edit_pat_page.osf_full_write_checkbox.is_selected()
+            edit_pat_page.scroll_into_view(
+                edit_pat_page.osf_nodes_full_write_checkbox.element
+            )
+            assert not edit_pat_page.osf_nodes_full_write_checkbox.is_selected()
+            edit_pat_page.scroll_into_view(
+                edit_pat_page.osf_nodes_metadata_write_checkbox.element
+            )
+            assert not edit_pat_page.osf_nodes_metadata_write_checkbox.is_selected()
+            edit_pat_page.scroll_into_view(
+                edit_pat_page.osf_nodes_access_write_checkbox.element
+            )
+            assert not edit_pat_page.osf_nodes_access_write_checkbox.is_selected()
+            edit_pat_page.scroll_into_view(
+                edit_pat_page.osf_nodes_data_write_checkbox.element
+            )
+            assert not edit_pat_page.osf_nodes_data_write_checkbox.is_selected()
+        finally:
+            # Delete the token using the api as cleanup
+            if token_id:
+                osf_api.delete_personal_access_token(session, token_id=token_id)
 
 
 @markers.dont_run_on_prod

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -235,6 +235,257 @@ class TestUserSettings:
             if token_id:
                 osf_api.delete_personal_access_token(session, token_id=token_id)
 
+    @markers.dont_run_on_prod
+    def test_user_settings_delete_PAT_from_edit_page(self, driver, session, fake):
+        """Delete a Personal Access Token from the User Settings Edit Personal Access
+        Token page in OSF. The test uses the OSF api to first create the personal access
+        token that will then be deleted using the Front End interface.
+        """
+        token_name = 'PAT created via api ' + fake.sentence(nb_words=1)
+        token_id = osf_api.create_personal_access_token(
+            session,
+            name=token_name,
+            scopes='osf.nodes.full_read osf.nodes.metadata_read osf.nodes.access_read osf.nodes.data_read',
+        )
+        try:
+            # Go to the Profile Information page first and use the side navigation bar
+            # to then go to the Personal Access Tokens page.
+            profile_settings_page = user.ProfileInformationPage(driver)
+            profile_settings_page.goto()
+            assert user.ProfileInformationPage(driver, verify=True)
+            profile_settings_page.side_navigation.personal_access_tokens_link.click()
+            pat_page = user.PersonalAccessTokenPage(driver, verify=True)
+            pat_page.loading_indicator.here_then_gone()
+            # Go through the list of PATs listed on the page to find the one that was
+            # just added via the api
+            pat_card = pat_page.get_pat_card_by_name(token_name)
+            pat_link = pat_card.find_element_by_css_selector('a')
+            link_url = pat_link.get_attribute('href')
+            link_token_id = link_url.split('tokens/', 1)[1]
+            assert link_token_id == token_id
+            # Now click the PAT name link to go to the Edit PAT page and verify the
+            # data
+            pat_link.click()
+            edit_pat_page = user.EditPersonalAccessTokenPage(driver, verify=True)
+            assert edit_pat_page.token_name_input.get_attribute('value') == token_name
+            edit_pat_page.scroll_into_view(
+                edit_pat_page.osf_nodes_full_read_checkbox.element
+            )
+            assert edit_pat_page.osf_nodes_full_read_checkbox.is_selected()
+            edit_pat_page.scroll_into_view(
+                edit_pat_page.osf_nodes_metadata_read_checkbox.element
+            )
+            assert edit_pat_page.osf_nodes_metadata_read_checkbox.is_selected()
+            edit_pat_page.scroll_into_view(
+                edit_pat_page.osf_nodes_access_read_checkbox.element
+            )
+            assert edit_pat_page.osf_nodes_access_read_checkbox.is_selected()
+            edit_pat_page.scroll_into_view(
+                edit_pat_page.osf_nodes_data_read_checkbox.element
+            )
+            assert edit_pat_page.osf_nodes_data_read_checkbox.is_selected()
+            edit_pat_page.scroll_into_view(
+                edit_pat_page.osf_users_profile_write_checkbox.element
+            )
+            assert not edit_pat_page.osf_users_profile_write_checkbox.is_selected()
+            edit_pat_page.scroll_into_view(
+                edit_pat_page.osf_full_write_checkbox.element
+            )
+            assert not edit_pat_page.osf_full_write_checkbox.is_selected()
+            edit_pat_page.scroll_into_view(
+                edit_pat_page.osf_nodes_metadata_write_checkbox.element
+            )
+            assert not edit_pat_page.osf_nodes_metadata_write_checkbox.is_selected()
+            edit_pat_page.scroll_into_view(edit_pat_page.osf_full_read_checkbox.element)
+            assert not edit_pat_page.osf_full_read_checkbox.is_selected()
+            edit_pat_page.scroll_into_view(
+                edit_pat_page.osf_nodes_full_write_checkbox.element
+            )
+            assert not edit_pat_page.osf_nodes_full_write_checkbox.is_selected()
+            edit_pat_page.scroll_into_view(
+                edit_pat_page.osf_nodes_access_write_checkbox.element
+            )
+            assert not edit_pat_page.osf_nodes_access_write_checkbox.is_selected()
+            edit_pat_page.scroll_into_view(
+                edit_pat_page.osf_nodes_data_write_checkbox.element
+            )
+            assert not edit_pat_page.osf_nodes_data_write_checkbox.is_selected()
+            edit_pat_page.scroll_into_view(
+                edit_pat_page.osf_users_email_read_checkbox.element
+            )
+            assert not edit_pat_page.osf_users_email_read_checkbox.is_selected()
+            edit_pat_page.scroll_into_view(
+                edit_pat_page.osf_users_profile_read_checkbox.element
+            )
+            assert not edit_pat_page.osf_users_profile_read_checkbox.is_selected()
+            # Click the Delete button
+            edit_pat_page.scroll_into_view(edit_pat_page.delete_button.element)
+            edit_pat_page.delete_button.click()
+            # On the Delete Token modal - first click the Cancel button
+            delete_modal = edit_pat_page.delete_pat_modal
+            assert delete_modal.token_name.text == token_name
+            delete_modal.cancel_button.click()
+            # Should still be on the Edit page
+            assert user.EditPersonalAccessTokenPage(driver, verify=True)
+            # Go back to the Personal Access Tokens list page to make sure the PAT is
+            # still there
+            pat_page = user.PersonalAccessTokenPage(driver)
+            pat_page.goto()
+            assert user.PersonalAccessTokenPage(driver, verify=True)
+            pat_page.loading_indicator.here_then_gone()
+            pat_card = pat_page.get_pat_card_by_name(token_name)
+            assert pat_card
+            pat_link = pat_card.find_element_by_css_selector('a')
+            # Now click the PAT name link again to go back to the Edit PAT page
+            pat_link.click()
+            edit_pat_page = user.EditPersonalAccessTokenPage(driver, verify=True)
+            assert edit_pat_page.token_name_input.get_attribute('value') == token_name
+            # Click the Delete button again and this time click the Delete button on the
+            # Delete Token Modal
+            edit_pat_page.scroll_into_view(edit_pat_page.delete_button.element)
+            edit_pat_page.delete_button.click()
+            delete_modal = edit_pat_page.delete_pat_modal
+            assert delete_modal.token_name.text == token_name
+            delete_modal.delete_button.click()
+            # This time we should end up on the PAT list page
+            pat_page = user.PersonalAccessTokenPage(driver, verify=True)
+            pat_page.loading_indicator.here_then_gone()
+            pat_card = pat_page.get_pat_card_by_name(token_name)
+            # Verify that we don't find the PAT card this time since it was deleted
+            assert not pat_card
+        except Exception:
+            # As cleanup, delete the PAT using the api if the test failed for some
+            # reason and the PAT was not actually deleted.
+            pat_data = osf_api.get_user_pat_data(session, token_id=token_id)
+            if pat_data:
+                osf_api.delete_personal_access_token(session, token_id=token_id)
+
+    @markers.dont_run_on_prod
+    def test_user_settings_delete_PAT_from_list_page(self, driver, session, fake):
+        """Delete a Personal Access Token from the User Settings Edit Personal Access
+        Token page in OSF. The test uses the OSF api to first create the personal access
+        token that will then be deleted using the Front End interface.
+        """
+        token_name = 'PAT created via api ' + fake.sentence(nb_words=1)
+        token_id = osf_api.create_personal_access_token(
+            session,
+            name=token_name,
+            scopes='osf.users.profile_read osf.users.email_read',
+        )
+        try:
+            # Go to the Profile Information page first and use the side navigation bar
+            # to then go to the Personal Access Tokens page.
+            profile_settings_page = user.ProfileInformationPage(driver)
+            profile_settings_page.goto()
+            assert user.ProfileInformationPage(driver, verify=True)
+            profile_settings_page.side_navigation.personal_access_tokens_link.click()
+            pat_page = user.PersonalAccessTokenPage(driver, verify=True)
+            pat_page.loading_indicator.here_then_gone()
+            # Go through the list of PATs listed on the page to find the one that was
+            # just added via the api
+            pat_card = pat_page.get_pat_card_by_name(token_name)
+            pat_link = pat_card.find_element_by_css_selector('a')
+            link_url = pat_link.get_attribute('href')
+            link_token_id = link_url.split('tokens/', 1)[1]
+            assert link_token_id == token_id
+            # Now click the PAT name link to go to the Edit PAT page and verify the
+            # data
+            pat_link.click()
+            edit_pat_page = user.EditPersonalAccessTokenPage(driver, verify=True)
+            assert edit_pat_page.token_name_input.get_attribute('value') == token_name
+            edit_pat_page.scroll_into_view(
+                edit_pat_page.osf_nodes_full_read_checkbox.element
+            )
+            assert not edit_pat_page.osf_nodes_full_read_checkbox.is_selected()
+            edit_pat_page.scroll_into_view(
+                edit_pat_page.osf_nodes_metadata_read_checkbox.element
+            )
+            assert not edit_pat_page.osf_nodes_metadata_read_checkbox.is_selected()
+            edit_pat_page.scroll_into_view(
+                edit_pat_page.osf_nodes_access_read_checkbox.element
+            )
+            assert not edit_pat_page.osf_nodes_access_read_checkbox.is_selected()
+            edit_pat_page.scroll_into_view(
+                edit_pat_page.osf_nodes_data_read_checkbox.element
+            )
+            assert not edit_pat_page.osf_nodes_data_read_checkbox.is_selected()
+            edit_pat_page.scroll_into_view(
+                edit_pat_page.osf_users_profile_write_checkbox.element
+            )
+            assert not edit_pat_page.osf_users_profile_write_checkbox.is_selected()
+            edit_pat_page.scroll_into_view(
+                edit_pat_page.osf_full_write_checkbox.element
+            )
+            assert not edit_pat_page.osf_full_write_checkbox.is_selected()
+            edit_pat_page.scroll_into_view(
+                edit_pat_page.osf_nodes_metadata_write_checkbox.element
+            )
+            assert not edit_pat_page.osf_nodes_metadata_write_checkbox.is_selected()
+            edit_pat_page.scroll_into_view(edit_pat_page.osf_full_read_checkbox.element)
+            assert not edit_pat_page.osf_full_read_checkbox.is_selected()
+            edit_pat_page.scroll_into_view(
+                edit_pat_page.osf_nodes_full_write_checkbox.element
+            )
+            assert not edit_pat_page.osf_nodes_full_write_checkbox.is_selected()
+            edit_pat_page.scroll_into_view(
+                edit_pat_page.osf_nodes_access_write_checkbox.element
+            )
+            assert not edit_pat_page.osf_nodes_access_write_checkbox.is_selected()
+            edit_pat_page.scroll_into_view(
+                edit_pat_page.osf_nodes_data_write_checkbox.element
+            )
+            assert not edit_pat_page.osf_nodes_data_write_checkbox.is_selected()
+            edit_pat_page.scroll_into_view(
+                edit_pat_page.osf_users_email_read_checkbox.element
+            )
+            assert edit_pat_page.osf_users_email_read_checkbox.is_selected()
+            edit_pat_page.scroll_into_view(
+                edit_pat_page.osf_users_profile_read_checkbox.element
+            )
+            assert edit_pat_page.osf_users_profile_read_checkbox.is_selected()
+            # Click the Back to list of tokens link
+            edit_pat_page.back_to_list_of_tokens_link.click()
+            assert user.PersonalAccessTokenPage(driver, verify=True)
+            pat_page.loading_indicator.here_then_gone()
+            # Find the PAT on the list page and click the Delete button on the right
+            # side of the card
+            pat_card = pat_page.get_pat_card_by_name(token_name)
+            assert pat_card
+            delete_button = pat_card.find_element_by_css_selector(
+                '[data-test-delete-button]'
+            )
+            delete_button.click()
+            # On the Delete Token modal - first click the Cancel button
+            delete_modal = pat_page.delete_pat_modal
+            assert delete_modal.token_name.text == token_name
+            delete_modal.cancel_button.click()
+            # Should still be on the PAT list page and the PAT should still be displayed
+            pat_page = user.PersonalAccessTokenPage(driver, verify=True)
+            pat_page.loading_indicator.here_then_gone()
+            pat_card = pat_page.get_pat_card_by_name(token_name)
+            assert pat_card
+            # Click the Delete button again and this time click the Delete button on the
+            # Delete Token Modal
+            delete_button = pat_card.find_element_by_css_selector(
+                '[data-test-delete-button]'
+            )
+            delete_button.click()
+            delete_modal = pat_page.delete_pat_modal
+            assert delete_modal.token_name.text == token_name
+            delete_modal.delete_button.click()
+            # Should still be on PAT list page
+            pat_page = user.PersonalAccessTokenPage(driver, verify=True)
+            pat_page.loading_indicator.here_then_gone()
+            pat_card = pat_page.get_pat_card_by_name(token_name)
+            # Verify that we don't find the PAT card this time since it was deleted
+            assert not pat_card
+        except Exception:
+            # As cleanup, delete the PAT using the api if the test failed for some
+            # reason and the PAT was not actually deleted.
+            pat_data = osf_api.get_user_pat_data(session, token_id=token_id)
+            if pat_data:
+                osf_api.delete_personal_access_token(session, token_id=token_id)
+
 
 @markers.dont_run_on_prod
 @pytest.mark.usefixtures('must_be_logged_in')

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -599,6 +599,7 @@ class TestUserPersonalAccessTokens:
             # data
             pat_link.click()
             edit_page = user.EditPersonalAccessTokenPage(driver, verify=True)
+            edit_page.loading_indicator.here_then_gone()
             assert edit_page.token_name_input.get_attribute('value') == token_name
 
             # Use helper function to verify scopes. Pre-set all scopes to True and then
@@ -663,6 +664,7 @@ class TestUserPersonalAccessTokens:
             # data
             pat_link.click()
             edit_page = user.EditPersonalAccessTokenPage(driver, verify=True)
+            edit_page.loading_indicator.here_then_gone()
             assert edit_page.token_name_input.get_attribute('value') == token_name
 
             # Use helper function to verify scopes. Pre-set all scopes to False and then
@@ -772,6 +774,7 @@ class TestUserPersonalAccessTokens:
             # data
             pat_link.click()
             edit_page = user.EditPersonalAccessTokenPage(driver, verify=True)
+            edit_page.loading_indicator.here_then_gone()
             assert edit_page.token_name_input.get_attribute('value') == token_name
 
             # Use helper function to verify scopes. Pre-set all scopes to False and then
@@ -859,6 +862,7 @@ class TestUserPersonalAccessTokens:
             # data
             pat_link.click()
             edit_page = user.EditPersonalAccessTokenPage(driver, verify=True)
+            edit_page.loading_indicator.here_then_gone()
             assert edit_page.token_name_input.get_attribute('value') == token_name
 
             # Use helper function to verify scopes. Pre-set all scopes to False and then
@@ -893,6 +897,7 @@ class TestUserPersonalAccessTokens:
             pat_link = pat_card.find_element_by_css_selector('a')
             pat_link.click()
             edit_page = user.EditPersonalAccessTokenPage(driver, verify=True)
+            edit_page.loading_indicator.here_then_gone()
             assert edit_page.token_name_input.get_attribute('value') == new_token_name
 
             # Use helper function to verify scopes. Pre-set all scopes to False and then

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -108,545 +108,6 @@ class TestUserSettings:
             )
         )
 
-    @markers.dont_run_on_prod
-    def test_user_settings_create_PAT(self, driver, session, fake):
-        """Create a Personal Access Token from the User Settings Personal Access Tokens
-        page in OSF. The test uses the OSF api to delete the personal access token at
-        the end of the test as cleanup.
-        """
-        pat_page = user.PersonalAccessTokenPage(driver)
-        pat_page.goto()
-        assert user.PersonalAccessTokenPage(driver, verify=True)
-        pat_page.loading_indicator.here_then_gone()
-        pat_page.create_token_button.click()
-        create_pat_page = user.CreatePersonalAccessTokenPage(driver, verify=True)
-        try:
-            # Complete the form fields and click the Create token button
-            token_name = fake.sentence(nb_words=3)
-            create_pat_page.token_name_input.send_keys(token_name)
-            # Check all the 'read' access checkboxes
-            create_pat_page.scroll_into_view(
-                create_pat_page.osf_nodes_full_read_checkbox.element
-            )
-            create_pat_page.osf_nodes_full_read_checkbox.click()
-            create_pat_page.scroll_into_view(
-                create_pat_page.osf_full_read_checkbox.element
-            )
-            create_pat_page.osf_full_read_checkbox.click()
-            create_pat_page.scroll_into_view(
-                create_pat_page.osf_nodes_metadata_read_checkbox.element
-            )
-            create_pat_page.osf_nodes_metadata_read_checkbox.click()
-            create_pat_page.scroll_into_view(
-                create_pat_page.osf_nodes_access_read_checkbox.element
-            )
-            create_pat_page.osf_nodes_access_read_checkbox.click()
-            create_pat_page.scroll_into_view(
-                create_pat_page.osf_nodes_data_read_checkbox.element
-            )
-            create_pat_page.osf_nodes_data_read_checkbox.click()
-            create_pat_page.scroll_into_view(
-                create_pat_page.osf_users_email_read_checkbox.element
-            )
-            create_pat_page.osf_users_email_read_checkbox.click()
-            create_pat_page.scroll_into_view(
-                create_pat_page.osf_users_profile_read_checkbox.element
-            )
-            create_pat_page.osf_users_profile_read_checkbox.click()
-            create_pat_page.scroll_into_view(
-                create_pat_page.create_token_button.element
-            )
-            create_pat_page.create_token_button.click()
-            # Should end up on Token Detail page with newly created token displayed
-            edit_pat_page = user.EditPersonalAccessTokenPage(driver, verify=True)
-            # Capture the token id from the url
-            match = re.search(r'tokens/([a-z0-9]{24})\?view_only=', driver.current_url)
-            token_id = match.group(1)
-            # Verify that New Token Input Box has a value
-            assert edit_pat_page.new_token_input.get_attribute('value') != ''
-            # Click the Back to list of tokens link
-            edit_pat_page.back_to_list_of_tokens_link.click()
-            pat_page = user.PersonalAccessTokenPage(driver, verify=True)
-            pat_page.loading_indicator.here_then_gone()
-            # Go through the list of PATs listed on the page to find the one that was
-            # just added
-            pat_card = pat_page.get_pat_card_by_name(token_name)
-            pat_link = pat_card.find_element_by_css_selector('a')
-            link_url = pat_link.get_attribute('href')
-            link_token_id = link_url.split('tokens/', 1)[1]
-            assert link_token_id == token_id
-            # Now click the PAT name link to go to the Edit PAT page and verify the
-            # data
-            pat_link.click()
-            edit_pat_page = user.EditPersonalAccessTokenPage(driver, verify=True)
-            assert edit_pat_page.token_name_input.get_attribute('value') == token_name
-            edit_pat_page.scroll_into_view(
-                edit_pat_page.osf_nodes_full_read_checkbox.element
-            )
-            assert edit_pat_page.osf_nodes_full_read_checkbox.is_selected()
-            edit_pat_page.scroll_into_view(edit_pat_page.osf_full_read_checkbox.element)
-            assert edit_pat_page.osf_full_read_checkbox.is_selected()
-            edit_pat_page.scroll_into_view(
-                edit_pat_page.osf_nodes_metadata_read_checkbox.element
-            )
-            assert edit_pat_page.osf_nodes_metadata_read_checkbox.is_selected()
-            edit_pat_page.scroll_into_view(
-                edit_pat_page.osf_nodes_access_read_checkbox.element
-            )
-            assert edit_pat_page.osf_nodes_access_read_checkbox.is_selected()
-            edit_pat_page.scroll_into_view(
-                edit_pat_page.osf_nodes_data_read_checkbox.element
-            )
-            assert edit_pat_page.osf_nodes_data_read_checkbox.is_selected()
-            edit_pat_page.scroll_into_view(
-                edit_pat_page.osf_users_email_read_checkbox.element
-            )
-            assert edit_pat_page.osf_users_email_read_checkbox.is_selected()
-            edit_pat_page.scroll_into_view(
-                edit_pat_page.osf_users_profile_read_checkbox.element
-            )
-            assert edit_pat_page.osf_users_profile_read_checkbox.is_selected()
-            edit_pat_page.scroll_into_view(
-                edit_pat_page.osf_users_profile_write_checkbox.element
-            )
-            assert not edit_pat_page.osf_users_profile_write_checkbox.is_selected()
-            edit_pat_page.scroll_into_view(
-                edit_pat_page.osf_full_write_checkbox.element
-            )
-            assert not edit_pat_page.osf_full_write_checkbox.is_selected()
-            edit_pat_page.scroll_into_view(
-                edit_pat_page.osf_nodes_full_write_checkbox.element
-            )
-            assert not edit_pat_page.osf_nodes_full_write_checkbox.is_selected()
-            edit_pat_page.scroll_into_view(
-                edit_pat_page.osf_nodes_metadata_write_checkbox.element
-            )
-            assert not edit_pat_page.osf_nodes_metadata_write_checkbox.is_selected()
-            edit_pat_page.scroll_into_view(
-                edit_pat_page.osf_nodes_access_write_checkbox.element
-            )
-            assert not edit_pat_page.osf_nodes_access_write_checkbox.is_selected()
-            edit_pat_page.scroll_into_view(
-                edit_pat_page.osf_nodes_data_write_checkbox.element
-            )
-            assert not edit_pat_page.osf_nodes_data_write_checkbox.is_selected()
-        finally:
-            # Delete the token using the api as cleanup
-            if token_id:
-                osf_api.delete_personal_access_token(session, token_id=token_id)
-
-    @markers.dont_run_on_prod
-    def test_user_settings_delete_PAT_from_edit_page(self, driver, session, fake):
-        """Delete a Personal Access Token from the User Settings Edit Personal Access
-        Token page in OSF. The test uses the OSF api to first create the personal access
-        token that will then be deleted using the Front End interface.
-        """
-        token_name = 'PAT created via api ' + fake.sentence(nb_words=1)
-        token_id = osf_api.create_personal_access_token(
-            session,
-            name=token_name,
-            scopes='osf.nodes.full_read osf.nodes.metadata_read osf.nodes.access_read osf.nodes.data_read',
-        )
-        try:
-            # Go to the Profile Information page first and use the side navigation bar
-            # to then go to the Personal Access Tokens page.
-            profile_settings_page = user.ProfileInformationPage(driver)
-            profile_settings_page.goto()
-            assert user.ProfileInformationPage(driver, verify=True)
-            profile_settings_page.side_navigation.personal_access_tokens_link.click()
-            pat_page = user.PersonalAccessTokenPage(driver, verify=True)
-            pat_page.loading_indicator.here_then_gone()
-            # Go through the list of PATs listed on the page to find the one that was
-            # just added via the api
-            pat_card = pat_page.get_pat_card_by_name(token_name)
-            pat_link = pat_card.find_element_by_css_selector('a')
-            link_url = pat_link.get_attribute('href')
-            link_token_id = link_url.split('tokens/', 1)[1]
-            assert link_token_id == token_id
-            # Now click the PAT name link to go to the Edit PAT page and verify the
-            # data
-            pat_link.click()
-            edit_pat_page = user.EditPersonalAccessTokenPage(driver, verify=True)
-            assert edit_pat_page.token_name_input.get_attribute('value') == token_name
-            edit_pat_page.scroll_into_view(
-                edit_pat_page.osf_nodes_full_read_checkbox.element
-            )
-            assert edit_pat_page.osf_nodes_full_read_checkbox.is_selected()
-            edit_pat_page.scroll_into_view(
-                edit_pat_page.osf_nodes_metadata_read_checkbox.element
-            )
-            assert edit_pat_page.osf_nodes_metadata_read_checkbox.is_selected()
-            edit_pat_page.scroll_into_view(
-                edit_pat_page.osf_nodes_access_read_checkbox.element
-            )
-            assert edit_pat_page.osf_nodes_access_read_checkbox.is_selected()
-            edit_pat_page.scroll_into_view(
-                edit_pat_page.osf_nodes_data_read_checkbox.element
-            )
-            assert edit_pat_page.osf_nodes_data_read_checkbox.is_selected()
-            edit_pat_page.scroll_into_view(
-                edit_pat_page.osf_users_profile_write_checkbox.element
-            )
-            assert not edit_pat_page.osf_users_profile_write_checkbox.is_selected()
-            edit_pat_page.scroll_into_view(
-                edit_pat_page.osf_full_write_checkbox.element
-            )
-            assert not edit_pat_page.osf_full_write_checkbox.is_selected()
-            edit_pat_page.scroll_into_view(
-                edit_pat_page.osf_nodes_metadata_write_checkbox.element
-            )
-            assert not edit_pat_page.osf_nodes_metadata_write_checkbox.is_selected()
-            edit_pat_page.scroll_into_view(edit_pat_page.osf_full_read_checkbox.element)
-            assert not edit_pat_page.osf_full_read_checkbox.is_selected()
-            edit_pat_page.scroll_into_view(
-                edit_pat_page.osf_nodes_full_write_checkbox.element
-            )
-            assert not edit_pat_page.osf_nodes_full_write_checkbox.is_selected()
-            edit_pat_page.scroll_into_view(
-                edit_pat_page.osf_nodes_access_write_checkbox.element
-            )
-            assert not edit_pat_page.osf_nodes_access_write_checkbox.is_selected()
-            edit_pat_page.scroll_into_view(
-                edit_pat_page.osf_nodes_data_write_checkbox.element
-            )
-            assert not edit_pat_page.osf_nodes_data_write_checkbox.is_selected()
-            edit_pat_page.scroll_into_view(
-                edit_pat_page.osf_users_email_read_checkbox.element
-            )
-            assert not edit_pat_page.osf_users_email_read_checkbox.is_selected()
-            edit_pat_page.scroll_into_view(
-                edit_pat_page.osf_users_profile_read_checkbox.element
-            )
-            assert not edit_pat_page.osf_users_profile_read_checkbox.is_selected()
-            # Click the Delete button
-            edit_pat_page.scroll_into_view(edit_pat_page.delete_button.element)
-            edit_pat_page.delete_button.click()
-            # On the Delete Token modal - first click the Cancel button
-            delete_modal = edit_pat_page.delete_pat_modal
-            assert delete_modal.token_name.text == token_name
-            delete_modal.cancel_button.click()
-            # Should still be on the Edit page
-            assert user.EditPersonalAccessTokenPage(driver, verify=True)
-            # Go back to the Personal Access Tokens list page to make sure the PAT is
-            # still there
-            pat_page = user.PersonalAccessTokenPage(driver)
-            pat_page.goto()
-            assert user.PersonalAccessTokenPage(driver, verify=True)
-            pat_page.loading_indicator.here_then_gone()
-            pat_card = pat_page.get_pat_card_by_name(token_name)
-            assert pat_card
-            pat_link = pat_card.find_element_by_css_selector('a')
-            # Now click the PAT name link again to go back to the Edit PAT page
-            pat_link.click()
-            edit_pat_page = user.EditPersonalAccessTokenPage(driver, verify=True)
-            assert edit_pat_page.token_name_input.get_attribute('value') == token_name
-            # Click the Delete button again and this time click the Delete button on the
-            # Delete Token Modal
-            edit_pat_page.scroll_into_view(edit_pat_page.delete_button.element)
-            edit_pat_page.delete_button.click()
-            delete_modal = edit_pat_page.delete_pat_modal
-            assert delete_modal.token_name.text == token_name
-            delete_modal.delete_button.click()
-            # This time we should end up on the PAT list page
-            pat_page = user.PersonalAccessTokenPage(driver, verify=True)
-            pat_page.loading_indicator.here_then_gone()
-            pat_card = pat_page.get_pat_card_by_name(token_name)
-            # Verify that we don't find the PAT card this time since it was deleted
-            assert not pat_card
-        except Exception:
-            # As cleanup, delete the PAT using the api if the test failed for some
-            # reason and the PAT was not actually deleted.
-            pat_data = osf_api.get_user_pat_data(session, token_id=token_id)
-            if pat_data:
-                osf_api.delete_personal_access_token(session, token_id=token_id)
-
-    @markers.dont_run_on_prod
-    def test_user_settings_delete_PAT_from_list_page(self, driver, session, fake):
-        """Delete a Personal Access Token from the User Settings Edit Personal Access
-        Token page in OSF. The test uses the OSF api to first create the personal access
-        token that will then be deleted using the Front End interface.
-        """
-        token_name = 'PAT created via api ' + fake.sentence(nb_words=1)
-        token_id = osf_api.create_personal_access_token(
-            session,
-            name=token_name,
-            scopes='osf.users.profile_read osf.users.email_read',
-        )
-        try:
-            # Go to the Profile Information page first and use the side navigation bar
-            # to then go to the Personal Access Tokens page.
-            profile_settings_page = user.ProfileInformationPage(driver)
-            profile_settings_page.goto()
-            assert user.ProfileInformationPage(driver, verify=True)
-            profile_settings_page.side_navigation.personal_access_tokens_link.click()
-            pat_page = user.PersonalAccessTokenPage(driver, verify=True)
-            pat_page.loading_indicator.here_then_gone()
-            # Go through the list of PATs listed on the page to find the one that was
-            # just added via the api
-            pat_card = pat_page.get_pat_card_by_name(token_name)
-            pat_link = pat_card.find_element_by_css_selector('a')
-            link_url = pat_link.get_attribute('href')
-            link_token_id = link_url.split('tokens/', 1)[1]
-            assert link_token_id == token_id
-            # Now click the PAT name link to go to the Edit PAT page and verify the
-            # data
-            pat_link.click()
-            edit_pat_page = user.EditPersonalAccessTokenPage(driver, verify=True)
-            assert edit_pat_page.token_name_input.get_attribute('value') == token_name
-            edit_pat_page.scroll_into_view(
-                edit_pat_page.osf_nodes_full_read_checkbox.element
-            )
-            assert not edit_pat_page.osf_nodes_full_read_checkbox.is_selected()
-            edit_pat_page.scroll_into_view(
-                edit_pat_page.osf_nodes_metadata_read_checkbox.element
-            )
-            assert not edit_pat_page.osf_nodes_metadata_read_checkbox.is_selected()
-            edit_pat_page.scroll_into_view(
-                edit_pat_page.osf_nodes_access_read_checkbox.element
-            )
-            assert not edit_pat_page.osf_nodes_access_read_checkbox.is_selected()
-            edit_pat_page.scroll_into_view(
-                edit_pat_page.osf_nodes_data_read_checkbox.element
-            )
-            assert not edit_pat_page.osf_nodes_data_read_checkbox.is_selected()
-            edit_pat_page.scroll_into_view(
-                edit_pat_page.osf_users_profile_write_checkbox.element
-            )
-            assert not edit_pat_page.osf_users_profile_write_checkbox.is_selected()
-            edit_pat_page.scroll_into_view(
-                edit_pat_page.osf_full_write_checkbox.element
-            )
-            assert not edit_pat_page.osf_full_write_checkbox.is_selected()
-            edit_pat_page.scroll_into_view(
-                edit_pat_page.osf_nodes_metadata_write_checkbox.element
-            )
-            assert not edit_pat_page.osf_nodes_metadata_write_checkbox.is_selected()
-            edit_pat_page.scroll_into_view(edit_pat_page.osf_full_read_checkbox.element)
-            assert not edit_pat_page.osf_full_read_checkbox.is_selected()
-            edit_pat_page.scroll_into_view(
-                edit_pat_page.osf_nodes_full_write_checkbox.element
-            )
-            assert not edit_pat_page.osf_nodes_full_write_checkbox.is_selected()
-            edit_pat_page.scroll_into_view(
-                edit_pat_page.osf_nodes_access_write_checkbox.element
-            )
-            assert not edit_pat_page.osf_nodes_access_write_checkbox.is_selected()
-            edit_pat_page.scroll_into_view(
-                edit_pat_page.osf_nodes_data_write_checkbox.element
-            )
-            assert not edit_pat_page.osf_nodes_data_write_checkbox.is_selected()
-            edit_pat_page.scroll_into_view(
-                edit_pat_page.osf_users_email_read_checkbox.element
-            )
-            assert edit_pat_page.osf_users_email_read_checkbox.is_selected()
-            edit_pat_page.scroll_into_view(
-                edit_pat_page.osf_users_profile_read_checkbox.element
-            )
-            assert edit_pat_page.osf_users_profile_read_checkbox.is_selected()
-            # Click the Back to list of tokens link
-            edit_pat_page.back_to_list_of_tokens_link.click()
-            assert user.PersonalAccessTokenPage(driver, verify=True)
-            pat_page.loading_indicator.here_then_gone()
-            # Find the PAT on the list page and click the Delete button on the right
-            # side of the card
-            pat_card = pat_page.get_pat_card_by_name(token_name)
-            assert pat_card
-            delete_button = pat_card.find_element_by_css_selector(
-                '[data-test-delete-button]'
-            )
-            delete_button.click()
-            # On the Delete Token modal - first click the Cancel button
-            delete_modal = pat_page.delete_pat_modal
-            assert delete_modal.token_name.text == token_name
-            delete_modal.cancel_button.click()
-            # Should still be on the PAT list page and the PAT should still be displayed
-            pat_page = user.PersonalAccessTokenPage(driver, verify=True)
-            pat_page.loading_indicator.here_then_gone()
-            pat_card = pat_page.get_pat_card_by_name(token_name)
-            assert pat_card
-            # Click the Delete button again and this time click the Delete button on the
-            # Delete Token Modal
-            delete_button = pat_card.find_element_by_css_selector(
-                '[data-test-delete-button]'
-            )
-            delete_button.click()
-            delete_modal = pat_page.delete_pat_modal
-            assert delete_modal.token_name.text == token_name
-            delete_modal.delete_button.click()
-            # Should still be on PAT list page
-            pat_page = user.PersonalAccessTokenPage(driver, verify=True)
-            pat_page.loading_indicator.here_then_gone()
-            pat_card = pat_page.get_pat_card_by_name(token_name)
-            # Verify that we don't find the PAT card this time since it was deleted
-            assert not pat_card
-        except Exception:
-            # As cleanup, delete the PAT using the api if the test failed for some
-            # reason and the PAT was not actually deleted.
-            pat_data = osf_api.get_user_pat_data(session, token_id=token_id)
-            if pat_data:
-                osf_api.delete_personal_access_token(session, token_id=token_id)
-
-    @markers.dont_run_on_prod
-    def test_user_settings_edit_PAT(self, driver, session, fake):
-        """Edit a Personal Access Token from the User Settings Edit Personal Access
-        Token page in OSF. The test uses the OSF api to first create the personal access
-        token that will then be edited using the Front End interface. At the end of the
-        test the PAT will be deleted using the api as cleanup.
-        """
-        token_name = 'PAT created via api ' + fake.sentence(nb_words=1)
-        token_id = osf_api.create_personal_access_token(
-            session, name=token_name, scopes='osf.full_read'
-        )
-        try:
-            pat_page = user.PersonalAccessTokenPage(driver)
-            pat_page.goto()
-            assert user.PersonalAccessTokenPage(driver, verify=True)
-            pat_page.loading_indicator.here_then_gone()
-            # Go through the list of PATs listed on the page to find the one that was
-            # just added via the api
-            pat_card = pat_page.get_pat_card_by_name(token_name)
-            pat_link = pat_card.find_element_by_css_selector('a')
-            link_url = pat_link.get_attribute('href')
-            link_token_id = link_url.split('tokens/', 1)[1]
-            assert link_token_id == token_id
-            # Now click the PAT name link to go to the Edit PAT page and verify the
-            # data
-            pat_link.click()
-            edit_pat_page = user.EditPersonalAccessTokenPage(driver, verify=True)
-            assert edit_pat_page.token_name_input.get_attribute('value') == token_name
-            edit_pat_page.scroll_into_view(
-                edit_pat_page.osf_nodes_full_read_checkbox.element
-            )
-            assert not edit_pat_page.osf_nodes_full_read_checkbox.is_selected()
-            edit_pat_page.scroll_into_view(
-                edit_pat_page.osf_nodes_metadata_read_checkbox.element
-            )
-            assert not edit_pat_page.osf_nodes_metadata_read_checkbox.is_selected()
-            edit_pat_page.scroll_into_view(
-                edit_pat_page.osf_nodes_access_read_checkbox.element
-            )
-            assert not edit_pat_page.osf_nodes_access_read_checkbox.is_selected()
-            edit_pat_page.scroll_into_view(
-                edit_pat_page.osf_nodes_data_read_checkbox.element
-            )
-            assert not edit_pat_page.osf_nodes_data_read_checkbox.is_selected()
-            edit_pat_page.scroll_into_view(
-                edit_pat_page.osf_users_profile_write_checkbox.element
-            )
-            assert not edit_pat_page.osf_users_profile_write_checkbox.is_selected()
-            edit_pat_page.scroll_into_view(
-                edit_pat_page.osf_full_write_checkbox.element
-            )
-            assert not edit_pat_page.osf_full_write_checkbox.is_selected()
-            edit_pat_page.scroll_into_view(
-                edit_pat_page.osf_nodes_metadata_write_checkbox.element
-            )
-            assert not edit_pat_page.osf_nodes_metadata_write_checkbox.is_selected()
-            edit_pat_page.scroll_into_view(edit_pat_page.osf_full_read_checkbox.element)
-            assert edit_pat_page.osf_full_read_checkbox.is_selected()
-            edit_pat_page.scroll_into_view(
-                edit_pat_page.osf_nodes_full_write_checkbox.element
-            )
-            assert not edit_pat_page.osf_nodes_full_write_checkbox.is_selected()
-            edit_pat_page.scroll_into_view(
-                edit_pat_page.osf_nodes_access_write_checkbox.element
-            )
-            assert not edit_pat_page.osf_nodes_access_write_checkbox.is_selected()
-            edit_pat_page.scroll_into_view(
-                edit_pat_page.osf_nodes_data_write_checkbox.element
-            )
-            assert not edit_pat_page.osf_nodes_data_write_checkbox.is_selected()
-            edit_pat_page.scroll_into_view(
-                edit_pat_page.osf_users_email_read_checkbox.element
-            )
-            assert not edit_pat_page.osf_users_email_read_checkbox.is_selected()
-            edit_pat_page.scroll_into_view(
-                edit_pat_page.osf_users_profile_read_checkbox.element
-            )
-            assert not edit_pat_page.osf_users_profile_read_checkbox.is_selected()
-            # Make some Edits - change the token name and change permissions from
-            # osf.full_read to osf.full_write
-            new_token_name = token_name + ' edited'
-            edit_pat_page.scroll_into_view(edit_pat_page.token_name_input.element)
-            edit_pat_page.token_name_input.clear()
-            edit_pat_page.token_name_input.send_keys(new_token_name)
-            edit_pat_page.scroll_into_view(edit_pat_page.osf_full_read_checkbox.element)
-            edit_pat_page.osf_full_read_checkbox.click()
-            edit_pat_page.scroll_into_view(
-                edit_pat_page.osf_full_write_checkbox.element
-            )
-            edit_pat_page.osf_full_write_checkbox.click()
-            # Click the Save button
-            edit_pat_page.scroll_into_view(edit_pat_page.save_button.element)
-            edit_pat_page.save_button.click()
-            # Should end up back on PAT list page with new token name listed
-            pat_page = user.PersonalAccessTokenPage(driver, verify=True)
-            pat_page.loading_indicator.here_then_gone()
-            pat_card = pat_page.get_pat_card_by_name(new_token_name)
-            assert pat_card
-            # Now click the PAT name link to go back to the Edit PAT page and verify
-            # the data changes
-            pat_link = pat_card.find_element_by_css_selector('a')
-            pat_link.click()
-            edit_pat_page = user.EditPersonalAccessTokenPage(driver, verify=True)
-            assert (
-                edit_pat_page.token_name_input.get_attribute('value') == new_token_name
-            )
-            edit_pat_page.scroll_into_view(
-                edit_pat_page.osf_nodes_full_read_checkbox.element
-            )
-            assert not edit_pat_page.osf_nodes_full_read_checkbox.is_selected()
-            edit_pat_page.scroll_into_view(
-                edit_pat_page.osf_nodes_metadata_read_checkbox.element
-            )
-            assert not edit_pat_page.osf_nodes_metadata_read_checkbox.is_selected()
-            edit_pat_page.scroll_into_view(
-                edit_pat_page.osf_nodes_access_read_checkbox.element
-            )
-            assert not edit_pat_page.osf_nodes_access_read_checkbox.is_selected()
-            edit_pat_page.scroll_into_view(
-                edit_pat_page.osf_nodes_data_read_checkbox.element
-            )
-            assert not edit_pat_page.osf_nodes_data_read_checkbox.is_selected()
-            edit_pat_page.scroll_into_view(
-                edit_pat_page.osf_users_profile_write_checkbox.element
-            )
-            assert not edit_pat_page.osf_users_profile_write_checkbox.is_selected()
-            edit_pat_page.scroll_into_view(
-                edit_pat_page.osf_full_write_checkbox.element
-            )
-            assert edit_pat_page.osf_full_write_checkbox.is_selected()
-            edit_pat_page.scroll_into_view(
-                edit_pat_page.osf_nodes_metadata_write_checkbox.element
-            )
-            assert not edit_pat_page.osf_nodes_metadata_write_checkbox.is_selected()
-            edit_pat_page.scroll_into_view(edit_pat_page.osf_full_read_checkbox.element)
-            assert not edit_pat_page.osf_full_read_checkbox.is_selected()
-            edit_pat_page.scroll_into_view(
-                edit_pat_page.osf_nodes_full_write_checkbox.element
-            )
-            assert not edit_pat_page.osf_nodes_full_write_checkbox.is_selected()
-            edit_pat_page.scroll_into_view(
-                edit_pat_page.osf_nodes_access_write_checkbox.element
-            )
-            assert not edit_pat_page.osf_nodes_access_write_checkbox.is_selected()
-            edit_pat_page.scroll_into_view(
-                edit_pat_page.osf_nodes_data_write_checkbox.element
-            )
-            assert not edit_pat_page.osf_nodes_data_write_checkbox.is_selected()
-            edit_pat_page.scroll_into_view(
-                edit_pat_page.osf_users_email_read_checkbox.element
-            )
-            assert not edit_pat_page.osf_users_email_read_checkbox.is_selected()
-            edit_pat_page.scroll_into_view(
-                edit_pat_page.osf_users_profile_read_checkbox.element
-            )
-            assert not edit_pat_page.osf_users_profile_read_checkbox.is_selected()
-        finally:
-            # Delete the token using the api as cleanup
-            if token_id:
-                osf_api.delete_personal_access_token(session, token_id=token_id)
-
 
 @markers.dont_run_on_prod
 @pytest.mark.usefixtures('must_be_logged_in')
@@ -998,3 +459,497 @@ class TestUserDeveloperApps:
         finally:
             # Lastly use the api to delete the dev app as cleanup
             osf_api.delete_user_developer_app(session, app_id=app_id)
+
+
+@markers.dont_run_on_prod
+@pytest.mark.usefixtures('must_be_logged_in')
+class TestUserPersonalAccessTokens:
+    def test_user_settings_create_PAT(self, driver, session, fake):
+        """Create a Personal Access Token from the User Settings Personal Access Tokens
+        page in OSF. The test uses the OSF api to delete the personal access token at
+        the end of the test as cleanup.
+        """
+        pat_page = user.PersonalAccessTokenPage(driver)
+        pat_page.goto()
+        assert user.PersonalAccessTokenPage(driver, verify=True)
+        pat_page.loading_indicator.here_then_gone()
+        pat_page.create_token_button.click()
+        create_page = user.CreatePersonalAccessTokenPage(driver, verify=True)
+
+        try:
+            # Complete the form fields and click the Create token button
+            token_name = fake.sentence(nb_words=3)
+            create_page.token_name_input.send_keys(token_name)
+
+            # Check all the 'read' access checkboxes
+            create_page.scroll_into_view(
+                create_page.osf_nodes_full_read_checkbox.element
+            )
+            create_page.osf_nodes_full_read_checkbox.click()
+            create_page.scroll_into_view(create_page.osf_full_read_checkbox.element)
+            create_page.osf_full_read_checkbox.click()
+            create_page.scroll_into_view(
+                create_page.osf_nodes_metadata_read_checkbox.element
+            )
+            create_page.osf_nodes_metadata_read_checkbox.click()
+            create_page.scroll_into_view(
+                create_page.osf_nodes_access_read_checkbox.element
+            )
+            create_page.osf_nodes_access_read_checkbox.click()
+            create_page.scroll_into_view(
+                create_page.osf_nodes_data_read_checkbox.element
+            )
+            create_page.osf_nodes_data_read_checkbox.click()
+            create_page.scroll_into_view(
+                create_page.osf_users_email_read_checkbox.element
+            )
+            create_page.osf_users_email_read_checkbox.click()
+            create_page.scroll_into_view(
+                create_page.osf_users_profile_read_checkbox.element
+            )
+            create_page.osf_users_profile_read_checkbox.click()
+            create_page.scroll_into_view(create_page.create_token_button.element)
+            create_page.create_token_button.click()
+
+            # Should end up on Token Detail page with newly created token displayed
+            edit_page = user.EditPersonalAccessTokenPage(driver, verify=True)
+
+            # Capture the token id from the url
+            match = re.search(r'tokens/([a-z0-9]{24})\?view_only=', driver.current_url)
+            token_id = match.group(1)
+
+            # Verify that New Token Input Box has a value
+            assert edit_page.new_token_input.get_attribute('value') != ''
+
+            # Click the Back to list of tokens link
+            edit_page.back_to_list_of_tokens_link.click()
+            pat_page = user.PersonalAccessTokenPage(driver, verify=True)
+            pat_page.loading_indicator.here_then_gone()
+
+            # Go through the list of PATs listed on the page to find the one that was
+            # just added
+            pat_card = pat_page.get_pat_card_by_name(token_name)
+            pat_link = pat_card.find_element_by_css_selector('a')
+            link_url = pat_link.get_attribute('href')
+            link_token_id = link_url.split('tokens/', 1)[1]
+            assert link_token_id == token_id
+
+            # Now click the PAT name link to go to the Edit PAT page and verify the
+            # data
+            pat_link.click()
+            edit_page = user.EditPersonalAccessTokenPage(driver, verify=True)
+            assert edit_page.token_name_input.get_attribute('value') == token_name
+            edit_page.scroll_into_view(edit_page.osf_nodes_full_read_checkbox.element)
+            assert edit_page.osf_nodes_full_read_checkbox.is_selected()
+            edit_page.scroll_into_view(edit_page.osf_full_read_checkbox.element)
+            assert edit_page.osf_full_read_checkbox.is_selected()
+            edit_page.scroll_into_view(
+                edit_page.osf_nodes_metadata_read_checkbox.element
+            )
+            assert edit_page.osf_nodes_metadata_read_checkbox.is_selected()
+            edit_page.scroll_into_view(edit_page.osf_nodes_access_read_checkbox.element)
+            assert edit_page.osf_nodes_access_read_checkbox.is_selected()
+            edit_page.scroll_into_view(edit_page.osf_nodes_data_read_checkbox.element)
+            assert edit_page.osf_nodes_data_read_checkbox.is_selected()
+            edit_page.scroll_into_view(edit_page.osf_users_email_read_checkbox.element)
+            assert edit_page.osf_users_email_read_checkbox.is_selected()
+            edit_page.scroll_into_view(
+                edit_page.osf_users_profile_read_checkbox.element
+            )
+            assert edit_page.osf_users_profile_read_checkbox.is_selected()
+            edit_page.scroll_into_view(
+                edit_page.osf_users_profile_write_checkbox.element
+            )
+            assert not edit_page.osf_users_profile_write_checkbox.is_selected()
+            edit_page.scroll_into_view(edit_page.osf_full_write_checkbox.element)
+            assert not edit_page.osf_full_write_checkbox.is_selected()
+            edit_page.scroll_into_view(edit_page.osf_nodes_full_write_checkbox.element)
+            assert not edit_page.osf_nodes_full_write_checkbox.is_selected()
+            edit_page.scroll_into_view(
+                edit_page.osf_nodes_metadata_write_checkbox.element
+            )
+            assert not edit_page.osf_nodes_metadata_write_checkbox.is_selected()
+            edit_page.scroll_into_view(
+                edit_page.osf_nodes_access_write_checkbox.element
+            )
+            assert not edit_page.osf_nodes_access_write_checkbox.is_selected()
+            edit_page.scroll_into_view(edit_page.osf_nodes_data_write_checkbox.element)
+            assert not edit_page.osf_nodes_data_write_checkbox.is_selected()
+        finally:
+            # Delete the token using the api as cleanup
+            if token_id:
+                osf_api.delete_personal_access_token(session, token_id=token_id)
+
+    def test_user_settings_delete_PAT_from_edit_page(self, driver, session, fake):
+        """Delete a Personal Access Token from the User Settings Edit Personal Access
+        Token page in OSF. The test uses the OSF api to first create the personal access
+        token that will then be deleted using the Front End interface.
+        """
+        token_name = 'PAT created via api ' + fake.sentence(nb_words=1)
+        token_id = osf_api.create_personal_access_token(
+            session,
+            name=token_name,
+            scopes='osf.nodes.full_read osf.nodes.metadata_read osf.nodes.access_read osf.nodes.data_read',
+        )
+        try:
+            # Go to the Profile Information page first and use the side navigation bar
+            # to then go to the Personal Access Tokens page.
+            profile_settings_page = user.ProfileInformationPage(driver)
+            profile_settings_page.goto()
+            assert user.ProfileInformationPage(driver, verify=True)
+            profile_settings_page.side_navigation.personal_access_tokens_link.click()
+            pat_page = user.PersonalAccessTokenPage(driver, verify=True)
+            pat_page.loading_indicator.here_then_gone()
+
+            # Go through the list of PATs listed on the page to find the one that was
+            # just added via the api
+            pat_card = pat_page.get_pat_card_by_name(token_name)
+            pat_link = pat_card.find_element_by_css_selector('a')
+            link_url = pat_link.get_attribute('href')
+            link_token_id = link_url.split('tokens/', 1)[1]
+            assert link_token_id == token_id
+
+            # Now click the PAT name link to go to the Edit PAT page and verify the
+            # data
+            pat_link.click()
+            edit_page = user.EditPersonalAccessTokenPage(driver, verify=True)
+            assert edit_page.token_name_input.get_attribute('value') == token_name
+            edit_page.scroll_into_view(edit_page.osf_nodes_full_read_checkbox.element)
+            assert edit_page.osf_nodes_full_read_checkbox.is_selected()
+            edit_page.scroll_into_view(
+                edit_page.osf_nodes_metadata_read_checkbox.element
+            )
+            assert edit_page.osf_nodes_metadata_read_checkbox.is_selected()
+            edit_page.scroll_into_view(edit_page.osf_nodes_access_read_checkbox.element)
+            assert edit_page.osf_nodes_access_read_checkbox.is_selected()
+            edit_page.scroll_into_view(edit_page.osf_nodes_data_read_checkbox.element)
+            assert edit_page.osf_nodes_data_read_checkbox.is_selected()
+            edit_page.scroll_into_view(
+                edit_page.osf_users_profile_write_checkbox.element
+            )
+            assert not edit_page.osf_users_profile_write_checkbox.is_selected()
+            edit_page.scroll_into_view(edit_page.osf_full_write_checkbox.element)
+            assert not edit_page.osf_full_write_checkbox.is_selected()
+            edit_page.scroll_into_view(
+                edit_page.osf_nodes_metadata_write_checkbox.element
+            )
+            assert not edit_page.osf_nodes_metadata_write_checkbox.is_selected()
+            edit_page.scroll_into_view(edit_page.osf_full_read_checkbox.element)
+            assert not edit_page.osf_full_read_checkbox.is_selected()
+            edit_page.scroll_into_view(edit_page.osf_nodes_full_write_checkbox.element)
+            assert not edit_page.osf_nodes_full_write_checkbox.is_selected()
+            edit_page.scroll_into_view(
+                edit_page.osf_nodes_access_write_checkbox.element
+            )
+            assert not edit_page.osf_nodes_access_write_checkbox.is_selected()
+            edit_page.scroll_into_view(edit_page.osf_nodes_data_write_checkbox.element)
+            assert not edit_page.osf_nodes_data_write_checkbox.is_selected()
+            edit_page.scroll_into_view(edit_page.osf_users_email_read_checkbox.element)
+            assert not edit_page.osf_users_email_read_checkbox.is_selected()
+            edit_page.scroll_into_view(
+                edit_page.osf_users_profile_read_checkbox.element
+            )
+            assert not edit_page.osf_users_profile_read_checkbox.is_selected()
+
+            # Click the Delete button
+            edit_page.scroll_into_view(edit_page.delete_button.element)
+            edit_page.delete_button.click()
+
+            # On the Delete Token modal - first click the Cancel button
+            delete_modal = edit_page.delete_pat_modal
+            assert delete_modal.token_name.text == token_name
+            delete_modal.cancel_button.click()
+
+            # Should still be on the Edit page
+            assert user.EditPersonalAccessTokenPage(driver, verify=True)
+
+            # Go back to the Personal Access Tokens list page to make sure the PAT is
+            # still there
+            pat_page = user.PersonalAccessTokenPage(driver)
+            pat_page.goto()
+            assert user.PersonalAccessTokenPage(driver, verify=True)
+            pat_page.loading_indicator.here_then_gone()
+            pat_card = pat_page.get_pat_card_by_name(token_name)
+            assert pat_card
+            pat_link = pat_card.find_element_by_css_selector('a')
+
+            # Now click the PAT name link again to go back to the Edit PAT page
+            pat_link.click()
+            edit_page = user.EditPersonalAccessTokenPage(driver, verify=True)
+            assert edit_page.token_name_input.get_attribute('value') == token_name
+
+            # Click the Delete button again and this time click the Delete button on the
+            # Delete Token Modal
+            edit_page.scroll_into_view(edit_page.delete_button.element)
+            edit_page.delete_button.click()
+            delete_modal = edit_page.delete_pat_modal
+            assert delete_modal.token_name.text == token_name
+            delete_modal.delete_button.click()
+
+            # This time we should end up on the PAT list page
+            pat_page = user.PersonalAccessTokenPage(driver, verify=True)
+            pat_page.loading_indicator.here_then_gone()
+            pat_card = pat_page.get_pat_card_by_name(token_name)
+
+            # Verify that we don't find the PAT card this time since it was deleted
+            assert not pat_card
+        except Exception:
+            # As cleanup, delete the PAT using the api if the test failed for some
+            # reason and the PAT was not actually deleted.
+            pat_data = osf_api.get_user_pat_data(session, token_id=token_id)
+            if pat_data:
+                osf_api.delete_personal_access_token(session, token_id=token_id)
+
+    def test_user_settings_delete_PAT_from_list_page(self, driver, session, fake):
+        """Delete a Personal Access Token from the User Settings Edit Personal Access
+        Token page in OSF. The test uses the OSF api to first create the personal access
+        token that will then be deleted using the Front End interface.
+        """
+        token_name = 'PAT created via api ' + fake.sentence(nb_words=1)
+        token_id = osf_api.create_personal_access_token(
+            session,
+            name=token_name,
+            scopes='osf.users.profile_read osf.users.email_read',
+        )
+        try:
+            # Go to the Profile Information page first and use the side navigation bar
+            # to then go to the Personal Access Tokens page.
+            profile_settings_page = user.ProfileInformationPage(driver)
+            profile_settings_page.goto()
+            assert user.ProfileInformationPage(driver, verify=True)
+            profile_settings_page.side_navigation.personal_access_tokens_link.click()
+            pat_page = user.PersonalAccessTokenPage(driver, verify=True)
+            pat_page.loading_indicator.here_then_gone()
+
+            # Go through the list of PATs listed on the page to find the one that was
+            # just added via the api
+            pat_card = pat_page.get_pat_card_by_name(token_name)
+            pat_link = pat_card.find_element_by_css_selector('a')
+            link_url = pat_link.get_attribute('href')
+            link_token_id = link_url.split('tokens/', 1)[1]
+            assert link_token_id == token_id
+
+            # Now click the PAT name link to go to the Edit PAT page and verify the
+            # data
+            pat_link.click()
+            edit_page = user.EditPersonalAccessTokenPage(driver, verify=True)
+            assert edit_page.token_name_input.get_attribute('value') == token_name
+            edit_page.scroll_into_view(edit_page.osf_nodes_full_read_checkbox.element)
+            assert not edit_page.osf_nodes_full_read_checkbox.is_selected()
+            edit_page.scroll_into_view(
+                edit_page.osf_nodes_metadata_read_checkbox.element
+            )
+            assert not edit_page.osf_nodes_metadata_read_checkbox.is_selected()
+            edit_page.scroll_into_view(edit_page.osf_nodes_access_read_checkbox.element)
+            assert not edit_page.osf_nodes_access_read_checkbox.is_selected()
+            edit_page.scroll_into_view(edit_page.osf_nodes_data_read_checkbox.element)
+            assert not edit_page.osf_nodes_data_read_checkbox.is_selected()
+            edit_page.scroll_into_view(
+                edit_page.osf_users_profile_write_checkbox.element
+            )
+            assert not edit_page.osf_users_profile_write_checkbox.is_selected()
+            edit_page.scroll_into_view(edit_page.osf_full_write_checkbox.element)
+            assert not edit_page.osf_full_write_checkbox.is_selected()
+            edit_page.scroll_into_view(
+                edit_page.osf_nodes_metadata_write_checkbox.element
+            )
+            assert not edit_page.osf_nodes_metadata_write_checkbox.is_selected()
+            edit_page.scroll_into_view(edit_page.osf_full_read_checkbox.element)
+            assert not edit_page.osf_full_read_checkbox.is_selected()
+            edit_page.scroll_into_view(edit_page.osf_nodes_full_write_checkbox.element)
+            assert not edit_page.osf_nodes_full_write_checkbox.is_selected()
+            edit_page.scroll_into_view(
+                edit_page.osf_nodes_access_write_checkbox.element
+            )
+            assert not edit_page.osf_nodes_access_write_checkbox.is_selected()
+            edit_page.scroll_into_view(edit_page.osf_nodes_data_write_checkbox.element)
+            assert not edit_page.osf_nodes_data_write_checkbox.is_selected()
+            edit_page.scroll_into_view(edit_page.osf_users_email_read_checkbox.element)
+            assert edit_page.osf_users_email_read_checkbox.is_selected()
+            edit_page.scroll_into_view(
+                edit_page.osf_users_profile_read_checkbox.element
+            )
+            assert edit_page.osf_users_profile_read_checkbox.is_selected()
+
+            # Click the Back to list of tokens link
+            edit_page.back_to_list_of_tokens_link.click()
+            assert user.PersonalAccessTokenPage(driver, verify=True)
+            pat_page.loading_indicator.here_then_gone()
+
+            # Find the PAT on the list page and click the Delete button on the right
+            # side of the card
+            pat_card = pat_page.get_pat_card_by_name(token_name)
+            assert pat_card
+            delete_button = pat_card.find_element_by_css_selector(
+                '[data-test-delete-button]'
+            )
+            delete_button.click()
+
+            # On the Delete Token modal - first click the Cancel button
+            delete_modal = pat_page.delete_pat_modal
+            assert delete_modal.token_name.text == token_name
+            delete_modal.cancel_button.click()
+
+            # Should still be on the PAT list page and the PAT should still be displayed
+            pat_page = user.PersonalAccessTokenPage(driver, verify=True)
+            pat_page.loading_indicator.here_then_gone()
+            pat_card = pat_page.get_pat_card_by_name(token_name)
+            assert pat_card
+
+            # Click the Delete button again and this time click the Delete button on the
+            # Delete Token Modal
+            delete_button = pat_card.find_element_by_css_selector(
+                '[data-test-delete-button]'
+            )
+            delete_button.click()
+            delete_modal = pat_page.delete_pat_modal
+            assert delete_modal.token_name.text == token_name
+            delete_modal.delete_button.click()
+
+            # Should still be on PAT list page
+            pat_page = user.PersonalAccessTokenPage(driver, verify=True)
+            pat_page.loading_indicator.here_then_gone()
+            pat_card = pat_page.get_pat_card_by_name(token_name)
+
+            # Verify that we don't find the PAT card this time since it was deleted
+            assert not pat_card
+        except Exception:
+            # As cleanup, delete the PAT using the api if the test failed for some
+            # reason and the PAT was not actually deleted.
+            pat_data = osf_api.get_user_pat_data(session, token_id=token_id)
+            if pat_data:
+                osf_api.delete_personal_access_token(session, token_id=token_id)
+
+    def test_user_settings_edit_PAT(self, driver, session, fake):
+        """Edit a Personal Access Token from the User Settings Edit Personal Access
+        Token page in OSF. The test uses the OSF api to first create the personal access
+        token that will then be edited using the Front End interface. At the end of the
+        test the PAT will be deleted using the api as cleanup.
+        """
+        token_name = 'PAT created via api ' + fake.sentence(nb_words=1)
+        token_id = osf_api.create_personal_access_token(
+            session, name=token_name, scopes='osf.full_read'
+        )
+        try:
+            pat_page = user.PersonalAccessTokenPage(driver)
+            pat_page.goto()
+            assert user.PersonalAccessTokenPage(driver, verify=True)
+            pat_page.loading_indicator.here_then_gone()
+
+            # Go through the list of PATs listed on the page to find the one that was
+            # just added via the api
+            pat_card = pat_page.get_pat_card_by_name(token_name)
+            pat_link = pat_card.find_element_by_css_selector('a')
+            link_url = pat_link.get_attribute('href')
+            link_token_id = link_url.split('tokens/', 1)[1]
+            assert link_token_id == token_id
+
+            # Now click the PAT name link to go to the Edit PAT page and verify the
+            # data
+            pat_link.click()
+            edit_page = user.EditPersonalAccessTokenPage(driver, verify=True)
+            assert edit_page.token_name_input.get_attribute('value') == token_name
+            edit_page.scroll_into_view(edit_page.osf_nodes_full_read_checkbox.element)
+            assert not edit_page.osf_nodes_full_read_checkbox.is_selected()
+            edit_page.scroll_into_view(
+                edit_page.osf_nodes_metadata_read_checkbox.element
+            )
+            assert not edit_page.osf_nodes_metadata_read_checkbox.is_selected()
+            edit_page.scroll_into_view(edit_page.osf_nodes_access_read_checkbox.element)
+            assert not edit_page.osf_nodes_access_read_checkbox.is_selected()
+            edit_page.scroll_into_view(edit_page.osf_nodes_data_read_checkbox.element)
+            assert not edit_page.osf_nodes_data_read_checkbox.is_selected()
+            edit_page.scroll_into_view(
+                edit_page.osf_users_profile_write_checkbox.element
+            )
+            assert not edit_page.osf_users_profile_write_checkbox.is_selected()
+            edit_page.scroll_into_view(edit_page.osf_full_write_checkbox.element)
+            assert not edit_page.osf_full_write_checkbox.is_selected()
+            edit_page.scroll_into_view(
+                edit_page.osf_nodes_metadata_write_checkbox.element
+            )
+            assert not edit_page.osf_nodes_metadata_write_checkbox.is_selected()
+            edit_page.scroll_into_view(edit_page.osf_full_read_checkbox.element)
+            assert edit_page.osf_full_read_checkbox.is_selected()
+            edit_page.scroll_into_view(edit_page.osf_nodes_full_write_checkbox.element)
+            assert not edit_page.osf_nodes_full_write_checkbox.is_selected()
+            edit_page.scroll_into_view(
+                edit_page.osf_nodes_access_write_checkbox.element
+            )
+            assert not edit_page.osf_nodes_access_write_checkbox.is_selected()
+            edit_page.scroll_into_view(edit_page.osf_nodes_data_write_checkbox.element)
+            assert not edit_page.osf_nodes_data_write_checkbox.is_selected()
+            edit_page.scroll_into_view(edit_page.osf_users_email_read_checkbox.element)
+            assert not edit_page.osf_users_email_read_checkbox.is_selected()
+            edit_page.scroll_into_view(
+                edit_page.osf_users_profile_read_checkbox.element
+            )
+            assert not edit_page.osf_users_profile_read_checkbox.is_selected()
+
+            # Make some Edits - change the token name and change permissions from
+            # osf.full_read to osf.full_write
+            new_token_name = token_name + ' edited'
+            edit_page.scroll_into_view(edit_page.token_name_input.element)
+            edit_page.token_name_input.clear()
+            edit_page.token_name_input.send_keys(new_token_name)
+            edit_page.scroll_into_view(edit_page.osf_full_read_checkbox.element)
+            edit_page.osf_full_read_checkbox.click()
+            edit_page.scroll_into_view(edit_page.osf_full_write_checkbox.element)
+            edit_page.osf_full_write_checkbox.click()
+
+            # Click the Save button
+            edit_page.scroll_into_view(edit_page.save_button.element)
+            edit_page.save_button.click()
+
+            # Should end up back on PAT list page with new token name listed
+            pat_page = user.PersonalAccessTokenPage(driver, verify=True)
+            pat_page.loading_indicator.here_then_gone()
+            pat_card = pat_page.get_pat_card_by_name(new_token_name)
+            assert pat_card
+
+            # Now click the PAT name link to go back to the Edit PAT page and verify
+            # the data changes
+            pat_link = pat_card.find_element_by_css_selector('a')
+            pat_link.click()
+            edit_page = user.EditPersonalAccessTokenPage(driver, verify=True)
+            assert edit_page.token_name_input.get_attribute('value') == new_token_name
+            edit_page.scroll_into_view(edit_page.osf_nodes_full_read_checkbox.element)
+            assert not edit_page.osf_nodes_full_read_checkbox.is_selected()
+            edit_page.scroll_into_view(
+                edit_page.osf_nodes_metadata_read_checkbox.element
+            )
+            assert not edit_page.osf_nodes_metadata_read_checkbox.is_selected()
+            edit_page.scroll_into_view(edit_page.osf_nodes_access_read_checkbox.element)
+            assert not edit_page.osf_nodes_access_read_checkbox.is_selected()
+            edit_page.scroll_into_view(edit_page.osf_nodes_data_read_checkbox.element)
+            assert not edit_page.osf_nodes_data_read_checkbox.is_selected()
+            edit_page.scroll_into_view(
+                edit_page.osf_users_profile_write_checkbox.element
+            )
+            assert not edit_page.osf_users_profile_write_checkbox.is_selected()
+            edit_page.scroll_into_view(edit_page.osf_full_write_checkbox.element)
+            assert edit_page.osf_full_write_checkbox.is_selected()
+            edit_page.scroll_into_view(
+                edit_page.osf_nodes_metadata_write_checkbox.element
+            )
+            assert not edit_page.osf_nodes_metadata_write_checkbox.is_selected()
+            edit_page.scroll_into_view(edit_page.osf_full_read_checkbox.element)
+            assert not edit_page.osf_full_read_checkbox.is_selected()
+            edit_page.scroll_into_view(edit_page.osf_nodes_full_write_checkbox.element)
+            assert not edit_page.osf_nodes_full_write_checkbox.is_selected()
+            edit_page.scroll_into_view(
+                edit_page.osf_nodes_access_write_checkbox.element
+            )
+            assert not edit_page.osf_nodes_access_write_checkbox.is_selected()
+            edit_page.scroll_into_view(edit_page.osf_nodes_data_write_checkbox.element)
+            assert not edit_page.osf_nodes_data_write_checkbox.is_selected()
+            edit_page.scroll_into_view(edit_page.osf_users_email_read_checkbox.element)
+            assert not edit_page.osf_users_email_read_checkbox.is_selected()
+            edit_page.scroll_into_view(
+                edit_page.osf_users_profile_read_checkbox.element
+            )
+            assert not edit_page.osf_users_profile_read_checkbox.is_selected()
+        finally:
+            # Delete the token using the api as cleanup
+            if token_id:
+                osf_api.delete_personal_access_token(session, token_id=token_id)


### PR DESCRIPTION
<!-- Before you submit your Pull Request, please confirm that:

     - Any test that will create public data either has the `QAtest` tag or the `dont_run_on_production` marker
     - `core_functionality` is marked as such
     - Your tests will be able to run on *all* servers (all stagings, test)
 -->


## Purpose
To expand selenium test coverage to include creating, deleting, and editing User Personal Access Tokens.


## Summary of Changes

- api/osf_api.py - adding 3 new functions: create_personal_access_token, delete_personal_access_token, and get_user_pat_data
- components/user.py - adding new modal class: DeletePATModal
- pages/user.py - updating PersonalAccessTokenPage class, adding CreatePersonalAccessTokenPage and EditPersonalAccessTokenPage, and deleting no longer needed EmberPersonalAccessTokenPage
- tests/test_user.py - adding 4 new tests: test_user_settings_create_PAT, test_user_settings_delete_PAT_from_list_page, test_user_settings_delete_PAT_from_edit_page, and test_user_settings_edit_PAT

## Reviewer's Actions
`git fetch <remote> pull/<PR_number>/head:testFix/user-settings-PAT`

Run this test using
`tests/test_user.py -s -v`

## Testing Changes Moving Forward
N/A


## Ticket
ENG-3960: SEL: User Test - Add New Test for User Settings Personal Access Tokens Page
https://openscience.atlassian.net/browse/ENG-3960
