### PR TITLE
[ENG-3957} - Add Test for Institution Admin Dashboard

### DIFF
--- a/api/osf_api.py
+++ b/api/osf_api.py
@@ -62,6 +62,32 @@ def get_user_institutions(session, user=None):
     return institutions
 
 
+def get_institution_metrics_summary(session, institution_id='cos'):
+    """Return the metrics summary data for a given institution id"""
+    if not session:
+        session = get_default_session()
+    institution_url = '/v2/institutions/{}/metrics/summary/'.format(institution_id)
+    data = session.get(institution_url)
+    if data:
+        return data['data']
+    return None
+
+
+def get_institution_users_per_department(
+    session, institution_id='cos', department='QA'
+):
+    """Return the users for a given institution id filtered by department"""
+    if not session:
+        session = get_default_session()
+    institution_url = 'v2/institutions/{}/metrics/users/?filter[department]={}'.format(
+        institution_id, department
+    )
+    data = session.get(institution_url)
+    if data:
+        return data['data']
+    return None
+
+
 def get_user_addon(session, provider, user=None):
     """Get list of accounts on the given provider that have already been connected by the user."""
     if not user:

--- a/pages/institutions.py
+++ b/pages/institutions.py
@@ -26,7 +26,21 @@ class InstitutionsLandingPage(OSFBasePage):
     navbar = ComponentLocator(InstitutionsNavbar)
 
 
-class InstitutionBrandedPage(OSFBasePage):
+class BaseInstitutionPage(OSFBasePage):
+
+    base_url = settings.OSF_HOME + '/institutions/'
+    url_addition = ''
+
+    def __init__(self, driver, verify=False, institution_id=''):
+        self.institution_id = institution_id
+        super().__init__(driver, verify)
+
+    @property
+    def url(self):
+        return self.base_url + self.institution_id + self.url_addition
+
+
+class InstitutionBrandedPage(BaseInstitutionPage):
 
     identity = Locator(
         By.CSS_SELECTOR,
@@ -37,3 +51,43 @@ class InstitutionBrandedPage(OSFBasePage):
 
     # Group Locators
     project_list = GroupLocator(By.CSS_SELECTOR, '#tb-tbody > div > div > div.tb-row')
+
+
+class InstitutionAdminDashboardPage(BaseInstitutionPage):
+
+    url_addition = '/dashboard'
+
+    identity = Locator(By.CSS_SELECTOR, 'div[data-analytics-scope="Dashboard"]')
+    loading_indicator = Locator(By.CSS_SELECTOR, '.ball-scale', settings.LONG_TIMEOUT)
+    departments_listbox_trigger = Locator(
+        By.CSS_SELECTOR,
+        'div.ember-basic-dropdown-trigger.ember-power-select-trigger._select_tdvp4z',
+    )
+    total_user_count = Locator(
+        By.CSS_SELECTOR,
+        'div.ember-view._panel_1dj7yu._sso-users-connected_1w5vdt > div > div.panel-body',
+    )
+    total_project_count = Locator(
+        By.CSS_SELECTOR,
+        'div.ember-view._panel_1dj7yu._projects_1w5vdt > div > div.panel-body > div > h3',
+    )
+    public_project_count = Locator(
+        By.CSS_SELECTOR, 'div._projects-count_1ky9tx > span:nth-child(1) > strong'
+    )
+    private_project_count = Locator(
+        By.CSS_SELECTOR, 'div._projects-count_1ky9tx > span:nth-child(2) > strong'
+    )
+
+    department_options = GroupLocator(
+        By.CSS_SELECTOR, 'ul.ember-power-select-options > li.ember-power-select-option'
+    )
+    user_table_rows = GroupLocator(
+        By.CSS_SELECTOR,
+        'div._table-wrapper_1w5vdt > div > div.ember-view > div > div > table > tbody > tr',
+    )
+
+    def select_department_from_listbox(self, department):
+        for option in self.department_options:
+            if option.text == department:
+                option.click()
+                break

--- a/tests/test_institutions.py
+++ b/tests/test_institutions.py
@@ -5,7 +5,9 @@ from selenium.webdriver.support.ui import WebDriverWait
 
 import markers
 import settings
+from api import osf_api
 from pages.institutions import (
+    InstitutionAdminDashboardPage,
     InstitutionBrandedPage,
     InstitutionsLandingPage,
 )
@@ -52,3 +54,59 @@ class TestCustomDomains:
                     (By.CSS_SELECTOR, '#tb-tbody > div > div > div.tb-row')
                 )
             )
+
+
+# Can't run this is Production since we don't have admin access to any institutions in
+# Production
+@markers.dont_run_on_prod
+@markers.core_functionality
+class TestInstitutionAdminDashboardPage:
+    def test_institution_admin_dashboard(self, driver, session, must_be_logged_in):
+        """Test using the COS admin dashboard page - user must already be setup as an
+        admin for the COS institution in each environment through the OSF admin app.
+        """
+        dashboard_page = InstitutionAdminDashboardPage(driver, institution_id='cos')
+        dashboard_page.goto()
+        assert InstitutionAdminDashboardPage(driver, verify=True)
+        dashboard_page.loading_indicator.here_then_gone()
+
+        # Select 'QA' from Departments listbox and verify that the correct number
+        # of users are displayed in the table
+        dashboard_page.departments_listbox_trigger.click()
+        dashboard_page.select_department_from_listbox('QA')
+        WebDriverWait(driver, 10).until(
+            EC.visibility_of_element_located((By.CSS_SELECTOR, '[data-test-item-name]'))
+        )
+        api_qa_users = osf_api.get_institution_users_per_department(
+            session, institution_id='cos', department='QA'
+        )
+        assert len(dashboard_page.user_table_rows) == len(api_qa_users)
+
+        # Get metrics data using the OSF api
+        metrics_data = osf_api.get_institution_metrics_summary(
+            session, institution_id='cos'
+        )
+        api_user_count = metrics_data['attributes']['user_count']
+        api_public_project_count = metrics_data['attributes']['public_project_count']
+        api_private_project_count = metrics_data['attributes']['private_project_count']
+
+        dashboard_page.scroll_into_view(dashboard_page.total_project_count.element)
+
+        # Verify Total User Count
+        displayed_user_count = dashboard_page.total_user_count.text
+        assert int(displayed_user_count) == api_user_count
+
+        # Verify Public Project Count
+        displayed_public_project_count = dashboard_page.public_project_count.text
+        assert int(displayed_public_project_count) == api_public_project_count
+
+        # Verify Private Project Count
+        displayed_private_project_count = dashboard_page.private_project_count.text
+        assert int(displayed_private_project_count) == api_private_project_count
+
+        # Verify Total Project Count
+        total_project_count = dashboard_page.total_project_count.text
+        assert (
+            int(total_project_count)
+            == api_public_project_count + api_private_project_count
+        )


### PR DESCRIPTION
<!-- Before you submit your Pull Request, please confirm that:

     - Any test that will create public data either has the `QAtest` tag or the `dont_run_on_production` marker
     - `core_functionality` is marked as such
     - Your tests will be able to run on *all* servers (all stagings, test)
 -->


## Purpose
To expand selenium test coverage to include testing of the Institution Admin Dashboard Page.


## Summary of Changes

- api/osf_api.py - adding 2 new functions: get_institution_metrics_summary() and get_institution_users_per_department()
- pages/institutions.py - adding 2 new page classes: BaseInstitutionPage and InstitutionAdminDashboardPage
- tests/test_institutions.py - adding new test: test_institution_admin_dashboard


## Reviewer's Actions
`git fetch <remote> pull/222/head:testFix/institutions-admin-dashboard`

Run this test using
`tests/test_institutions.py -s -v`

## Testing Changes Moving Forward
N/A


## Ticket
ENG-3957: SEL: Institutions Test - Add new test for Institution Admin Dashboard page
https://openscience.atlassian.net/browse/ENG-3957
