### PR TITLE
[ENG-4445] - Replacing Deprecated FirefoxProfile with Options

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -27,33 +27,32 @@ def launch_driver(driver_name=settings.DRIVER, desired_capabilities=None):
         # that are specific to Firefox.  Currently when running Chrome or Edge in
         # BrowserStack we are running with the default base install options.
 
-        # DeprecationWarning: Please use FirefoxOptions to set browser profile
-        from selenium.webdriver import FirefoxProfile
+        from selenium.webdriver.firefox.options import Options
 
-        ffp = FirefoxProfile()
+        ffo = Options()
         # Set the default download location [0=Desktop, 1=Downloads, 2=Specified location]
-        ffp.set_preference('browser.download.folderList', 1)
+        ffo.set_preference('browser.download.folderList', 1)
 
         # Disable the OS-level pop-up modal
-        ffp.set_preference('browser.download.manager.showWhenStarting', False)
-        ffp.set_preference('browser.helperApps.alwaysAsk.force', False)
-        ffp.set_preference('browser.download.manager.alertOnEXEOpen', False)
-        ffp.set_preference('browser.download.manager.closeWhenDone', True)
-        ffp.set_preference('browser.download.manager.showAlertOnComplete', False)
-        ffp.set_preference('browser.download.manager.useWindow', False)
+        ffo.set_preference('browser.download.manager.showWhenStarting', False)
+        ffo.set_preference('browser.helperApps.alwaysAsk.force', False)
+        ffo.set_preference('browser.download.manager.alertOnEXEOpen', False)
+        ffo.set_preference('browser.download.manager.closeWhenDone', True)
+        ffo.set_preference('browser.download.manager.showAlertOnComplete', False)
+        ffo.set_preference('browser.download.manager.useWindow', False)
         # Specify the file types supported by the download
-        ffp.set_preference(
+        ffo.set_preference(
             'browser.helperApps.neverAsk.saveToDisk',
             'text/plain, application/octet-stream, application/binary, text/csv, application/csv, '
             'application/excel, text/comma-separated-values, text/xml, application/xml, binary/octet-stream',
         )
         # Block Third Party Tracking Cookies (Default in Firefox is now 5 which blocks
         # all Cross-site cookies)
-        ffp.set_preference('network.cookie.cookieBehavior', 4)
+        ffo.set_preference('network.cookie.cookieBehavior', 4)
         driver = driver_cls(
             command_executor=command_executor,
             desired_capabilities=desired_capabilities,
-            browser_profile=ffp,
+            options=ffo,
         )
     elif driver_name == 'Chrome' and settings.HEADLESS:
         from selenium.webdriver.chrome.options import Options
@@ -62,7 +61,7 @@ def launch_driver(driver_name=settings.DRIVER, desired_capabilities=None):
         chrome_options.add_argument('--headless')
         chrome_options.add_argument('--disable-gpu')
         chrome_options.add_argument('window-size=1200x600')
-        driver = driver_cls(chrome_options=chrome_options)
+        driver = driver_cls(options=chrome_options)
     elif driver_name == 'Chrome' and not settings.HEADLESS:
         from selenium.webdriver.chrome.options import Options
 
@@ -71,30 +70,26 @@ def launch_driver(driver_name=settings.DRIVER, desired_capabilities=None):
         chrome_options.add_experimental_option('w3c', False)
         preferences = {'download.default_directory': ''}
         chrome_options.add_experimental_option('prefs', preferences)
-        driver = driver_cls(chrome_options=chrome_options)
+        driver = driver_cls(options=chrome_options)
     elif driver_name == 'Firefox' and not settings.HEADLESS:
-        from selenium.webdriver import FirefoxProfile
         from selenium.webdriver.firefox.options import Options
 
-        ffp = FirefoxProfile()
+        ffo = Options()
         # Set the default download location [0=Desktop, 1=Downloads, 2=Specified location]
-        ffp.set_preference('browser.download.folderList', 1)
-        ffp.set_preference('browser.download.manager.showWhenStarting', False)
-        ffp.set_preference('browser.helperApps.alwaysAsk.force', False)
-        ffp.set_preference(
+        ffo.set_preference('browser.download.folderList', 1)
+        ffo.set_preference('browser.download.manager.showWhenStarting', False)
+        ffo.set_preference('browser.helperApps.alwaysAsk.force', False)
+        ffo.set_preference(
             'browser.helperApps.neverAsk.saveToDisk',
             'text/plain, application/octet-stream, application/binary, text/csv, application/csv, '
             'application/excel, text/comma-separated-values, text/xml, application/xml, binary/octet-stream',
         )
         # Block Third Party Tracking Cookies (Default in Firefox is now 5 which blocks
         # all Cross-site cookies)
-        ffp.set_preference('network.cookie.cookieBehavior', 4)
-        # Force Firefox to open links in new tab instead of new browser window. Have to
-        # use Options instead of Firefox Profile because the profile preference doesn't
-        # work.
-        ffo = Options()
+        ffo.set_preference('network.cookie.cookieBehavior', 4)
+        # Force Firefox to open links in new tab instead of new browser window.
         ffo.set_preference('browser.link.open_newwindow', 3)
-        driver = driver_cls(firefox_profile=ffp, options=ffo)
+        driver = driver_cls(options=ffo)
     elif driver_name == 'Edge' and not settings.HEADLESS:
         from msedge.selenium_tools import Edge
 


### PR DESCRIPTION
<!-- Before you submit your Pull Request, please confirm that:

     - Any test that will create public data either has the `QAtest` tag or the `dont_run_on_production` marker
     - `core_functionality` is marked as such
     - Your tests will be able to run on *all* servers (all stagings, test)
 -->


## Purpose
To eliminate a deprecation warning message by replacing FirefoxProfile with Options when setting up to open the Firefox browser.


## Summary of Changes

- utils.py - replace FirefoxProfile with Options when running locally and via BrowserStack


## Reviewer's Actions
`git fetch <remote> pull/237/head:testFix/deprecated-firefox-profile`

Run this test using
You can run any random tests and make sure that with each browser and environment that you no longer see the deprecation error: "DeprecationWarning: Please use FirefoxOptions to set browser profile" at the end of the test run. Run locally and through BrowserStack.

## Testing Changes Moving Forward
N/A


## Ticket
ENG-4445: SEL: Deprecation Warning Messages in All Test runs - DeprecationWarning: Please use FirefoxOptions to set browser profile
https://openscience.atlassian.net/browse/ENG-4445
