### PR TITLE
[ENG-4390] - Add Sort Order Check for Second Level Subjects on Draft Registration Metadata page

### DIFF
--- a/pages/registries.py
+++ b/pages/registries.py
@@ -287,6 +287,10 @@ class DraftRegistrationMetadataPage(BaseRegistrationDraftPage):
         'div[data-test-select-license] > div.ember-basic-dropdown-trigger.ember-power-select-trigger',
     )
     first_selected_subject = Locator(By.CSS_SELECTOR, 'li[data-test-selected-subject]')
+    expand_first_subject_button = Locator(
+        By.CSS_SELECTOR, 'label[data-test-subject-browse-label] > button'
+    )
+
     tags_input_box = Locator(By.CSS_SELECTOR, 'li.emberTagInput-new > input')
     next_page_button = Locator(By.CSS_SELECTOR, 'a[data-test-goto-next-page] > button')
 
@@ -299,6 +303,12 @@ class DraftRegistrationMetadataPage(BaseRegistrationDraftPage):
 
     top_level_subjects = GroupLocator(
         By.CSS_SELECTOR, 'div[data-analytics-scope="Browse"] > ul > li'
+    )
+    # The following is for the list of second level subjects for the first top level
+    # subject. NOTE: The first top level subject must be expanded (click the downward
+    # caret to the right of the subject name) before this list is populated on the page.
+    first_subject_second_level_subjects = GroupLocator(
+        By.CSS_SELECTOR, 'div[data-analytics-scope="Browse"] > ul > li > div > ul > li'
     )
 
     def select_from_dropdown_listbox(self, selection):

--- a/tests/test_registries.py
+++ b/tests/test_registries.py
@@ -158,6 +158,20 @@ class TestDraftRegistration:
         # the subject list as displayed on the page is correctly sorted alphabetically.
         assert sorted_subjects == subject_list
 
+        # Expand the first top level subject to show the list of secondary subjects
+        metadata_page.expand_first_subject_button.click()
+        metadata_page.loading_indicator.here_then_gone()
+
+        # Create a list of the expanded second level subject names and a sorted copy
+        # of the list and verify that the second level subject list is also sorted
+        # correctly.
+        sec_subject_list = [
+            subject.text
+            for subject in metadata_page.first_subject_second_level_subjects
+        ]
+        sec_sorted_subjects = sorted(sec_subject_list.copy())
+        assert sec_sorted_subjects == sec_subject_list
+
 
 @pytest.fixture(scope='class')
 def login_as_user_with_registrations(driver):


### PR DESCRIPTION
<!-- Before you submit your Pull Request, please confirm that:

     - Any test that will create public data either has the `QAtest` tag or the `dont_run_on_production` marker
     - `core_functionality` is marked as such
     - Your tests will be able to run on *all* servers (all stagings, test)
 -->


## Purpose
To update a previously added test: "tests/test_registries.py::TestDraftRegistration::test_subjects_sort_order" to also check the second level Subjects sort order since it was not included previously and was not sorting as expected.


## Summary of Changes

- pages/registries.py - adding a couple new elements to DraftRegistrationMetadataPage page class
- tests/test_registries.py - add steps to "test_subjects_sort_order" to expand the first top level subject to reveal its second level subject list and then verify that the second level subject list is sorted alphabetically.


## Reviewer's Actions
`git fetch <remote> pull/236/head:newTest/reg-subject-sorting`

Run this test using
`tests/test_registries.py::TestDraftRegistration::test_subjects_sort_order -s -v`

## Testing Changes Moving Forward
N/A


## Ticket
ENG-4390: SEL: Registrations Test - Update Test for Draft Registration Subject Sort Order to add Second Level Subjects
https://openscience.atlassian.net/browse/ENG-4390
