### PR TITLE
[ENG-4275] - Add New User Settings Test to Delete Affiliated Institution

### DIFF
--- a/components/user.py
+++ b/components/user.py
@@ -49,3 +49,8 @@ class ConfirmEmailSentModal(BaseElement):
 class ConfirmRemoveEmailModal(BaseElement):
     deleted_email = Locator(By.CSS_SELECTOR, 'div.modal-body > p > strong')
     delete_button = Locator(By.CSS_SELECTOR, '[data-test-confirm-delete]')
+
+
+class DeleteAffiliatedInstitutionModal(BaseElement):
+    cancel_button = Locator(By.CSS_SELECTOR, 'button[data-test-cancel-delete]')
+    delete_button = Locator(By.CSS_SELECTOR, 'button[data-test-confirm-delete]')

--- a/pages/user.py
+++ b/pages/user.py
@@ -12,6 +12,7 @@ from components.user import (
     ConfirmDeactivationRequestModal,
     ConfirmEmailSentModal,
     ConfirmRemoveEmailModal,
+    DeleteAffiliatedInstitutionModal,
     DeleteDevAppModal,
     DeletePATModal,
     SettingsSideNavigation,
@@ -82,6 +83,16 @@ class AccountSettingsPage(BaseUserSettingsPage):
     storage_location_listbox = Locator(
         By.CSS_SELECTOR, 'div[data-test-region-selector] > div'
     )
+    first_affiliated_institution = Locator(
+        By.CSS_SELECTOR, 'span[data-test-affiliated-institutions-item]'
+    )
+    first_aff_inst_delete_button = Locator(
+        By.CSS_SELECTOR, 'span[data-test-affiliated-institutions-delete] > button'
+    )
+    no_affiliations_message = Locator(
+        By.CSS_SELECTOR,
+        'div[data-analytics-scope="User Affiliated Institutions"] > div > div',
+    )
     update_password_button = Locator(
         By.CSS_SELECTOR, 'button[data-test-update-password-button]'
     )
@@ -120,6 +131,7 @@ class AccountSettingsPage(BaseUserSettingsPage):
     undo_deactivation_modal = ComponentLocator(UndoDeactivationRequestModal)
     confirm_email_sent_modal = ComponentLocator(ConfirmEmailSentModal)
     confirm_remove_email_modal = ComponentLocator(ConfirmRemoveEmailModal)
+    delete_aff_inst_modal = ComponentLocator(DeleteAffiliatedInstitutionModal)
 
     def get_unconfirmed_email_item(self, email_address):
         for email_item in self.unconfirmed_emails:

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -226,6 +226,36 @@ class TestUserAccountSettings:
         api_regions = sorted([region['attributes']['name'] for region in regions_data])
         assert listbox_regions == api_regions
 
+    def test_user_account_settings_delete_affiliated_institution(self, driver, session):
+        """Test the functionality of deleting an affiliated institution. The test will
+        temporarily delete the first (and only) listed affiliated institution for the
+        logged in user account. However, since we are not also deleting any connected
+        emails then the next time we login to OSF with this account the institution will
+        automatically be re-affiliated to the account.
+        """
+        settings_page = user.AccountSettingsPage(driver)
+        settings_page.goto()
+        assert user.AccountSettingsPage(driver, verify=True)
+        settings_page.scroll_into_view(
+            settings_page.first_affiliated_institution.element
+        )
+
+        # Click the Delete button to the far right of the first affiliated institution.
+        # On the Delete modal, first click the Cancel button and verify that the
+        # institution is still listed.
+        settings_page.first_aff_inst_delete_button.click()
+        settings_page.delete_aff_inst_modal.cancel_button.click()
+        settings_page.first_affiliated_institution.present()
+
+        # Click the Delete button again and this time click the Delete button on the
+        # modal and verify that the affiliated institution no longer appears in the
+        # affiliated institutions section.
+        settings_page.first_aff_inst_delete_button.click()
+        settings_page.delete_aff_inst_modal.delete_button.click()
+        settings_page.loading_indicator.here_then_gone()
+        settings_page.first_affiliated_institution.absent()
+        assert settings_page.no_affiliations_message.text == 'You have no affiliations.'
+
     def test_user_account_settings_update_password(self, driver, session):
         """Test the Change password section on the User Account Settings page in OSF.
         This test will NOT actually change the user's password.  It will just click the


### PR DESCRIPTION
<!-- Before you submit your Pull Request, please confirm that:

     - Any test that will create public data either has the `QAtest` tag or the `dont_run_on_production` marker
     - `core_functionality` is marked as such
     - Your tests will be able to run on *all* servers (all stagings, test)
 -->


## Purpose
To keep our selenium test suite up to date with new functionality added with the Institution Rework Project.


## Summary of Changes

- components/user.py - added new DeleteAffiliatedInstitutionModal class
- pages/user.py - added new elements to AccountSettingsPage class
- tests/test_user.py - added new test: test_user_account_settings_delete_affiliated_institution


## Reviewer's Actions
`git fetch <remote> pull/228/head:testFix/user-affiliated-inst`

Run this test using
`tests/test_user.py::TestUserAccountSettings::test_user_account_settings_delete_affiliated_institution -s -v`

## Testing Changes Moving Forward
N/A


## Ticket
ENG-4275: SEL: User Test - Add New Test for Affiliated Institutions Section on User Settings Account Settings Page
https://openscience.atlassian.net/browse/ENG-4275
