### PR TITLE
{ENG-4425} - Fix Registries Search Detail Page test failure in testing environments

### DIFF
--- a/pages/registries.py
+++ b/pages/registries.py
@@ -55,6 +55,10 @@ class RegistriesDiscoverPage(BaseRegistriesPage):
     osf_filter = Locator(
         By.CSS_SELECTOR, '[data-test-source-filter-id$="OSF Registries"]'
     )
+    sort_by_button = Locator(By.CSS_SELECTOR, 'div[data-test-sort-dropdown]')
+    sort_by_date_newest = Locator(
+        By.CSS_SELECTOR, 'button[data-test-sort-option-id="2"]'
+    )
 
     # Group Locators
     search_results = GroupLocator(

--- a/tests/test_registries.py
+++ b/tests/test_registries.py
@@ -53,19 +53,7 @@ class TestRegistriesDiscoverPage:
         assert len(discover_page.search_results) > 0
 
     @markers.smoke_test
-    # NOTE: 03/10/2023 - This test is now consistently failing in the Test environment
-    # due to some old registrations that have been re-indexed in the only SHARE server
-    # that all testing environments use. These old registrations that are actually in
-    # other testing environments (i.e. Stage3) are now showing in the search results
-    # in the Test environment. When the test attempts to navigate to the detail page
-    # for the registration the test fails. Since the OSF Registries Discover page will
-    # be deprecated and replaced by the new OSF Search page in a few months we are
-    # going to skip the test in all of the testing environments and only run it in
-    # Production until the test is removed/replaced around July 2023.
-    @pytest.mark.skipif(
-        not settings.PRODUCTION,
-        reason='Single SHARE server in testing environments causes test failure.',
-    )
+    @markers.core_functionality
     def test_detail_page(self, driver):
         """Test a registration detail page by grabbing the first search result from the discover page."""
         discover_page = RegistriesDiscoverPage(driver)
@@ -84,6 +72,10 @@ class TestRegistriesDiscoverPage:
             search_text = 'affiliations:' + environment
             discover_page.search_box.send_keys_deliberately(search_text)
             discover_page.search_box.send_keys(Keys.ENTER)
+            # Update 3/10/2023 - Adding sorting by date (newest to oldest) to eliminate
+            # search result issues due to re-indexing of SHARE.
+            discover_page.sort_by_button.click()
+            discover_page.sort_by_date_newest.click()
         discover_page.loading_indicator.here_then_gone()
         search_results = discover_page.search_results
         assert search_results

--- a/tests/test_registries.py
+++ b/tests/test_registries.py
@@ -53,7 +53,19 @@ class TestRegistriesDiscoverPage:
         assert len(discover_page.search_results) > 0
 
     @markers.smoke_test
-    @markers.core_functionality
+    # NOTE: 03/10/2023 - This test is now consistently failing in the Test environment
+    # due to some old registrations that have been re-indexed in the only SHARE server
+    # that all testing environments use. These old registrations that are actually in
+    # other testing environments (i.e. Stage3) are now showing in the search results
+    # in the Test environment. When the test attempts to navigate to the detail page
+    # for the registration the test fails. Since the OSF Registries Discover page will
+    # be deprecated and replaced by the new OSF Search page in a few months we are
+    # going to skip the test in all of the testing environments and only run it in
+    # Production until the test is removed/replaced around July 2023.
+    @pytest.mark.skipif(
+        not settings.PRODUCTION,
+        reason='Single SHARE server in testing environments causes test failure.',
+    )
     def test_detail_page(self, driver):
         """Test a registration detail page by grabbing the first search result from the discover page."""
         discover_page = RegistriesDiscoverPage(driver)


### PR DESCRIPTION
<!-- Before you submit your Pull Request, please confirm that:

     - Any test that will create public data either has the `QAtest` tag or the `dont_run_on_production` marker
     - `core_functionality` is marked as such
     - Your tests will be able to run on *all* servers (all stagings, test)
 -->


## Purpose
To fix test failure with test: "tests/test_registries.py::TestRegistriesDiscoverPage::test_detail_page" in the testing environments since it is now failing due to old data that was re-indexed in the single staging SHARE server.  


## Summary of Changes

- pages/registries.py - adding elements: sort_by_button and sort_by_date_newest to Registries Discover page
- tests/test_registries.py - adding steps to sort the search results by date (newest to oldest) when running in the testing environments


## Reviewer's Actions
`git fetch <remote> pull/233/head:testFix/registries-search`

Run this test using
`tests/test_registries.py::TestRegistriesDiscoverPage::test_detail_page -s -v`

## Testing Changes Moving Forward
NA


## Ticket
ENG-4425: SEL: Registries Test - Test Failure in Nightly Core Functionality Test Run - tests/test_registries.py::TestRegistriesDiscoverPage::test_detail_page
https://openscience.atlassian.net/browse/ENG-4425
