### PR TITLE
[ENG-4331] - Set feature popover cookie in registration page init to prevent test failure

### DIFF
--- a/pages/registries.py
+++ b/pages/registries.py
@@ -75,6 +75,14 @@ class BaseSubmittedRegistrationPage(GuidBasePage):
     base_url = settings.OSF_HOME
     url_addition = ''
 
+    def __init__(self, driver, verify=False, guid=''):
+        # Set the cookie that prevents the New Feature popover from appearing on
+        # submitted registration pages since this popover can get in the way of other
+        # actions.
+        driver.add_cookie({'name': 'metadataFeaturePopover', 'value': '1'})
+
+        super().__init__(driver, verify, guid)
+
     @property
     def url(self):
         return self.base_url + '/' + self.guid + '/' + self.url_addition

--- a/tests/test_registries.py
+++ b/tests/test_registries.py
@@ -580,11 +580,6 @@ class TestRegistrationFilesPages:
         my_registrations_page = MyRegistrationsPage(driver)
         my_registrations_page.goto()
 
-        # Set the cookie that prevents the New Feature popover from appearing on
-        # submitted registration pages since this popover can get in the way of other
-        # actions.
-        driver.add_cookie({'name': 'outputFeaturePopover', 'value': '1'})
-
         # Wait for registration cards to load on page
         WebDriverWait(driver, 10).until(
             EC.presence_of_element_located((By.CSS_SELECTOR, '[data-test-node-card]'))


### PR DESCRIPTION
<!-- Before you submit your Pull Request, please confirm that:

     - Any test that will create public data either has the `QAtest` tag or the `dont_run_on_production` marker
     - `core_functionality` is marked as such
     - Your tests will be able to run on *all* servers (all stagings, test)
 -->


## Purpose
To fix a test failure by setting the cookie that prevents the new metadata feature popover window from appearing on registration pages.


## Summary of Changes

- pages/registries.py - adding "__init__" with statement that sets the "metadataFeaturePopover" cookie.
- tests/test_registries.py - remove outdated code that set an older cookie for the Output Reporting feature popover.


## Reviewer's Actions
`git fetch <remote> pull/230/head:testFix/reg-feature-popover`

Run this test using
" pytest -s -v -k 'regist' "

## Testing Changes Moving Forward
N/A


## Ticket
ENG-4331: SEL: My Registration Page Delete Versioning Test Failure
https://openscience.atlassian.net/browse/ENG-4331
