### PR TITLE
[ENG-4315] - Use better file locator in Project File Widget Load Test

### DIFF
--- a/components/project.py
+++ b/components/project.py
@@ -15,6 +15,7 @@ class FileWidget(BaseElement):
     file_expander = Locator(By.CSS_SELECTOR, '.fa-plus')
     filter_button = Locator(By.CSS_SELECTOR, '.fangorn-toolbar-icon .fa-search')
     filter_input = Locator(By.CSS_SELECTOR, '#folderRow .form-control')
+    first_file = Locator(By.CSS_SELECTOR, 'div[data-level="3"] > .td-title')
 
     # Group Locators
     component_and_file_titles = GroupLocator(By.CSS_SELECTOR, '.td-title')

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -82,7 +82,7 @@ class TestProjectDetailPage:
     def test_file_widget_loads(self, project_page_with_file):
         # Check the uploaded file shows up in the files widget
         project_page_with_file.file_widget.loading_indicator.here_then_gone()
-        assert project_page_with_file.file_widget.component_and_file_titles[3]
+        assert project_page_with_file.file_widget.first_file
 
     @markers.smoke_test
     @pytest.mark.skipif(


### PR DESCRIPTION
<!-- Before you submit your Pull Request, please confirm that:

     - Any test that will create public data either has the `QAtest` tag or the `dont_run_on_production` marker
     - `core_functionality` is marked as such
     - Your tests will be able to run on *all* servers (all stagings, test)
 -->


## Purpose
Update Project File Widget Load Test to use a better locator for a file after code changes to the Project Overview page that will cause the test to fail due to a bad index.


## Summary of Changes

- components/project.py - add new first_file element
- tests/test_project.py - update test_file_widget_loads to use new first_file element


## Reviewer's Actions
`git fetch <remote> pull/229/head:testFix/project-file-widget`

Run this test using
`tests/test_project.py -s -v`

## Testing Changes Moving Forward
N/A


## Ticket
ENG-4315: SEL: Project Test - File Widget Load Test Failure
https://openscience.atlassian.net/browse/ENG-4315
