### PR TITLE
[ENG-4480] - Add 2 minute drill marker to existing tests

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -53,11 +53,14 @@
 ##   note: if you do not select a domain, the default is stage1
 ## PREFERRED_NODE: When DOMAIN=prod, don't create new projects. Instead, run all tests under
 ##   this guid. MANDATORY if DOMAIN=prod. You must ask QA team for its guid and add it here.
+## POPULAR_PAGES: list of popular pages in Production as part of Two Minute Drill test. Format of
+##.  each list item is <object_type>:<guid> EX: [project:abcde,preprint:fghij,registration:klmno]
 ## EXPECTED_PROVIDERS: Only applies when DOMAIN=prod.  A comma-separated list of storage
 ##   providers connected to the PREFERRED_NODE.
 
 # DOMAIN=stage1
 # PREFERRED_NODE=<mst3k>
+# POPULAR_PAGES=project:abcde,preprint:fghij,registration:klmno
 # EXPECTED_PROVIDERS=bitbucket,box,dataverse,dropbox,figshare,github,gitlab,googledrive,osfstorage,owncloud,onedrive,s3
 
 

--- a/.github/workflows/two_minute_drill.yml
+++ b/.github/workflows/two_minute_drill.yml
@@ -1,0 +1,105 @@
+name: Two Minute Drill
+
+on:
+  # Allows you to run this workflow manually from the Actions tab and change the
+  # browser.
+  workflow_dispatch:
+    inputs:
+      browser:
+        description: 'Browser'
+        required: true
+        default: 'chrome'
+        type: choice
+        options:
+        - chrome
+        - firefox
+        - edge
+
+env:
+  DRIVER: "Remote"
+  DOMAIN: prod
+  NEW_USER_EMAIL: ${{ secrets.NEW_USER_EMAIL }}
+  BSTACK_USER: ${{ secrets.BROWSERSTACK_USERNAME }}
+  BSTACK_KEY: ${{ secrets.BROWSERSTACK_ACCESS_KEY }}
+  CHROME_USER: ${{ secrets.CHROME_USER }}
+  CHROME_USER_TOKEN: ${{ secrets.CHROME_USER_TOKEN }}
+  EDGE_USER: ${{ secrets.EDGE_USER }}
+  EDGE_USER_TOKEN: ${{ secrets.EDGE_USER_TOKEN }}
+  FIREFOX_USER: ${{ secrets.FIREFOX_USER }}
+  FIREFOX_USER_TOKEN: ${{ secrets.FIREFOX_USER_TOKEN }}
+  USER_ONE: ${{ secrets.USER_ONE }}
+  USER_ONE_PASSWORD: ${{ secrets.USER_ONE_PASSWORD }}
+  USER_TWO: ${{ secrets.USER_TWO }}
+  USER_TWO_PASSWORD: ${{ secrets.USER_TWO_PASSWORD }}
+  DEACTIVATED_USER: ${{ secrets.DEACTIVATED_USER }}
+  DEACTIVATED_USER_PASSWORD: ${{ secrets.DEACTIVATED_USER_PASSWORD }}
+  UNCONFIRMED_USER: ${{ secrets.UNCONFIRMED_USER }}
+  UNCONFIRMED_USER_PASSWORD: ${{ secrets.UNCONFIRMED_USER_PASSWORD }}
+  CAS_2FA_USER: ${{ secrets.CAS_2FA_USER }}
+  CAS_2FA_USER_PASSWORD: ${{ secrets.CAS_2FA_USER_PASSWORD }}
+  CAS_TOS_USER: ${{ secrets.CAS_TOS_USER }}
+  CAS_TOS_USER_PASSWORD: ${{ secrets.CAS_TOS_USER_PASSWORD }}
+  DEVAPP_CLIENT_ID: ${{ secrets.DEVAPP_CLIENT_ID }}
+  DEVAPP_CLIENT_SECRET: ${{ secrets.DEVAPP_CLIENT_SECRET }}
+  IMAP_EMAIL: ${{ secrets.IMAP_EMAIL }}
+  IMAP_EMAIL_PASSWORD: ${{ secrets.IMAP_EMAIL_PASSWORD }}
+  IMAP_HOST: ${{ secrets.IMAP_HOST }}
+  REGISTRATIONS_USER: ${{ secrets.REGISTRATIONS_USER }}
+  REGISTRATIONS_USER_PASSWORD: ${{ secrets.REGISTRATIONS_USER_PASSWORD }}
+
+jobs:
+
+  build:
+    runs-on: ubuntu-20.04
+    env:
+      GHA_DISTRO: ubuntu-20.04
+    if: "!contains(github.event.head_commit.message, 'skip ci')"
+    strategy:
+      matrix:
+        python-version: [3.6]
+    steps:
+      - name: Git checkout
+        uses: actions/checkout@v3
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Cache Build Requirements
+        id: pip-cache-step
+        uses: actions/cache@v3
+        with:
+          path: ${{ env.pythonLocation }}
+          key: ${{ env.GHA_DISTRO }}-${{ env.pythonLocation }}-${{ hashFiles('requirements.txt') }}
+      - name: install dependencies
+        if: steps.pip-cache-step.outputs.cache-hit != 'true'
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          invoke requirements
+
+  two_minute_drill_tests:
+    name: Two Minute Drill Tests (${{ github.event.inputs.browser }})
+    needs: [build]
+    runs-on: ubuntu-20.04
+    env:
+      GHA_DISTRO: ubuntu-20.04
+    strategy:
+      fail-fast: false
+      max-parallel: 1  # run in series
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python 3.6
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.6
+      - name: Cache pip
+        uses: actions/cache@v3
+        with:
+          path: ${{ env.pythonLocation }}
+          key: ${{ env.GHA_DISTRO }}-${{ env.pythonLocation }}-${{ hashFiles('requirements.txt') }}
+      - name: run two minute drill tests
+        env:
+          PREFERRED_NODE: ra4bf
+          TEST_BUILD: ${{ github.event.inputs.browser }}
+        run: |
+          invoke test_two_minute_drill

--- a/.github/workflows/two_minute_drill.yml
+++ b/.github/workflows/two_minute_drill.yml
@@ -46,6 +46,8 @@ env:
   IMAP_HOST: ${{ secrets.IMAP_HOST }}
   REGISTRATIONS_USER: ${{ secrets.REGISTRATIONS_USER }}
   REGISTRATIONS_USER_PASSWORD: ${{ secrets.REGISTRATIONS_USER_PASSWORD }}
+  PREFERRED_NODE: ${{ secrets.PREFERRED_NODE }}
+  POPULAR_PAGES: ${{ secrets.POPULAR_PAGES }}
 
 jobs:
 
@@ -99,7 +101,6 @@ jobs:
           key: ${{ env.GHA_DISTRO }}-${{ env.pythonLocation }}-${{ hashFiles('requirements.txt') }}
       - name: run two minute drill tests
         env:
-          PREFERRED_NODE: ra4bf
           TEST_BUILD: ${{ github.event.inputs.browser }}
         run: |
           invoke test_two_minute_drill

--- a/markers.py
+++ b/markers.py
@@ -3,6 +3,7 @@ import pytest
 import settings
 
 
+two_minute_drill = pytest.mark.two_minute_drill
 smoke_test = pytest.mark.smoke_test
 core_functionality = pytest.mark.core_functionality
 dont_run_on_prod = pytest.mark.skipif(

--- a/settings.py
+++ b/settings.py
@@ -71,6 +71,9 @@ PREFERRED_NODE = env('PREFERRED_NODE', None)
 if DOMAIN == 'prod':
     PREFERRED_NODE = env('PREFERRED_NODE')
 
+# List of popular pages in Production to test as part of the 2 Minute Drill
+POPULAR_PAGES = env.list('POPULAR_PAGES')
+
 EXPECTED_PROVIDERS = env.list(
     'EXPECTED_PROVIDERS',
     [

--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -83,6 +83,17 @@ def test_selenium_on_prod(ctx):
 
 
 @task
+def test_two_minute_drill(ctx):
+    """Run Two Minute Drill Tests on the browser defined by TEST_BUILD."""
+    test_selenium_with_retries(
+        ctx,
+        'Two Minute Drill',
+        _get_test_file_list(),
+        module=['-m', 'two_minute_drill'],
+    )
+
+
+@task
 def test_core_functionality_part_one(ctx):
     """Run first group of Core Functionality tests on the browser defined by TEST_BUILD."""
     all_test_files = _get_test_file_list()

--- a/test_data/popular_pages.txt
+++ b/test_data/popular_pages.txt
@@ -1,0 +1,2 @@
+project:ef53g
+project:su57f

--- a/test_data/popular_pages.txt
+++ b/test_data/popular_pages.txt
@@ -1,2 +1,0 @@
-project:ef53g
-project:su57f

--- a/tests/test_collections.py
+++ b/tests/test_collections.py
@@ -23,6 +23,7 @@ from pages.login import (
 from pages.project import ProjectPage
 
 
+@markers.two_minute_drill
 @markers.smoke_test
 @markers.core_functionality
 class TestCollectionDiscoverPages:

--- a/tests/test_popular_pages.py
+++ b/tests/test_popular_pages.py
@@ -1,0 +1,63 @@
+import pytest
+
+import markers
+import settings
+from base.exceptions import PageException
+from pages.preprints import PreprintDetailPage
+from pages.project import ProjectPage
+from pages.registries import RegistrationDetailPage
+
+
+@pytest.mark.skipif(
+    not settings.PRODUCTION,
+    reason='This test is only for the Two Minute Drill in Production',
+)
+@markers.two_minute_drill
+class TestPopularPages:
+    def test_popular_pages_load(self, driver):
+        """Test that ensures certain popular pages in OSF Production load correctly.
+        The list of pages are contained in an external text file to make it easier to
+        maintain.  Only one page should be entered on each line in the file and each
+        line should begin with the OSF object type (project, preprint, or registration)
+        followed by a : and then the guid of the object. EX: 'project:ef53g'. The test
+        will process every line in the file and attempt to load every page before any
+        error is thrown.  After the entire file has been read, if there were any errors
+        the test will fail and display a list of all of the pages that failed to load.
+        """
+        file = open('test_data/popular_pages.txt')
+
+        failed_list = []
+        for line in file.readlines():
+            segments = line.split(':')
+            page_type = segments[0]
+            guid = segments[1]
+            if page_type == 'project':
+                try:
+                    project_page = ProjectPage(driver, guid=guid)
+                    project_page.goto()
+                    assert ProjectPage(driver, verify=True)
+                except PageException:
+                    failed_list.append(line)
+            elif page_type == 'preprint':
+                try:
+                    preprint_page = PreprintDetailPage(driver, guid=guid)
+                    preprint_page.goto()
+                    assert PreprintDetailPage(driver, verify=True)
+                except PageException:
+                    failed_list.append(line)
+            elif page_type == 'registration':
+                try:
+                    registration_page = RegistrationDetailPage(driver, guid=guid)
+                    registration_page.goto()
+                    assert RegistrationDetailPage(driver, verify=True)
+                except PageException:
+                    failed_list.append(line)
+            else:
+                # Not one of the valid object types so add to the error list
+                failed_list.append('Not a valid object type - ' + line)
+
+        # If there were any page load failures then fail the test and print the lines
+        # that failed
+        assert len(failed_list) == 0, 'The following Pages Failed: ' + str(failed_list)
+
+        file.close()

--- a/tests/test_preprints.py
+++ b/tests/test_preprints.py
@@ -1030,6 +1030,7 @@ class TestPreprintModeration:
 
 @markers.core_functionality
 class TestPreprintSearch:
+    @markers.two_minute_drill
     @markers.smoke_test
     def test_search_results_exist(self, driver, landing_page):
         landing_page.search_button.click()

--- a/tests/test_registries.py
+++ b/tests/test_registries.py
@@ -43,6 +43,7 @@ def landing_page(driver):
 
 
 class TestRegistriesDiscoverPage:
+    @markers.two_minute_drill
     @markers.smoke_test
     @markers.core_functionality
     def test_search_results_exist(self, driver, landing_page):


### PR DESCRIPTION
<!-- Before you submit your Pull Request, please confirm that:

     - Any test that will create public data either has the `QAtest` tag or the `dont_run_on_production` marker
     - `core_functionality` is marked as such
     - Your tests will be able to run on *all* servers (all stagings, test)
 -->


## Purpose
Basic sanity check immediately following release to ascertain that released software is functioning on prod as expected and BASIC OSF functionality is unaffected.

## Summary of Changes
- Add `two_minute_drill` marker to existing tests
- Create new test to check for popular pages
- Setup new "2 minute drill" workflow in Github actions

## Reviewer's Actions
`git fetch <remote> pull/239/head:feature/new_marker`

Run this test using
Use the new marker and run against production
`pytest tests/ -m two_minute_drill  -sv`

## Testing Changes Moving Forward
N/A


## Ticket
https://openscience.atlassian.net/browse/ENG-4480
