### PR TITLE
[ENG-4232] - Update Collections test for Collections Moderation Project

### DIFF
--- a/pages/project.py
+++ b/pages/project.py
@@ -39,10 +39,12 @@ class ProjectPage(GuidBasePage):
     make_private_link = Locator(By.XPATH, '//a[contains(text(), "Make Private")]')
     confirm_privacy_change_link = Locator(By.XPATH, '//a[text()="Confirm"]')
     cancel_privacy_change_link = Locator(By.XPATH, '//a[text()="Cancel"]')
-    collections_container = Locator(By.CLASS_NAME, 'collections-container')
-    collections_link = Locator(
+    collections_container = Locator(
+        By.CSS_SELECTOR, '#projectBanner > div.row > div.collections-container.col-12'
+    )
+    pending_collection_display = Locator(
         By.CSS_SELECTOR,
-        'div.collections-container > div > div > div:nth-child(1) > a:nth-child(1)',
+        '#collections-header > div.pull-left > div',
     )
 
     # Components

--- a/tests/test_collections.py
+++ b/tests/test_collections.py
@@ -21,16 +21,12 @@ class TestCollectionDiscoverPages:
     """
 
     def providers():
-        """Return collection providers to be used in Discover page test."""
-        all_providers = osf_api.get_providers_list(type='collections')
-        coll_providers = []
-        # The list of collections in some environments (i.e. Staging2) has gotten very
-        # long, so a way to narrow the list is to set allow_submssions to False in the
-        # admin app and we can then skip those old testing collections.
-        for provider in all_providers:
-            if provider['attributes']['allow_submissions']:
-                coll_providers.append(provider)
-        return coll_providers
+        """Return collection providers to be used in Discover page test. The list of
+        collections in some environments (i.e. Staging2) has gotten very long, so a way
+        to narrow the list is to set allow_submssions to False in the admin app and we
+        can then skip those old testing collections."""
+        all_prov = osf_api.get_providers_list(type='collections')
+        return [prov for prov in all_prov if prov['attributes']['allow_submissions']]
 
     @pytest.fixture(params=providers(), ids=[prov['id'] for prov in providers()])
     def provider(self, request):

--- a/tests/test_collections.py
+++ b/tests/test_collections.py
@@ -21,8 +21,16 @@ class TestCollectionDiscoverPages:
     """
 
     def providers():
-        """Return all collection providers."""
-        return osf_api.get_providers_list(type='collections')
+        """Return collection providers to be used in Discover page test."""
+        all_providers = osf_api.get_providers_list(type='collections')
+        coll_providers = []
+        # The list of collections in some environments (i.e. Staging2) has gotten very
+        # long, so a way to narrow the list is to set allow_submssions to False in the
+        # admin app and we can then skip those old testing collections.
+        for provider in all_providers:
+            if provider['attributes']['allow_submissions']:
+                coll_providers.append(provider)
+        return coll_providers
 
     @pytest.fixture(params=providers(), ids=[prov['id'] for prov in providers()])
     def provider(self, request):
@@ -93,12 +101,15 @@ class TestCollectionSubmission:
             # the confirmation modal to complete the submission
             submit_page.add_to_collection_button.click()
             submit_page.modal_add_to_collection_button.click()
-            # After submitting we will end up on the Project page - verify this and verify
-            # there is a new section on Project page indicating the project is part of a
-            # collection with a link to the collection.
+            # After submitting we will end up on the Project page - verify this and
+            # verify there is a new section on Project page indicating the project has
+            # been submitted to the collection.
             project_page = ProjectPage(driver, verify=True, guid=project_with_file.id)
             assert project_page.collections_container.present()
-            assert provider['id'] in project_page.collections_link.get_attribute('href')
+            assert (
+                'Pending entry into Selenium Testing Collection'
+                in project_page.pending_collection_display.text
+            )
             # Also verify Project is now Public.
             assert project_page.make_private_link.present()
         finally:


### PR DESCRIPTION
<!-- Before you submit your Pull Request, please confirm that:

     - Any test that will create public data either has the `QAtest` tag or the `dont_run_on_production` marker
     - `core_functionality` is marked as such
     - Your tests will be able to run on *all* servers (all stagings, test)
 -->


## Purpose
To fix a test failure in test_add_to_collection due to changes from the Collections Moderation project.


## Summary of Changes

- pages/project.py - update a couple of locators on the Project Overview page
- tests/test_collections.py - update  test_add_to_collection to account for the changes to the Project Overview page and also update the providers fixture that is used to get a more manageable list of collection providers in each environment.


## Reviewer's Actions
`git fetch <remote> pull/223/head:testFix/collections`

Run this test using
`tests/test_collections.py -s -v`

## Testing Changes Moving Forward
N/A


## Ticket
ENG-4232: SEL: Collections Test - Update test_collections.py for Collections Moderation Project
https://openscience.atlassian.net/browse/ENG-4232
