### PR TITLE
[ENG-4375] - Add test for subject sorting on draft registrations

### DIFF
--- a/api/osf_api.py
+++ b/api/osf_api.py
@@ -489,7 +489,7 @@ def create_draft_registration(session, node_id=None, schema_id=None):
             },
         },
     }
-    session.post(
+    return session.post(
         url=url, item_type='draft_registrations', raw_body=json.dumps(raw_payload)
     )
 

--- a/pages/registries.py
+++ b/pages/registries.py
@@ -254,6 +254,7 @@ class BaseRegistrationDraftPage(BaseRegistriesPage):
     def url(self):
         return self.base_url + self.draft_id + '/' + self.url_addition
 
+    loading_indicator = Locator(By.CSS_SELECTOR, '.ball-scale')
     page_heading = Locator(By.CSS_SELECTOR, 'h2[data-test-page-heading]')
     next_page_button = Locator(By.CSS_SELECTOR, 'a[data-test-goto-next-page] > button')
     first_file_name = Locator(By.CSS_SELECTOR, 'span[data-test-file-name]')


### PR DESCRIPTION
<!-- Before you submit your Pull Request, please confirm that:

     - Any test that will create public data either has the `QAtest` tag or the `dont_run_on_production` marker
     - `core_functionality` is marked as such
     - Your tests will be able to run on *all* servers (all stagings, test)
 -->


## Purpose
To expand selenium test coverage to include a recently discovered sorting issue.


## Summary of Changes

- api/osf_api.py - updating create_draft_registration to return the data for the created draft registration
- pages/registries.py - adding loading_indicator element to BaseRegistrationDraftPage class
- tests/test_registries.py - adding new class: TestDraftRegistration with new fixture: draft_registration and new test: test_subjects_sort_order


## Reviewer's Actions
`git fetch <remote> pull/231/head:newTest/reg-subject-sorting`

Run this test using
`tests/test_registries.py::TestDraftRegistration::test_subjects_sort_order -s -v`

## Testing Changes Moving Forward
N/A


## Ticket
ENG-4375: SEL: Registrations Test - Add New Test for Draft Registration Subject Sort Order
https://openscience.atlassian.net/browse/ENG-4375
