### PR TITLE
[ENG-3956] - Add New Tests for Registration Files List Page and Registration File Detail Page

### DIFF
--- a/pages/registries.py
+++ b/pages/registries.py
@@ -71,7 +71,18 @@ class RegistriesDiscoverPage(BaseRegistriesPage):
                 )
 
 
-class RegistrationDetailPage(GuidBasePage):
+class BaseSubmittedRegistrationPage(GuidBasePage):
+    base_url = settings.OSF_HOME
+    url_addition = ''
+
+    @property
+    def url(self):
+        return self.base_url + '/' + self.guid + '/' + self.url_addition
+
+
+class RegistrationDetailPage(BaseSubmittedRegistrationPage):
+    """This is the Registration Overview Page"""
+
     identity = Locator(
         By.CSS_SELECTOR, '[data-test-registration-title]', settings.LONG_TIMEOUT
     )
@@ -90,6 +101,21 @@ class RegistrationDetailPage(GuidBasePage):
     associated_project_link = Locator(
         By.CSS_SELECTOR, 'a[data-analytics-name="Registered from"]'
     )
+
+
+class RegistrationFilesListPage(BaseSubmittedRegistrationPage):
+    url_addition = 'files'
+    identity = Locator(By.CSS_SELECTOR, '[data-test-file-providers-list]')
+    file_list_button = Locator(By.CSS_SELECTOR, '[data-test-file-list-link]')
+    loading_indicator = Locator(By.CSS_SELECTOR, '.ball-scale')
+    first_file_name = Locator(By.CSS_SELECTOR, '[data-test-file-name]')
+    first_file_options_button = Locator(
+        By.CSS_SELECTOR, '[data-test-file-download-share-trigger]'
+    )
+    download_link = Locator(By.CSS_SELECTOR, '[data-test-download-button]')
+    embed_link = Locator(By.CSS_SELECTOR, '[data-test-embed-button]')
+    copy_js_link = Locator(By.CSS_SELECTOR, '[data-test-copy-js]')
+    copy_html_link = Locator(By.CSS_SELECTOR, '[data-test-copy-html]')
 
 
 class RegistrationJustificationForm(GuidBasePage):

--- a/pages/registries.py
+++ b/pages/registries.py
@@ -118,6 +118,40 @@ class RegistrationFilesListPage(BaseSubmittedRegistrationPage):
     copy_html_link = Locator(By.CSS_SELECTOR, '[data-test-copy-html]')
 
 
+class RegistrationFileDetailPage(GuidBasePage):
+    identity = Locator(By.CSS_SELECTOR, '[data-test-file-renderer')
+    file_name = Locator(By.CSS_SELECTOR, 'h2[data-test-filename]')
+    first_file_options_button = Locator(
+        By.CSS_SELECTOR, '[data-test-file-download-share-trigger]'
+    )
+    download_link = Locator(By.CSS_SELECTOR, '[data-test-download-button]')
+    embed_link = Locator(By.CSS_SELECTOR, '[data-test-embed-button]')
+    copy_js_link = Locator(By.CSS_SELECTOR, '[data-test-copy-js]')
+    copy_html_link = Locator(By.CSS_SELECTOR, '[data-test-copy-html]')
+    versions_button = Locator(By.CSS_SELECTOR, '[data-test-versions-button]')
+    first_revision_toggle_button = Locator(
+        By.CSS_SELECTOR, '[data-test-file-version-toggle-button]'
+    )
+    copy_md5_link = Locator(
+        By.CSS_SELECTOR, 'div[data-test-file-version-section="md5"] > button'
+    )
+    copy_sha2_link = Locator(
+        By.CSS_SELECTOR, 'div[data-test-file-version-section="sha2"] > button'
+    )
+    tags_button = Locator(By.CSS_SELECTOR, '[data-test-tags-button]')
+    tags_input_box = Locator(By.CSS_SELECTOR, 'li.emberTagInput-new > input')
+
+    tags = GroupLocator(
+        By.CSS_SELECTOR, 'ul[data-test-tags-widget-tag-input] > li > span'
+    )
+
+    def get_tag(self, tag_value):
+        for tag in self.tags:
+            if tag.text == tag_value:
+                return tag
+        return None
+
+
 class RegistrationJustificationForm(GuidBasePage):
     identity = Locator(By.CSS_SELECTOR, '[data-test-link-back-to-registration]')
 
@@ -244,7 +278,7 @@ class DraftRegistrationMetadataPage(BaseRegistrationDraftPage):
     next_page_button = Locator(By.CSS_SELECTOR, 'a[data-test-goto-next-page] > button')
 
     # The following generic ember dropdown listbox options locator should work for both
-    # the Category listox and the License listbox
+    # the Category listbox and the License listbox
     dropdown_options = GroupLocator(
         By.CSS_SELECTOR,
         '#ember-basic-dropdown-wormhole > div > ul >li.ember-power-select-option',

--- a/utils.py
+++ b/utils.py
@@ -74,6 +74,7 @@ def launch_driver(driver_name=settings.DRIVER, desired_capabilities=None):
         driver = driver_cls(chrome_options=chrome_options)
     elif driver_name == 'Firefox' and not settings.HEADLESS:
         from selenium.webdriver import FirefoxProfile
+        from selenium.webdriver.firefox.options import Options
 
         ffp = FirefoxProfile()
         # Set the default download location [0=Desktop, 1=Downloads, 2=Specified location]
@@ -88,7 +89,12 @@ def launch_driver(driver_name=settings.DRIVER, desired_capabilities=None):
         # Block Third Party Tracking Cookies (Default in Firefox is now 5 which blocks
         # all Cross-site cookies)
         ffp.set_preference('network.cookie.cookieBehavior', 4)
-        driver = driver_cls(firefox_profile=ffp)
+        # Force Firefox to open links in new tab instead of new browser window. Have to
+        # use Options instead of Firefox Profile because the profile preference doesn't
+        # work.
+        ffo = Options()
+        ffo.set_preference('browser.link.open_newwindow', 3)
+        driver = driver_cls(firefox_profile=ffp, options=ffo)
     elif driver_name == 'Edge' and not settings.HEADLESS:
         from msedge.selenium_tools import Edge
 


### PR DESCRIPTION
<!-- Before you submit your Pull Request, please confirm that:

     - Any test that will create public data either has the `QAtest` tag or the `dont_run_on_production` marker
     - `core_functionality` is marked as such
     - Your tests will be able to run on *all* servers (all stagings, test)
 -->


## Purpose
To expand selenium test coverage to include the Registration Files List Page and the Registration File Detail Page.


## Summary of Changes

- pages/registries.py - added new page classes: BaseSubmittedRegistrationPage, RegistrationFilesListPage, and RegistrationFileDetailPage
- tests/test_registries.py - added new test class: TestRegistrationFilesPages with new tests: test_files_list_page and test_file_detail_page
- utils.py - added new Firefox specific Option to force Firefox to open links in new tab instead of new browser window.


## Reviewer's Actions
`git fetch <remote> pull/226/head:testFix/registrations-files`

Run this test using
`tests/test_registries.py::TestRegistrationFilesPages -s -v`

## Testing Changes Moving Forward
N/A


## Ticket
ENG-3956: SEL: Registrations Tests - Add New Tests for Files List Page and File Detail Page
https://openscience.atlassian.net/browse/ENG-3956
