### PR TITLE
[ENG-4391] - Add Project Tests for Components

### DIFF
--- a/api/osf_api.py
+++ b/api/osf_api.py
@@ -39,6 +39,22 @@ def create_project(session, title='osf selenium test', tags=None, **kwargs):
     return node
 
 
+def create_child_node(
+    session,
+    node=None,
+    node_id=None,
+    title='osf selenium child node',
+    tags=None,
+    **kwargs
+):
+    """Create a child node (a.k.a. component) of a given project node."""
+    if tags is None:
+        tags = ['qatest', os.environ['PYTEST_CURRENT_TEST']]
+    if not node:
+        node = get_node(session, node_id=node_id)
+    return node.create_child(title=title, tags=tags, **kwargs)
+
+
 def current_user(session=None):
     if not session:
         session = get_default_session()

--- a/components/project.py
+++ b/components/project.py
@@ -28,6 +28,21 @@ class LogWidget(BaseElement):
     log_items = GroupLocator(By.CSS_SELECTOR, '#logFeed .db-activity-item')
 
 
+class ConfirmPrivacyChangeModal(BaseElement):
+    cancel_link = Locator(By.LINK_TEXT, 'Cancel')
+    confirm_link = Locator(By.LINK_TEXT, 'Confirm')
+    continue_link = Locator(By.LINK_TEXT, 'Continue')
+
+
+class ComponentsPrivacyChangeModal(BaseElement):
+    first_component_checkbox = Locator(
+        By.CSS_SELECTOR,
+        '#tb-tbody > div > div > div.tb-row.tb-odd > div.tb-td.tb-col-0 > input[type=checkbox]',
+    )
+    cancel_link = Locator(By.LINK_TEXT, 'Cancel')
+    continue_link = Locator(By.LINK_TEXT, 'Continue')
+
+
 class CreateComponentModal(BaseElement):
     title_input = Locator(By.NAME, 'projectName')
     more_link = Locator(

--- a/components/project.py
+++ b/components/project.py
@@ -28,6 +28,25 @@ class LogWidget(BaseElement):
     log_items = GroupLocator(By.CSS_SELECTOR, '#logFeed .db-activity-item')
 
 
+class CreateComponentModal(BaseElement):
+    title_input = Locator(By.NAME, 'projectName')
+    more_link = Locator(
+        By.CSS_SELECTOR, 'div.modal-body > div > div.text-muted.pointer'
+    )
+    description_input = Locator(By.NAME, 'projectDesc')
+    cancel_button = Locator(
+        By.CSS_SELECTOR, 'div.modal-footer > button.btn.btn-default'
+    )
+    create_component_button = Locator(
+        By.CSS_SELECTOR, 'div.modal-footer > button.btn.btn-success'
+    )
+
+
+class ComponentCreatedModal(BaseElement):
+    keep_working_here_button = Locator(By.CSS_SELECTOR, 'button[data-dismiss="modal"]')
+    go_to_new_component_link = Locator(By.LINK_TEXT, 'Go to new component')
+
+
 class CreateRegistrationModal(BaseElement):
     modal_window = Locator(By.CSS_SELECTOR, '[data-test-new-registration-modal]')
     cancel_button = Locator(

--- a/components/project.py
+++ b/components/project.py
@@ -47,6 +47,23 @@ class ComponentCreatedModal(BaseElement):
     go_to_new_component_link = Locator(By.LINK_TEXT, 'Go to new component')
 
 
+class DeleteComponentModal(BaseElement):
+    confirmation_text = Locator(
+        By.CSS_SELECTOR,
+        'div.modal-body > div:nth-child(3) > div:nth-child(1) > p:nth-child(2) > strong',
+    )
+    confirmation_input = Locator(
+        By.CSS_SELECTOR, 'div.modal-body > div:nth-child(3) > div.form-control'
+    )
+    cancel_link = Locator(
+        By.CSS_SELECTOR, '#nodesDelete > div > div > div > div.modal-footer > a'
+    )
+    delete_link = Locator(
+        By.CSS_SELECTOR,
+        '#nodesDelete > div > div > div > div.modal-footer > span:nth-child(3) > a',
+    )
+
+
 class CreateRegistrationModal(BaseElement):
     modal_window = Locator(By.CSS_SELECTOR, '[data-test-new-registration-modal]')
     cancel_button = Locator(

--- a/pages/project.py
+++ b/pages/project.py
@@ -15,8 +15,10 @@ from components.dashboard import (
 )
 from components.project import (
     ComponentCreatedModal,
+    ComponentsPrivacyChangeModal,
     ConfirmDeleteDraftRegistrationModal,
     ConfirmFileDeleteModal,
+    ConfirmPrivacyChangeModal,
     CreateComponentModal,
     CreateRegistrationModal,
     DeleteComponentModal,
@@ -43,8 +45,6 @@ class ProjectPage(GuidBasePage):
     description = Locator(By.ID, 'nodeDescriptionEditable')
     make_public_link = Locator(By.LINK_TEXT, 'Make Public')
     make_private_link = Locator(By.LINK_TEXT, 'Make Private')
-    confirm_privacy_change_link = Locator(By.LINK_TEXT, 'Confirm')
-    cancel_privacy_change_link = Locator(By.LINK_TEXT, 'Cancel')
     loading_indicator = Locator(By.CSS_SELECTOR, '.ball-pulse')
     add_component_button = Locator(
         By.CSS_SELECTOR, '#newComponent > span > div.btn.btn-sm.btn-default'
@@ -71,6 +71,8 @@ class ProjectPage(GuidBasePage):
     # Components
     file_widget = ComponentLocator(FileWidget)
     log_widget = ComponentLocator(LogWidget)
+    confirm_privacy_change_modal = ComponentLocator(ConfirmPrivacyChangeModal)
+    components_privacy_change_modal = ComponentLocator(ComponentsPrivacyChangeModal)
     create_component_modal = ComponentLocator(CreateComponentModal)
     component_created_modal = ComponentLocator(ComponentCreatedModal)
     delete_component_modal = ComponentLocator(DeleteComponentModal)

--- a/pages/project.py
+++ b/pages/project.py
@@ -14,8 +14,10 @@ from components.dashboard import (
     ProjectCreatedModal,
 )
 from components.project import (
+    ComponentCreatedModal,
     ConfirmDeleteDraftRegistrationModal,
     ConfirmFileDeleteModal,
+    CreateComponentModal,
     CreateRegistrationModal,
     FileWidget,
     LogWidget,
@@ -35,11 +37,16 @@ class ProjectPage(GuidBasePage):
     title_input = Locator(By.CSS_SELECTOR, '.form-inline input')
     title_edit_submit_button = Locator(By.CSS_SELECTOR, '.editable-submit')
     title_edit_cancel_button = Locator(By.CSS_SELECTOR, '.editable-cancel')
-    make_public_link = Locator(By.XPATH, '//a[contains(text(), "Make Public")]')
-    make_private_link = Locator(By.XPATH, '//a[contains(text(), "Make Private")]')
-    confirm_privacy_change_link = Locator(By.XPATH, '//a[text()="Confirm"]')
-    cancel_privacy_change_link = Locator(By.XPATH, '//a[text()="Cancel"]')
+    parent_project_link = Locator(By.CSS_SELECTOR, 'h2.node-parent-title > a')
+    description = Locator(By.ID, 'nodeDescriptionEditable')
+    make_public_link = Locator(By.LINK_TEXT, 'Make Public')
+    make_private_link = Locator(By.LINK_TEXT, 'Make Private')
+    confirm_privacy_change_link = Locator(By.LINK_TEXT, 'Confirm')
+    cancel_privacy_change_link = Locator(By.LINK_TEXT, 'Cancel')
     loading_indicator = Locator(By.CSS_SELECTOR, '.ball-pulse')
+    add_component_button = Locator(
+        By.CSS_SELECTOR, '#newComponent > span > div.btn.btn-sm.btn-default'
+    )
     collections_container = Locator(
         By.CSS_SELECTOR, '#projectBanner > div.row > div.collections-container.col-12'
     )
@@ -57,9 +64,20 @@ class ProjectPage(GuidBasePage):
         By.CSS_SELECTOR, 'a.fa.fa-close.collections-cancel-icon'
     )
 
+    components = GroupLocator(By.ID, 'render-node')
+
     # Components
     file_widget = ComponentLocator(FileWidget)
     log_widget = ComponentLocator(LogWidget)
+    create_component_modal = ComponentLocator(CreateComponentModal)
+    component_created_modal = ComponentLocator(ComponentCreatedModal)
+
+    def get_component_by_node_id(self, node_id):
+        for component in self.components:
+            if node_id == component.find_element_by_css_selector('div').get_attribute(
+                'node_id'
+            ):
+                return component
 
 
 class RequestAccessPage(GuidBasePage):

--- a/pages/project.py
+++ b/pages/project.py
@@ -19,6 +19,7 @@ from components.project import (
     ConfirmFileDeleteModal,
     CreateComponentModal,
     CreateRegistrationModal,
+    DeleteComponentModal,
     FileWidget,
     LogWidget,
     MoveCopyFileModal,
@@ -37,6 +38,7 @@ class ProjectPage(GuidBasePage):
     title_input = Locator(By.CSS_SELECTOR, '.form-inline input')
     title_edit_submit_button = Locator(By.CSS_SELECTOR, '.editable-submit')
     title_edit_cancel_button = Locator(By.CSS_SELECTOR, '.editable-cancel')
+    alert_message = Locator(By.CSS_SELECTOR, '#alert-container > p')
     parent_project_link = Locator(By.CSS_SELECTOR, 'h2.node-parent-title > a')
     description = Locator(By.ID, 'nodeDescriptionEditable')
     make_public_link = Locator(By.LINK_TEXT, 'Make Public')
@@ -71,6 +73,7 @@ class ProjectPage(GuidBasePage):
     log_widget = ComponentLocator(LogWidget)
     create_component_modal = ComponentLocator(CreateComponentModal)
     component_created_modal = ComponentLocator(ComponentCreatedModal)
+    delete_component_modal = ComponentLocator(DeleteComponentModal)
 
     def get_component_by_node_id(self, node_id):
         for component in self.components:

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -1,3 +1,5 @@
+import re
+
 import pytest
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support import expected_conditions as EC
@@ -150,6 +152,82 @@ class TestForksPage:
         # Clean-up leftover fork
         fork_guid = forks_page.fork_link.get_attribute('data-test-node-title')
         osf_api.delete_project(session, fork_guid, None)
+
+
+@markers.dont_run_on_prod
+@pytest.mark.usefixtures('must_be_logged_in')
+class TestProjectComponents:
+    def test_add_component(self, driver, session, project_page):
+        """Test the functionality of adding a new child component node to a project"""
+
+        # Click Add Component button and on the Create Component Modal, first click the
+        # Cancel button and verify that there are no components listed on the Project
+        # Overview page.
+        project_page.loading_indicator.here_then_gone()
+        project_page.add_component_button.click()
+        project_page.create_component_modal.cancel_button.click()
+        WebDriverWait(driver, 3).until(
+            EC.invisibility_of_element_located(
+                (By.CSS_SELECTOR, 'div.modal-backdrop.fade')
+            )
+        )
+        assert len(project_page.components) == 0
+
+        # Click the Add Component button again and this time enter data on the modal to
+        # add a new component
+        project_page.add_component_button.click()
+        project_page.create_component_modal.title_input.click()
+        project_page.create_component_modal.title_input.send_keys_deliberately(
+            'Selenium Component'
+        )
+        project_page.create_component_modal.more_link.click()
+        project_page.create_component_modal.description_input.click()
+        project_page.create_component_modal.description_input.send_keys_deliberately(
+            'This component was added by an automated selenium test.'
+        )
+        project_page.scroll_into_view(
+            project_page.create_component_modal.create_component_button.element
+        )
+        project_page.create_component_modal.create_component_button.click()
+
+        # Get the guid for the component from the Go to new component link on the
+        # Component Created Confirmation modal
+        match = re.search(
+            r'([a-z0-9]{4,8})\.osf\.io/([a-z0-9]{5})',
+            project_page.component_created_modal.go_to_new_component_link.get_attribute(
+                'href'
+            ),
+        )
+        component_guid = match.group(2)
+
+        try:
+            # Click the Go to new component link and verify that you are navigated to
+            # the Overview page of a new node
+            project_page.component_created_modal.go_to_new_component_link.click()
+            component_page = ProjectPage(driver, verify=True)
+            assert component_page.title.text == 'Selenium Component'
+            assert (
+                component_page.description.text
+                == 'This component was added by an automated selenium test.'
+            )
+
+            # Click the link to the parent project at the top of the page to navigate
+            # back to the original parent Project Overview page.
+            component_page.parent_project_link.click()
+            assert project_page
+
+            # Verify that the Components section of the parent Project now lists the
+            # new component
+            assert len(project_page.components) == 1
+            component = project_page.get_component_by_node_id(component_guid)
+            assert (
+                component.find_element_by_css_selector('div > h4 > span > a').text
+                == 'Selenium Component'
+            )
+        finally:
+            # The parent project should be automatically deleted by the fixture code.
+            # But it cannot be deleted if the component is not deleted first.
+            osf_api.delete_project(session, component_guid, None)
 
 
 class TestAnalyticsPage:

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -72,11 +72,22 @@ class TestProjectDetailPage:
             )
         )
         project_page.make_public_link.click()
+
+        # First click the Cancel link on the Confirm Modal and verify that the project
+        # is still private.
+        project_page.confirm_privacy_change_modal.cancel_link.click()
+        assert project_page.make_private_link.absent()
+
+        # Click the Make Public link again and this time click the Confirm link on the
+        # modal to actually make the project public.
+        project_page.make_public_link.click()
         project_page.confirm_privacy_change_modal.confirm_link.click()
         assert project_page.make_private_link.present()
+
         # Confirm logged out user can now see project
         logout(driver)
         project_page.goto()
+        assert ProjectPage(driver, verify=True)
         login(driver)
 
     @markers.smoke_test


### PR DESCRIPTION
<!-- Before you submit your Pull Request, please confirm that:

     - Any test that will create public data either has the `QAtest` tag or the `dont_run_on_production` marker
     - `core_functionality` is marked as such
     - Your tests will be able to run on *all* servers (all stagings, test)
 -->


## Purpose
To expand selenium tests to include Project Components (a.k.a. child nodes) which are currently not being covered and represent a hole in our test coverage.


## Summary of Changes

- api/osf_api.py - add new function: create_child_node to create a component of a project
- components/project.py - add 5 new modals: ConfirmPrivacyChangeModal, ComponentsPrivacyChangeModal, CreateComponentModal, ComponentCreatedModal, and DeleteComponentModal
- pages/project.py - add new elements to the ProjectPage class
- tests/test_project.py - add new test class: TestProjectComponents with 3 new tests: test_add_component, test_delete_component_from_project, and test_make_public_project_with_component


## Reviewer's Actions
`git fetch <remote> pull/234/head:testFix/project-components`

Run this test using
`tests/test_project.py::TestProjectComponents -s -v`

## Testing Changes Moving Forward
N/A


## Ticket
ENG-4391: SEL: Project Test - Add Tests for Components
https://openscience.atlassian.net/browse/ENG-4391
