### PR TITLE
[ENG-4257] - Add New Tests for Collections Moderation Workflows

### DIFF
--- a/api/osf_api.py
+++ b/api/osf_api.py
@@ -417,6 +417,32 @@ def update_node_public_attribute(session, node_id, status=False):
     )
 
 
+def update_node_license(session, node_id, license_id, copyright_holders=[], year=2023):
+    """Update the license on a given project node."""
+    url = '/v2/nodes/{}/'.format(node_id)
+    raw_payload = {
+        'data': {
+            'type': 'nodes',
+            'id': node_id,
+            'attributes': {
+                'node_license': {
+                    'copyright_holders': copyright_holders,
+                    'year': year,
+                },
+            },
+            'relationships': {
+                'license': {'data': {'type': 'licenses', 'id': license_id}}
+            },
+        },
+    }
+    session.patch(
+        url=url,
+        item_type='nodes',
+        item_id=node_id,
+        raw_body=json.dumps(raw_payload),
+    )
+
+
 def get_most_recent_preprint_node_id(session=None):
     """Return the most recently published preprint node id"""
     if not session:
@@ -883,3 +909,48 @@ def delete_registration_version_draft(session, draft_id):
         session.api_base_url, draft_id
     )
     session.delete(url=registration_version_url, item_type='schema-responses')
+
+
+def submit_project_to_collection(
+    session, collection_guid, node_id, collected_type='selenium'
+):
+    """Submit a given project node to a collection.  This applies to branded public
+    collections and not a user's private custom collection.  NOTE: This function will
+    only work for collections using the 'collected_type' attribute.  Some collections
+    use different attributes (ex: 'school_type', 'study_design', 'status', etc.). If
+    this function will be used in the future to submit to a collection that uses one
+    of the other attributes, then the raw_payload below will need to be updated to add
+    those specific attributes.
+    """
+    if not session:
+        session = get_default_session()
+    user = current_user(session)
+
+    url = '/v2/collections/{}/collection_submissions/'.format(collection_guid)
+
+    raw_payload = {
+        'data': {
+            'type': 'collection_submissions',
+            'attributes': {
+                'collected_type': collected_type,
+                'guid': node_id,
+            },
+            'relationships': {
+                'collection': {
+                    'data': {
+                        'id': collection_guid,
+                        'type': 'collections',
+                    }
+                },
+                'creator': {
+                    'data': {
+                        'id': user.id,
+                        'type': 'users',
+                    }
+                },
+            },
+        },
+    }
+    session.post(
+        url=url, item_type='collection_submissions', raw_body=json.dumps(raw_payload)
+    )

--- a/api/osf_api.py
+++ b/api/osf_api.py
@@ -951,6 +951,9 @@ def submit_project_to_collection(
             },
         },
     }
-    session.post(
+    return session.post(
         url=url, item_type='collection_submissions', raw_body=json.dumps(raw_payload)
     )
+    # Note: We are not currently checking for any potential api request failure. We
+    # don't typically handle failures unless they are a recurring issue and in this
+    # case this post request has yet to fail in any of the testing environments.

--- a/pages/collections.py
+++ b/pages/collections.py
@@ -87,6 +87,34 @@ class CollectionSubmitPage(BaseCollectionPage):
     )
 
 
+class CollectionEditPage(BaseCollectionPage):
+    url_addition = '{guid}/edit'
+
+    identity = Locator(By.CSS_SELECTOR, 'div[data-test-submit-section-click-to-edit]')
+    remove_button = Locator(
+        By.CSS_SELECTOR, 'span[data-test-collections-remove-button] > button'
+    )
+    modal_remove_reason_input = Locator(
+        By.CSS_SELECTOR, 'textarea[data-test-collections-remove-reason]'
+    )
+    modal_cancel_remove_button = Locator(
+        By.CSS_SELECTOR, 'button[data-test-cancel-delete]'
+    )
+    modal_remove_button = Locator(By.CSS_SELECTOR, 'button[data-test-confirm-delete]')
+
+    def __init__(self, driver, verify=False, provider=None, guid=''):
+        self.guid = guid
+        super().__init__(driver, verify, provider)
+
+    @property
+    def url(self):
+        return (
+            urljoin(self.base_url, self.provider_id)
+            + '/'
+            + self.url_addition.format(guid=self.guid)
+        )
+
+
 class BaseCollectionModerationPage(BaseCollectionPage):
     loading_indicator = Locator(By.CSS_SELECTOR, '.ball-scale')
 

--- a/pages/collections.py
+++ b/pages/collections.py
@@ -87,12 +87,27 @@ class CollectionSubmitPage(BaseCollectionPage):
     )
 
 
-class CollectionModerationPendingPage(BaseCollectionPage):
+class BaseCollectionModerationPage(BaseCollectionPage):
+    loading_indicator = Locator(By.CSS_SELECTOR, '.ball-scale')
+
+    submission_cards = GroupLocator(By.CSS_SELECTOR, '[data-test-submission-card]')
+
+    def get_submission_card(self, node_id):
+        for card in self.submission_cards:
+            url = card.find_element_by_css_selector(
+                '[data-test-submission-card-title]'
+            ).get_attribute('href')
+            guid = url.split(settings.OSF_HOME + '/', 1)[1]
+            if guid == node_id:
+                return card
+            return None
+
+
+class CollectionModerationPendingPage(BaseCollectionModerationPage):
     url_addition = 'moderation/all?state=pending#'
     identity = Locator(
         By.CSS_SELECTOR, '[data-test-submissions-type="pending"]', settings.LONG_TIMEOUT
     )
-    loading_indicator = Locator(By.CSS_SELECTOR, '.ball-scale')
     accept_radio_button = Locator(By.CSS_SELECTOR, 'input[value="accept"]')
     reject_radio_button = Locator(By.CSS_SELECTOR, 'input[value="reject"]')
     moderation_comment = Locator(
@@ -102,58 +117,36 @@ class CollectionModerationPendingPage(BaseCollectionPage):
         By.CSS_SELECTOR, 'button[data-test-moderation-dropdown-submit]'
     )
 
-    submission_cards = GroupLocator(By.CSS_SELECTOR, '[data-test-submission-card]')
 
-    def get_submission_card(self, node_id):
-        for card in self.submission_cards:
-            url = card.find_element_by_css_selector(
-                '[data-test-submission-card-title]'
-            ).get_attribute('href')
-            guid = url.split(settings.OSF_HOME + '/', 1)[1]
-            if guid == node_id:
-                return card
-            return None
-
-
-class CollectionModerationAcceptedPage(BaseCollectionPage):
+class CollectionModerationAcceptedPage(BaseCollectionModerationPage):
     url_addition = 'moderation/all?state=accepted#'
     identity = Locator(
         By.CSS_SELECTOR,
         '[data-test-submissions-type="accepted"]',
         settings.LONG_TIMEOUT,
     )
-    loading_indicator = Locator(By.CSS_SELECTOR, '.ball-scale')
-
-    submission_cards = GroupLocator(By.CSS_SELECTOR, '[data-test-submission-card]')
-
-    def get_submission_card(self, node_id):
-        for card in self.submission_cards:
-            url = card.find_element_by_css_selector(
-                '[data-test-submission-card-title]'
-            ).get_attribute('href')
-            guid = url.split(settings.OSF_HOME + '/', 1)[1]
-            if guid == node_id:
-                return card
-            return None
+    remove_radio_button = Locator(By.CSS_SELECTOR, 'input[value="remove"]')
+    moderation_comment = Locator(
+        By.CSS_SELECTOR, '[data-test-moderation-dropdown-comment]'
+    )
+    submit_button = Locator(
+        By.CSS_SELECTOR, 'button[data-test-moderation-dropdown-submit]'
+    )
 
 
-class CollectionModerationRejectedPage(BaseCollectionPage):
+class CollectionModerationRejectedPage(BaseCollectionModerationPage):
     url_addition = 'moderation/all?state=rejected'
     identity = Locator(
         By.CSS_SELECTOR,
         '[data-test-submissions-type="rejected"]',
         settings.LONG_TIMEOUT,
     )
-    loading_indicator = Locator(By.CSS_SELECTOR, '.ball-scale')
 
-    submission_cards = GroupLocator(By.CSS_SELECTOR, '[data-test-submission-card]')
 
-    def get_submission_card(self, node_id):
-        for card in self.submission_cards:
-            url = card.find_element_by_css_selector(
-                '[data-test-submission-card-title]'
-            ).get_attribute('href')
-            guid = url.split(settings.OSF_HOME + '/', 1)[1]
-            if guid == node_id:
-                return card
-            return None
+class CollectionModerationRemovedPage(BaseCollectionModerationPage):
+    url_addition = 'moderation/all?state=removed'
+    identity = Locator(
+        By.CSS_SELECTOR,
+        '[data-test-submissions-type="removed"]',
+        settings.LONG_TIMEOUT,
+    )

--- a/pages/collections.py
+++ b/pages/collections.py
@@ -5,6 +5,7 @@ from selenium.webdriver.common.by import By
 import settings
 from base.locators import (
     ComponentLocator,
+    GroupLocator,
     Locator,
 )
 from components.navbars import CollectionsNavbar
@@ -84,3 +85,53 @@ class CollectionSubmitPage(BaseCollectionPage):
         By.CSS_SELECTOR,
         '[data-test-collection-submission-confirmation-modal-add-button]',
     )
+
+
+class CollectionModerationPendingPage(BaseCollectionPage):
+    url_addition = 'moderation/all?state=pending#'
+    identity = Locator(
+        By.CSS_SELECTOR, '[data-test-submissions-type="pending"]', settings.LONG_TIMEOUT
+    )
+    loading_indicator = Locator(By.CSS_SELECTOR, '.ball-scale')
+    accept_radio_button = Locator(By.CSS_SELECTOR, 'input[value="accept"]')
+    reject_radio_button = Locator(By.CSS_SELECTOR, 'input[value="reject"]')
+    moderation_comment = Locator(
+        By.CSS_SELECTOR, '[data-test-moderation-dropdown-comment]'
+    )
+    submit_button = Locator(
+        By.CSS_SELECTOR, 'button[data-test-moderation-dropdown-submit]'
+    )
+
+    submission_cards = GroupLocator(By.CSS_SELECTOR, '[data-test-submission-card]')
+
+    def get_submission_card(self, node_id):
+        for card in self.submission_cards:
+            url = card.find_element_by_css_selector(
+                '[data-test-submission-card-title]'
+            ).get_attribute('href')
+            guid = url.split(settings.OSF_HOME + '/', 1)[1]
+            if guid == node_id:
+                return card
+            return None
+
+
+class CollectionModerationAcceptedPage(BaseCollectionPage):
+    url_addition = 'moderation/all?state=accepted#'
+    identity = Locator(
+        By.CSS_SELECTOR,
+        '[data-test-submissions-type="accepted"]',
+        settings.LONG_TIMEOUT,
+    )
+    loading_indicator = Locator(By.CSS_SELECTOR, '.ball-scale')
+
+    submission_cards = GroupLocator(By.CSS_SELECTOR, '[data-test-submission-card]')
+
+    def get_submission_card(self, node_id):
+        for card in self.submission_cards:
+            url = card.find_element_by_css_selector(
+                '[data-test-submission-card-title]'
+            ).get_attribute('href')
+            guid = url.split(settings.OSF_HOME + '/', 1)[1]
+            if guid == node_id:
+                return card
+            return None

--- a/pages/collections.py
+++ b/pages/collections.py
@@ -128,7 +128,7 @@ class BaseCollectionModerationPage(BaseCollectionPage):
             guid = url.split(settings.OSF_HOME + '/', 1)[1]
             if guid == node_id:
                 return card
-            return None
+        return None
 
 
 class CollectionModerationPendingPage(BaseCollectionModerationPage):

--- a/pages/collections.py
+++ b/pages/collections.py
@@ -135,3 +135,25 @@ class CollectionModerationAcceptedPage(BaseCollectionPage):
             if guid == node_id:
                 return card
             return None
+
+
+class CollectionModerationRejectedPage(BaseCollectionPage):
+    url_addition = 'moderation/all?state=rejected'
+    identity = Locator(
+        By.CSS_SELECTOR,
+        '[data-test-submissions-type="rejected"]',
+        settings.LONG_TIMEOUT,
+    )
+    loading_indicator = Locator(By.CSS_SELECTOR, '.ball-scale')
+
+    submission_cards = GroupLocator(By.CSS_SELECTOR, '[data-test-submission-card]')
+
+    def get_submission_card(self, node_id):
+        for card in self.submission_cards:
+            url = card.find_element_by_css_selector(
+                '[data-test-submission-card-title]'
+            ).get_attribute('href')
+            guid = url.split(settings.OSF_HOME + '/', 1)[1]
+            if guid == node_id:
+                return card
+            return None

--- a/pages/project.py
+++ b/pages/project.py
@@ -39,6 +39,7 @@ class ProjectPage(GuidBasePage):
     make_private_link = Locator(By.XPATH, '//a[contains(text(), "Make Private")]')
     confirm_privacy_change_link = Locator(By.XPATH, '//a[text()="Confirm"]')
     cancel_privacy_change_link = Locator(By.XPATH, '//a[text()="Cancel"]')
+    loading_indicator = Locator(By.CSS_SELECTOR, '.ball-pulse')
     collections_container = Locator(
         By.CSS_SELECTOR, '#projectBanner > div.row > div.collections-container.col-12'
     )

--- a/pages/project.py
+++ b/pages/project.py
@@ -53,6 +53,9 @@ class ProjectPage(GuidBasePage):
         By.CSS_SELECTOR, '#collectionList > div > div:nth-child(3)'
     )
     first_collection_edit_link = Locator(By.CSS_SELECTOR, '#collectionList > div > a')
+    first_collection_cancel_link = Locator(
+        By.CSS_SELECTOR, 'a.fa.fa-close.collections-cancel-icon'
+    )
 
     # Components
     file_widget = ComponentLocator(FileWidget)

--- a/pages/project.py
+++ b/pages/project.py
@@ -46,6 +46,8 @@ class ProjectPage(GuidBasePage):
         By.CSS_SELECTOR,
         '#collections-header > div.pull-left > div',
     )
+    collection_justification_link = Locator(By.CSS_SELECTOR, 'a.comment-popover')
+    collection_justification_reason = Locator(By.CSS_SELECTOR, 'div.popover-content')
 
     # Components
     file_widget = ComponentLocator(FileWidget)

--- a/pages/project.py
+++ b/pages/project.py
@@ -48,6 +48,10 @@ class ProjectPage(GuidBasePage):
     )
     collection_justification_link = Locator(By.CSS_SELECTOR, 'a.comment-popover')
     collection_justification_reason = Locator(By.CSS_SELECTOR, 'div.popover-content')
+    first_collection_label = Locator(
+        By.CSS_SELECTOR, '#collectionList > div > div:nth-child(3)'
+    )
+    first_collection_edit_link = Locator(By.CSS_SELECTOR, '#collectionList > div > a')
 
     # Components
     file_widget = ComponentLocator(FileWidget)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -105,6 +105,18 @@ def must_be_logged_in_as_user_two(driver):
     safe_login(driver, user=settings.USER_TWO, password=settings.USER_TWO_PASSWORD)
 
 
+@pytest.fixture
+def log_in_as_user_two_if_not_already(driver):
+    """This fixture is similar to the must_be_logged_in_as_user_two fixture above.
+    Where it differs is that it first checks to see if the user is already logged in
+    before it attempts to login again. Also the scope of this fixture is 'function' by
+    default instead of 'class' so it will be executed with every test function within
+    a class.
+    """
+    if not user_logged_in(driver):
+        safe_login(driver, user=settings.USER_TWO, password=settings.USER_TWO_PASSWORD)
+
+
 @pytest.fixture(scope='class')
 def delete_user_projects_at_setup(session):
     osf_api.delete_all_user_projects(session=session)

--- a/tests/test_collections.py
+++ b/tests/test_collections.py
@@ -212,11 +212,11 @@ class TestCollectionModeration:
         pending_page.loading_indicator.here_then_gone()
 
         # Get the card for the project that was just submitted to the collection
-        submisison_card = pending_page.get_submission_card(collection_project.id)
+        submission_card = pending_page.get_submission_card(collection_project.id)
 
         # Click the Make Decision button on the submission card to reveal the Moderation
         # Dropdown
-        submisison_card.find_element_by_css_selector(
+        submission_card.find_element_by_css_selector(
             '[data-test-moderation-dropdown-button]'
         ).click()
 
@@ -291,16 +291,16 @@ class TestCollectionModeration:
             pending_page.loading_indicator.here_then_gone()
 
             # Get the card for the project that was just submitted to the collection
-            submisison_card = pending_page.get_submission_card(collection_project.id)
+            submission_card = pending_page.get_submission_card(collection_project.id)
 
-            # Click the Make Decision button on the submission card to reveal the Moderation
-            # Dropdown
-            submisison_card.find_element_by_css_selector(
+            # Click the Make Decision button on the submission card to reveal the
+            # Moderation Dropdown
+            submission_card.find_element_by_css_selector(
                 '[data-test-moderation-dropdown-button]'
             ).click()
 
-            # On the Moderation Dropdown, click the Reject Request radio button and enter a
-            # comment and then click the Submit button
+            # On the Moderation Dropdown, click the Reject Request radio button and
+            # enter a comment and then click the Submit button
             pending_page.loading_indicator.here_then_gone()
             pending_page.reject_radio_button.click()
             pending_page.moderation_comment.click()
@@ -319,9 +319,10 @@ class TestCollectionModeration:
             assert CollectionModerationRejectedPage(driver, verify=True)
             rejected_page.loading_indicator.here_then_gone()
 
-            # Find the card for the project that was just rejected and click the link for
-            # this project to go to the Project Overview Page. It should be the first one
-            # in the table since the default sort order is by Date (newest first).
+            # Find the card for the project that was just rejected and click the link
+            # for this project to go to the Project Overview Page. It should be the
+            # first one in the table since the default sort order is by Date (newest
+            # first).
             rejected_card = rejected_page.get_submission_card(collection_project.id)
             assert (
                 rejected_card.find_element_by_css_selector(
@@ -333,8 +334,8 @@ class TestCollectionModeration:
                 '[data-test-submission-card-title]'
             ).click()
 
-            # On the Project Overview Page, verify that the Collection Container is absent
-            # since the project is NOT included in the collection.
+            # On the Project Overview Page, verify that the Collection Container is
+            # absent since the project is NOT included in the collection.
             project_page = ProjectPage(driver, verify=True)
             assert project_page.collections_container.absent()
 
@@ -344,9 +345,9 @@ class TestCollectionModeration:
                 driver, user=settings.USER_TWO, password=settings.USER_TWO_PASSWORD
             )
 
-            # Navigate to the Project Overview page for the project that was just rejected
-            # from the collection and verify that the user that created and submitted the
-            # project can see the reason that it was rejected.
+            # Navigate to the Project Overview page for the project that was just
+            # rejected from the collection and verify that the user that created and
+            # submitted the project can see the reason that it was rejected.
             project_page = ProjectPage(driver, guid=collection_project.id)
             project_page.goto()
             assert project_page.collections_container.present()
@@ -400,11 +401,11 @@ class TestCollectionModeration:
             accepted_page.loading_indicator.here_then_gone()
 
             # Get the card for the project that was just submitted to the collection
-            submisison_card = accepted_page.get_submission_card(collection_project.id)
+            submission_card = accepted_page.get_submission_card(collection_project.id)
 
-            # Click the Make Decision button on the submission card to reveal the Moderation
-            # Dropdown
-            submisison_card.find_element_by_css_selector(
+            # Click the Make Decision button on the submission card to reveal the
+            # Moderation Dropdown
+            submission_card.find_element_by_css_selector(
                 '[data-test-moderation-dropdown-button]'
             ).click()
 
@@ -428,9 +429,10 @@ class TestCollectionModeration:
             assert CollectionModerationRemovedPage(driver, verify=True)
             removed_page.loading_indicator.here_then_gone()
 
-            # Find the card for the project that was just removed and click the link for
-            # this project to go to the Project Overview Page. It should be the first one
-            # in the table since the default sort order is by Date (newest first).
+            # Find the card for the project that was just removed and click the link
+            # for this project to go to the Project Overview Page. It should be the
+            # first one in the table since the default sort order is by Date (newest
+            # first).
             removed_card = removed_page.get_submission_card(collection_project.id)
             assert (
                 removed_card.find_element_by_css_selector(
@@ -442,8 +444,8 @@ class TestCollectionModeration:
                 '[data-test-submission-card-title]'
             ).click()
 
-            # On the Project Overview Page, verify that the Collection Container is absent
-            # since the project is no longer included in the collection.
+            # On the Project Overview Page, verify that the Collection Container is
+            # absent since the project is no longer included in the collection.
             project_page = ProjectPage(driver, verify=True)
             assert project_page.collections_container.absent()
 
@@ -453,9 +455,9 @@ class TestCollectionModeration:
                 driver, user=settings.USER_TWO, password=settings.USER_TWO_PASSWORD
             )
 
-            # Navigate to the Project Overview page for the project that was just removed
-            # from the collection and verify that the user that created and submitted the
-            # project can see the reason that it was removed.
+            # Navigate to the Project Overview page for the project that was just
+            # removed from the collection and verify that the user that created and
+            # submitted the project can see the reason that it was removed.
             project_page = ProjectPage(driver, guid=collection_project.id)
             project_page.goto()
             assert project_page.collections_container.present()
@@ -486,66 +488,104 @@ class TestCollectionModeration:
         the collection via the OSF api.
         """
 
-        # Get data for the Selenium Post-moderated Collection
-        collection_provider = osf_api.get_provider(
-            session, type='collections', provider_id='selpostmod'
-        )
+        try:
+            # Get data for the Selenium Post-moderated Collection
+            collection_provider = osf_api.get_provider(
+                session, type='collections', provider_id='selpostmod'
+            )
 
-        # Submit the project to the Selenium Post-moderated Collection
-        self.submit_to_moderated_collection(collection_provider, collection_project.id)
+            # Submit the project to the Selenium Post-moderated Collection
+            self.submit_to_moderated_collection(
+                collection_provider, collection_project.id
+            )
 
-        # Navigate to the Project Overview page for the project that was submitted to
-        # the collection.
-        project_page = ProjectPage(driver, guid=collection_project.id)
-        project_page.goto()
-        assert project_page.collections_container.present()
-        assert (
-            'Included in Selenium Post Moderation'
-            in project_page.pending_collection_display.text
-        )
+            # Navigate to the Project Overview page for the project that was submitted to
+            # the collection.
+            project_page = ProjectPage(driver, guid=collection_project.id)
+            project_page.goto()
+            assert project_page.collections_container.present()
+            assert (
+                'Included in Selenium Post Moderation'
+                in project_page.pending_collection_display.text
+            )
 
-        # Expand the collection container and click the edit button (pencil icon) to
-        # go to the Edit Collection page.
-        project_page.collections_container.click()
-        project_page.first_collection_edit_link.click()
-        edit_page = CollectionEditPage(driver, verify=True)
+            # Expand the collection container and click the edit button (pencil icon) to
+            # go to the Edit Collection page.
+            project_page.collections_container.click()
+            project_page.first_collection_edit_link.click()
+            edit_page = CollectionEditPage(driver, verify=True)
 
-        # Scroll to the bottom of the page and click the Remove from collection button
-        edit_page.scroll_into_view(edit_page.remove_button.element)
-        edit_page.remove_button.click()
+            # Scroll to the bottom of the page and click the Remove from collection button
+            edit_page.scroll_into_view(edit_page.remove_button.element)
+            edit_page.remove_button.click()
 
-        # On the Remove from collection modal, first click the Cancel button and verify
-        # that you are still on the Edit Collection page.
-        edit_page.modal_cancel_remove_button.click()
-        assert CollectionEditPage(driver, verify=True)
+            # On the Remove from collection modal, first click the Cancel button and verify
+            # that you are still on the Edit Collection page.
+            edit_page.modal_cancel_remove_button.click()
+            assert CollectionEditPage(driver, verify=True)
 
-        # Click the Remove from collection button again. This time enter a reason in the
-        # input box and click the Remove from collection button on the modal.
-        edit_page.remove_button.click()
-        edit_page.modal_remove_reason_input.click()
-        edit_page.modal_remove_reason_input.send_keys_deliberately(
-            'Project admin removing project from collection via selenium automated test.'
-        )
-        edit_page.modal_remove_button.click()
+            # Click the Remove from collection button again. This time enter a reason in the
+            # input box and click the Remove from collection button on the modal.
+            edit_page.remove_button.click()
+            edit_page.modal_remove_reason_input.click()
+            edit_page.modal_remove_reason_input.send_keys_deliberately(
+                'Project admin removing project from collection via selenium automated test.'
+            )
+            edit_page.modal_remove_button.click()
 
-        # Verify that you are redirected back to the Project Overview page and that the
-        # remove reason can be seen by the project admin.
-        project_page = ProjectPage(driver, verify=True)
-        project_page.loading_indicator.here_then_gone()
-        assert project_page.collections_container.present()
-        project_page.collections_container.click()
-        assert (
-            'Removed from Selenium Post Moderation'
-            in project_page.first_collection_label.text
-        )
-        project_page.collection_justification_link.click()
-        assert (
-            project_page.collection_justification_reason.text
-            == 'Project admin removing project from collection via selenium automated test.'
-        )
+            # Verify that you are redirected back to the Project Overview page and that the
+            # remove reason can be seen by the project admin.
+            project_page = ProjectPage(driver, verify=True)
+            project_page.loading_indicator.here_then_gone()
+            assert project_page.collections_container.present()
+            project_page.collections_container.click()
+            assert (
+                'Removed from Selenium Post Moderation'
+                in project_page.first_collection_label.text
+            )
+            project_page.collection_justification_link.click()
+            assert (
+                project_page.collection_justification_reason.text
+                == 'Project admin removing project from collection via selenium automated test.'
+            )
+
+            # Logout and then login as User One who is the collection moderator
+            logout(driver)
+            safe_login(driver)
+
+            # Navigate to the Collection Moderation Removed Page
+            removed_page = CollectionModerationRemovedPage(
+                driver, provider=collection_provider
+            )
+            removed_page.goto()
+            assert CollectionModerationRemovedPage(driver, verify=True)
+            removed_page.loading_indicator.here_then_gone()
+
+            # Find the card for the project that was just removed and click the link for
+            # this project to go to the Project Overview Page. It should be the first one
+            # in the table since the default sort order is by Date (newest first).
+            removed_card = removed_page.get_submission_card(collection_project.id)
+            assert (
+                removed_card.find_element_by_css_selector(
+                    '[data-test-review-action-comment]'
+                ).text
+                == '— Project admin removing project from collection via selenium automated test.'
+            )
+            removed_card.find_element_by_css_selector(
+                '[data-test-submission-card-title]'
+            ).click()
+
+            # On the Project Overview Page, verify that the Collection Container is absent
+            # since the project is no longer included in the collection.
+            project_page = ProjectPage(driver, verify=True)
+            assert project_page.collections_container.absent()
+        finally:
+            # Since we are switching logins from User Two to User One we must make sure
+            # that we are properly logged out before proceeding to the next test case.
+            logout(driver)
 
     def test_pre_moderation_collection_cancel_pending(
-        self, session, driver, must_be_logged_in_as_user_two, collection_project
+        self, session, driver, log_in_as_user_two_if_not_already, collection_project
     ):
         """Test the cancellation of a project submission to a public branded collection
         with a pre-moderation workflow.  In this test a project is submitted to a

--- a/tests/test_collections.py
+++ b/tests/test_collections.py
@@ -346,8 +346,26 @@ class TestCollectionModeration:
         project_page = ProjectPage(driver, verify=True)
         assert project_page.collections_container.absent()
 
+        # Logout and then login as User Two
+        logout(driver)
+        safe_login(driver, user=settings.USER_TWO, password=settings.USER_TWO_PASSWORD)
+
+        # Navigate to the Project Overview page for the project that was just remjected
+        # from the collection and verify that the user that created and submitted the
+        # project can see the reason that it was rejected.
+        project_page = ProjectPage(driver, guid=collection_project.id)
+        project_page.goto()
+        assert project_page.collections_container.present()
+        project_page.collections_container.click()
+        project_page.collection_justification_link.click()
+        assert (
+            project_page.collection_justification_reason.text
+            == 'Rejecting collection submission via selenium automated test.'
+        )
+        logout(driver)
+
     def test_post_moderation_collection_remove(
-        self, session, driver, must_be_logged_in, collection_project
+        self, session, driver, log_in_if_not_already, collection_project
     ):
         """Test the removal of a project from a public branded collection with a
         post-moderation workflow.  In this test a project is submitted to a collection


### PR DESCRIPTION
<!-- Before you submit your Pull Request, please confirm that:

     - Any test that will create public data either has the `QAtest` tag or the `dont_run_on_production` marker
     - `core_functionality` is marked as such
     - Your tests will be able to run on *all* servers (all stagings, test)
 -->


## Purpose
To expand selenium test coverage to include new Collections Moderation workflows.


## Summary of Changes

- api/osf_api.py - add 2 new functions: update_node_license and submit_project_to_collection
- pages/collections.py - add 6 new page classes: CollectionEditPage, BaseCollectionModerationPage, CollectionModerationPendingPage, CollectionModerationAcceptedPage, CollectionModerationRejectedPage, and CollectionModerationRemovedPage
- pages/project.py - update page class: ProjectPage with new elements related to collections
- tests/test_collections.py - add new test class: TestCollectionModeration with 5 new tests: test_pre_moderation_collection_accept, test_pre_moderation_collection_reject, test_post_moderation_collection_remove, test_post_moderation_collection_remove_by_project_admin, and test_pre_moderation_collection_cancel_pending


## Reviewer's Actions
`git fetch <remote> pull/232/head:newTest/collections-moderation`

Run this test using
`tests/test_collections.py::TestCollectionModeration -s -v`

## Testing Changes Moving Forward
N/A


## Ticket
ENG-4257: SEL: Collections Test - Add Tests for Collections Moderation Workflows
https://openscience.atlassian.net/browse/ENG-4257
