### PR TITLE
[ENG-4513] - Update Registration Components and Links Page identities with data-test attributes

### DIFF
--- a/pages/registries.py
+++ b/pages/registries.py
@@ -184,12 +184,12 @@ class RegistrationWikiPage(BaseSubmittedRegistrationPage):
 
 class RegistrationComponentsPage(BaseSubmittedRegistrationPage):
     url_addition = 'components'
-    identity = Locator(By.XPATH, '//h3[text()="Components"]')
+    identity = Locator(By.CSS_SELECTOR, '[data-test-components-page-heading]')
 
 
 class RegistrationLinksPage(BaseSubmittedRegistrationPage):
     url_addition = 'links'
-    identity = Locator(By.XPATH, '//h3[text()="Linked projects and components"]')
+    identity = Locator(By.CSS_SELECTOR, '[data-test-links-page-heading]')
 
 
 class RegistrationAnalyticsPage(BaseSubmittedRegistrationPage):


### PR DESCRIPTION
<!-- Before you submit your Pull Request, please confirm that:

     - Any test that will create public data either has the `QAtest` tag or the `dont_run_on_production` marker
     - `core_functionality` is marked as such
     - Your tests will be able to run on *all* servers (all stagings, test)
 -->


## Purpose
To update the page identity locators for the Registration Components and Links pages to use newly added data-test attributes and get rid of the XPATH locator.


## Summary of Changes

- pages/registries.py - update the identity locators for RegistrationComponentsPage and RegistrationLinksPage


## Reviewer's Actions
`git fetch <remote> pull/241/head:newTest/registration-sidebar`

Run this test using
`tests/test_registration_sidebar.py -s -v`

## Testing Changes Moving Forward
N/A


## Ticket
ENG-4513: SEL: Registration Sidebar Test: Update Page Identity Locators for Components and Links Pages
https://openscience.atlassian.net/browse/ENG-4513
