### PR TITLE
[ENG-4282] - Add New Test for Sidebar Navigation of Registration Pages

### DIFF
--- a/api/osf_api.py
+++ b/api/osf_api.py
@@ -496,6 +496,23 @@ def get_preprint_downloads_count(session=None, node_id=None):
         return None
 
 
+def get_most_recent_registration_node_id(session=None):
+    """Return the most recently approved public registration node id"""
+    if not session:
+        session = get_default_session()
+    url = '/v2/registrations/'
+    data = session.get(url)['data']
+    if data:
+        for registration in data:
+            if (
+                registration['attributes']['public']
+                and (registration['attributes']['revision_state'] == 'approved')
+                and not registration['attributes']['withdrawn']
+            ):
+                return registration['id']
+    return None
+
+
 def get_registration_schemas_for_provider(session=None, provider_id='osf'):
     """Returns a list of allowed registration schemas for an individual provider.  The
     list will be a paired list of schema names and ids.  The The default provider_id is

--- a/api/osf_api.py
+++ b/api/osf_api.py
@@ -497,7 +497,12 @@ def get_preprint_downloads_count(session=None, node_id=None):
 
 
 def get_most_recent_registration_node_id(session=None):
-    """Return the most recently approved public registration node id"""
+    """Return the most recently approved public registration node id. The
+    /v2/registrations endpoint currently returns the most recently modified
+    registration sorted first. But we still need to check for a public and
+    approved registration that has not been withdrawn in order to get a
+    registration that is fully accessible.
+    """
     if not session:
         session = get_default_session()
     url = '/v2/registrations/'

--- a/components/registration.py
+++ b/components/registration.py
@@ -1,0 +1,20 @@
+from selenium.webdriver.common.by import By
+
+from base.locators import (
+    BaseElement,
+    Locator,
+)
+
+
+class SubmittedSideNavbar(BaseElement):
+    """This is the side navigation bar for a submitted registration"""
+
+    overview_link = Locator(By.CSS_SELECTOR, 'a[data-analytics-name="Overview"]')
+    metadata_link = Locator(By.CSS_SELECTOR, 'a[data-analytics-name="Metadata"]')
+    files_link = Locator(By.CSS_SELECTOR, 'a[data-analytics-name="Files"]')
+    resources_link = Locator(By.CSS_SELECTOR, 'a[data-analytics-name="Resources"]')
+    wiki_link = Locator(By.CSS_SELECTOR, 'a[data-analytics-name="Wiki"]')
+    components_link = Locator(By.CSS_SELECTOR, 'a[data-analytics-name="Components"]')
+    links_link = Locator(By.CSS_SELECTOR, 'a[data-analytics-name="Links"]')
+    analytics_link = Locator(By.CSS_SELECTOR, 'a[data-analytics-name="Analytics"]')
+    comments_link = Locator(By.CSS_SELECTOR, 'a[data-analytics-name="Comments"]')

--- a/pages/registries.py
+++ b/pages/registries.py
@@ -10,6 +10,7 @@ from base.locators import (
     Locator,
 )
 from components.navbars import RegistriesNavbar
+from components.registration import SubmittedSideNavbar
 from pages.base import (
     GuidBasePage,
     OSFBasePage,
@@ -78,6 +79,7 @@ class RegistriesDiscoverPage(BaseRegistriesPage):
 class BaseSubmittedRegistrationPage(GuidBasePage):
     base_url = settings.OSF_HOME
     url_addition = ''
+    side_navbar = ComponentLocator(SubmittedSideNavbar)
 
     def __init__(self, driver, verify=False, guid=''):
         # Set the cookie that prevents the New Feature popover from appearing on
@@ -96,7 +98,7 @@ class RegistrationDetailPage(BaseSubmittedRegistrationPage):
     """This is the Registration Overview Page"""
 
     identity = Locator(
-        By.CSS_SELECTOR, '[data-test-registration-title]', settings.LONG_TIMEOUT
+        By.CSS_SELECTOR, '[data-test-page-heading]', settings.LONG_TIMEOUT
     )
 
     narrative_summary = Locator(By.CSS_SELECTOR, '[data-test-read-only-response]')
@@ -113,6 +115,11 @@ class RegistrationDetailPage(BaseSubmittedRegistrationPage):
     associated_project_link = Locator(
         By.CSS_SELECTOR, 'a[data-analytics-name="Registered from"]'
     )
+
+
+class RegistrationMetadataPage(BaseSubmittedRegistrationPage):
+    url_addition = 'metadata'
+    identity = Locator(By.CSS_SELECTOR, '[data-test-display-resource-type-general]')
 
 
 class RegistrationFilesListPage(BaseSubmittedRegistrationPage):
@@ -162,6 +169,36 @@ class RegistrationFileDetailPage(GuidBasePage):
             if tag.text == tag_value:
                 return tag
         return None
+
+
+class RegistrationResourcesPage(BaseSubmittedRegistrationPage):
+    url_addition = 'resources'
+    identity = Locator(By.CSS_SELECTOR, '[data-test-add-resource-section]')
+
+
+class RegistrationWikiPage(BaseSubmittedRegistrationPage):
+    url_addition = 'wiki'
+    identity = Locator(By.ID, 'wikiName')
+
+
+class RegistrationComponentsPage(BaseSubmittedRegistrationPage):
+    url_addition = 'components'
+    identity = Locator(By.XPATH, '//h3[text()="Components"]')
+
+
+class RegistrationLinksPage(BaseSubmittedRegistrationPage):
+    url_addition = 'links'
+    identity = Locator(By.XPATH, '//h3[text()="Linked projects and components"]')
+
+
+class RegistrationAnalyticsPage(BaseSubmittedRegistrationPage):
+    url_addition = 'analytics'
+    identity = Locator(By.CSS_SELECTOR, '._Counts_1mhar6')
+
+
+class RegistrationCommentsPage(BaseSubmittedRegistrationPage):
+    url_addition = 'comments'
+    identity = Locator(By.CSS_SELECTOR, '._CommentsList_kh9x27')
 
 
 class RegistrationJustificationForm(GuidBasePage):

--- a/pages/registries.py
+++ b/pages/registries.py
@@ -80,6 +80,7 @@ class BaseSubmittedRegistrationPage(GuidBasePage):
     base_url = settings.OSF_HOME
     url_addition = ''
     side_navbar = ComponentLocator(SubmittedSideNavbar)
+    title = Locator(By.CSS_SELECTOR, '[data-test-registration-title]')
 
     def __init__(self, driver, verify=False, guid=''):
         # Set the cookie that prevents the New Feature popover from appearing on

--- a/tests/test_registration_sidebar.py
+++ b/tests/test_registration_sidebar.py
@@ -1,0 +1,75 @@
+import pytest
+
+import markers
+from api import osf_api
+from pages.registries import (
+    RegistrationAnalyticsPage,
+    RegistrationCommentsPage,
+    RegistrationComponentsPage,
+    RegistrationDetailPage,
+    RegistrationFilesListPage,
+    RegistrationLinksPage,
+    RegistrationMetadataPage,
+    RegistrationResourcesPage,
+    RegistrationWikiPage,
+)
+
+
+@markers.smoke_test
+@markers.core_functionality
+class TestSubmittedRegistrationSideNavigation:
+    """Test all of the links on the side navigation bar of a submitted registration and
+    verify the correct registration page is loaded.
+    """
+
+    @pytest.fixture()
+    def registration_page(self, driver, session):
+        """Use OSF api to get the most recent submitted and approved registration and
+        navigate to its overview page.
+        """
+        registration_guid = osf_api.get_most_recent_registration_node_id(session)
+        registration_page = RegistrationDetailPage(driver, guid=registration_guid)
+        registration_page.goto()
+        return registration_page
+
+    def test_metadata_link(self, driver, registration_page):
+        registration_page.side_navbar.metadata_link.click()
+        assert RegistrationMetadataPage(driver, verify=True)
+
+    def test_files_link(self, driver, registration_page):
+        registration_page.side_navbar.files_link.click()
+        assert RegistrationFilesListPage(driver, verify=True)
+
+    def test_resources_link(self, driver, registration_page):
+        registration_page.side_navbar.resources_link.click()
+        assert RegistrationResourcesPage(driver, verify=True)
+
+    def test_wiki_link(self, driver, registration_page):
+        registration_page.side_navbar.wiki_link.click()
+        assert RegistrationWikiPage(driver, verify=True)
+
+    def test_components_link(self, driver, registration_page):
+        registration_page.side_navbar.components_link.click()
+        assert RegistrationComponentsPage(driver, verify=True)
+
+    def test_links_link(self, driver, registration_page):
+        registration_page.side_navbar.links_link.click()
+        assert RegistrationLinksPage(driver, verify=True)
+
+    def test_analytics_link(self, driver, registration_page):
+        registration_page.side_navbar.analytics_link.click()
+        assert RegistrationAnalyticsPage(driver, verify=True)
+
+    def test_comments_link(self, driver, registration_page):
+        registration_page.side_navbar.comments_link.click()
+        assert RegistrationCommentsPage(driver, verify=True)
+
+    def test_overview_link(self, driver, session):
+        """This test starts on the Registration Metadata page and then clicks the
+        Overview link to navigate to the Registration Overview page.
+        """
+        registration_guid = osf_api.get_most_recent_registration_node_id(session)
+        metadata_page = RegistrationMetadataPage(driver, guid=registration_guid)
+        metadata_page.goto()
+        metadata_page.side_navbar.overview_link.click()
+        assert RegistrationDetailPage(driver, verify=True)

--- a/tests/test_registries.py
+++ b/tests/test_registries.py
@@ -87,7 +87,7 @@ class TestRegistriesDiscoverPage:
         detail_page = RegistrationDetailPage(driver)
         detail_page.identity.present()
         assert RegistrationDetailPage(driver, verify=True)
-        assert detail_page.identity.text in target_registration_title
+        assert detail_page.title.text in target_registration_title
 
 
 @markers.smoke_test


### PR DESCRIPTION
<!-- Before you submit your Pull Request, please confirm that:

     - Any test that will create public data either has the `QAtest` tag or the `dont_run_on_production` marker
     - `core_functionality` is marked as such
     - Your tests will be able to run on *all* servers (all stagings, test)
 -->


## Purpose
To expand selenium test suite to include testing of navigation sidebar on submitted registrations


## Summary of Changes

- api/osf_api.py - add new function: get_most_recent_registration_node_id() that returns the most recently approved public registration node id in any environment
- components/registration.py - add new component for registrations with the SubmittedSideNavbar class
- pages/registries.py - updates to BaseSubmittedRegistrationPage and addition of 7 new page definition classes to cover all of the available pages of a submitted registration
- tests/test_registration_sidebar.py - add new test with test class: TestSubmittedRegistrationSideNavigation and 9 new tests to test all of the navigation links and pages for a submitted registration


## Reviewer's Actions
`git fetch <remote> pull/238/head:newTest/registration-sidebar`

Run this test using
`tests/test_registration_sidebar.py -s -v`

## Testing Changes Moving Forward
N/A


## Ticket
ENG-4282: SEL: Add New Test for Sidebar Navigation of Registration Pages
https://openscience.atlassian.net/browse/ENG-4282
