### PR TITLE
[ENG-3978] - Add New Project Analytics Test

### DIFF
--- a/api/osf_api.py
+++ b/api/osf_api.py
@@ -75,6 +75,17 @@ def get_node_logs(session, node_id):
     return session.get(url)['data']
 
 
+def get_most_recent_public_node_id(session):
+    """Return the most recent public project node id"""
+    url = '/v2/nodes/'
+    data = session.get(url)['data']
+    if data:
+        for node in data:
+            if node['attributes']['public']:
+                return node['id']
+    return None
+
+
 def get_user_institutions(session, user=None):
     if not user:
         user = current_user(session)
@@ -1003,3 +1014,15 @@ def submit_project_to_collection(
     # Note: We are not currently checking for any potential api request failure. We
     # don't typically handle failures unless they are a recurring issue and in this
     # case this post request has yet to fail in any of the testing environments.
+
+
+def get_project_node_analytics_data(session, node_id=None, timespan='week'):
+    """Return the data from the metrics Node Analytics query for a given project node.
+    There are also three timespans available: 'week', 'fortnight', and 'month'.
+    """
+    url = '_/metrics/query/node_analytics/{}/{}/'.format(node_id, timespan)
+    data = session.get(url)['data']
+    if data:
+        return data
+    else:
+        return None

--- a/api/osf_api.py
+++ b/api/osf_api.py
@@ -1022,7 +1022,4 @@ def get_project_node_analytics_data(session, node_id=None, timespan='week'):
     """
     url = '_/metrics/query/node_analytics/{}/{}/'.format(node_id, timespan)
     data = session.get(url)['data']
-    if data:
-        return data
-    else:
-        return None
+    return data or None

--- a/pages/project.py
+++ b/pages/project.py
@@ -223,7 +223,7 @@ class MyProjectsPage(OSFBasePage):
 class AnalyticsPage(GuidBasePage):
     base_url = settings.OSF_HOME + '/{guid}/analytics/'
 
-    identity = Locator(By.CSS_SELECTOR, '._Counts_1mhar6')
+    identity = Locator(By.CSS_SELECTOR, '._Counts_1mhar6', settings.LONG_TIMEOUT)
     loading_indicator = Locator(By.CSS_SELECTOR, '.ball-pulse')
     private_project_message = Locator(By.CSS_SELECTOR, '._PrivateProject_1mhar6')
     disabled_chart = Locator(By.CSS_SELECTOR, '._Chart_1hff7g _Blurred_1hff7g')

--- a/pages/project.py
+++ b/pages/project.py
@@ -224,8 +224,17 @@ class AnalyticsPage(GuidBasePage):
     base_url = settings.OSF_HOME + '/{guid}/analytics/'
 
     identity = Locator(By.CSS_SELECTOR, '._Counts_1mhar6')
+    loading_indicator = Locator(By.CSS_SELECTOR, '.ball-pulse')
     private_project_message = Locator(By.CSS_SELECTOR, '._PrivateProject_1mhar6')
     disabled_chart = Locator(By.CSS_SELECTOR, '._Chart_1hff7g _Blurred_1hff7g')
+
+    unique_visits_week_current_day_point = Locator(
+        By.CSS_SELECTOR, 'circle.c3-shape.c3-shape-7.c3-circle.c3-circle-7'
+    )
+    unique_visits_tooltip_value = Locator(
+        By.CSS_SELECTOR,
+        'div.panel-body._ChartContainer_1hff7g > div > div > table > tbody > tr.c3-tooltip-name--count > td.value',
+    )
 
 
 class ForksPage(GuidBasePage):

--- a/pages/project.py
+++ b/pages/project.py
@@ -234,6 +234,10 @@ class AnalyticsPage(GuidBasePage):
         By.CSS_SELECTOR,
         'div.ember-view.btn-group > div > ul > li:nth-child(2) > button',
     )
+    month_menu_option = Locator(
+        By.CSS_SELECTOR,
+        'div.ember-view.btn-group > div > ul > li:nth-child(3) > button',
+    )
 
     unique_visits_week_current_day_point = Locator(
         By.CSS_SELECTOR, 'circle.c3-shape.c3-shape-7.c3-circle.c3-circle-7'
@@ -245,6 +249,18 @@ class AnalyticsPage(GuidBasePage):
     tod_visits_tooltip_value = Locator(
         By.CSS_SELECTOR,
         'div.container._PageContainer_1mhar6 > div:nth-child(4) > div > div:nth-child(2) > div > div.panel-body._ChartContainer_1hff7g > div > div > table > tbody > tr.c3-tooltip-name--count > td.value',
+    )
+    most_visited_page_label = Locator(
+        By.CSS_SELECTOR,
+        'div.container._PageContainer_1mhar6 > div:nth-child(4) > div > div:nth-child(4) > div > div.panel-body._ChartContainer_1hff7g > div > svg > g:nth-child(2) > g.c3-axis.c3-axis-x > g:nth-child(2) > text > tspan',
+    )
+    most_visited_page_bar = Locator(
+        By.CSS_SELECTOR,
+        'div.container._PageContainer_1mhar6 > div:nth-child(4) > div > div:nth-child(4) > div > div.panel-body._ChartContainer_1hff7g > div > svg > g:nth-child(2) > g.c3-chart > g.c3-chart-bars > g > g > path.c3-shape.c3-shape-0.c3-bar.c3-bar-0',
+    )
+    popular_pages_tooltip_value = Locator(
+        By.CSS_SELECTOR,
+        'div.container._PageContainer_1mhar6 > div:nth-child(4) > div > div:nth-child(4) > div > div.panel-body._ChartContainer_1hff7g > div > div > table > tbody > tr.c3-tooltip-name--count > td.value',
     )
 
     tod_bars = GroupLocator(

--- a/pages/project.py
+++ b/pages/project.py
@@ -227,6 +227,13 @@ class AnalyticsPage(GuidBasePage):
     loading_indicator = Locator(By.CSS_SELECTOR, '.ball-pulse')
     private_project_message = Locator(By.CSS_SELECTOR, '._PrivateProject_1mhar6')
     disabled_chart = Locator(By.CSS_SELECTOR, '._Chart_1hff7g _Blurred_1hff7g')
+    date_range_button = Locator(
+        By.CSS_SELECTOR, 'div._PickDateRange_1mhar6 > label > div > button'
+    )
+    two_weeks_menu_option = Locator(
+        By.CSS_SELECTOR,
+        'div.ember-view.btn-group > div > ul > li:nth-child(2) > button',
+    )
 
     unique_visits_week_current_day_point = Locator(
         By.CSS_SELECTOR, 'circle.c3-shape.c3-shape-7.c3-circle.c3-circle-7'
@@ -235,6 +242,20 @@ class AnalyticsPage(GuidBasePage):
         By.CSS_SELECTOR,
         'div.panel-body._ChartContainer_1hff7g > div > div > table > tbody > tr.c3-tooltip-name--count > td.value',
     )
+    tod_visits_tooltip_value = Locator(
+        By.CSS_SELECTOR,
+        'div.container._PageContainer_1mhar6 > div:nth-child(4) > div > div:nth-child(2) > div > div.panel-body._ChartContainer_1hff7g > div > div > table > tbody > tr.c3-tooltip-name--count > td.value',
+    )
+
+    tod_bars = GroupLocator(
+        By.CSS_SELECTOR,
+        'div.container._PageContainer_1mhar6 > div:nth-child(4) > div > div:nth-child(2) > div > div.panel-body._ChartContainer_1hff7g > div > svg > g:nth-child(2) > g.c3-chart > g.c3-chart-bars > g > g > path',
+    )
+
+    def get_tod_bar_by_hour(self, hour):
+        for bar in self.tod_bars:
+            if 'bar-' + str(hour) in bar.get_attribute('class'):
+                return bar
 
 
 class ForksPage(GuidBasePage):

--- a/pages/project.py
+++ b/pages/project.py
@@ -227,17 +227,6 @@ class AnalyticsPage(GuidBasePage):
     loading_indicator = Locator(By.CSS_SELECTOR, '.ball-pulse')
     private_project_message = Locator(By.CSS_SELECTOR, '._PrivateProject_1mhar6')
     disabled_chart = Locator(By.CSS_SELECTOR, '._Chart_1hff7g _Blurred_1hff7g')
-    date_range_button = Locator(
-        By.CSS_SELECTOR, 'div._PickDateRange_1mhar6 > label > div > button'
-    )
-    two_weeks_menu_option = Locator(
-        By.CSS_SELECTOR,
-        'div.ember-view.btn-group > div > ul > li:nth-child(2) > button',
-    )
-    month_menu_option = Locator(
-        By.CSS_SELECTOR,
-        'div.ember-view.btn-group > div > ul > li:nth-child(3) > button',
-    )
 
     unique_visits_week_current_day_point = Locator(
         By.CSS_SELECTOR, 'circle.c3-shape.c3-shape-7.c3-circle.c3-circle-7'

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -50,12 +50,22 @@ def waffled_pages(session):
 
 @pytest.fixture(scope='session', autouse=True)
 def hide_cookie_banner(driver):
-    """Set the cookieconsent cookie so that that cookie banner doesn't show up
+    """Set the cookieconsent cookie so that the cookie banner doesn't show up
     (as it can obscure other UI elements).
      Note: If we ever want to test that banner will need to stop this cookie from being set.
     """
     driver.get(settings.OSF_HOME)
     driver.add_cookie({'name': 'osf_cookieconsent', 'value': '1', 'domain': '.osf.io'})
+
+
+@pytest.fixture(scope='session')
+def hide_footer_slide_in(driver):
+    """Set the browser local storage flag so that the Footer Slide In doesn't show up
+    (i.e. overlay that displays at the bottom of the OSF page when you are not logged
+    in. The slide in heading is: 'Start managing your projects on the OSF today.').
+    This slide in can obscure other elements.
+    """
+    driver.execute_script('window.localStorage.setItem("slide", 0);')
 
 
 @pytest.fixture(scope='class', autouse=True)

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -14,7 +14,6 @@ from pages.login import (
     logout,
 )
 from pages.project import (
-    AnalyticsPage,
     ForksPage,
     ProjectPage,
     RequestAccessPage,
@@ -396,11 +395,3 @@ class TestProjectComponents:
             # component so that the dummy project can also be deleted.
             if osf_api.get_node(session, node_id=component.id):
                 osf_api.delete_project(session, component.id, None)
-
-
-class TestAnalyticsPage:
-    @markers.core_functionality
-    def private_project(self, default_project):
-        analytics_page = AnalyticsPage(default_project.id)
-        assert analytics_page.private_project_message.present()
-        assert analytics_page.disabled_chart.present()

--- a/tests/test_project_analytics.py
+++ b/tests/test_project_analytics.py
@@ -1,0 +1,141 @@
+from datetime import (
+    datetime,
+    timezone,
+)
+
+import pytest
+from selenium.webdriver.common.action_chains import ActionChains
+from selenium.webdriver.support import expected_conditions as EC
+from selenium.webdriver.support.ui import WebDriverWait
+
+from api import osf_api
+from pages.project import (
+    AnalyticsPage,
+    FilesPage,
+)
+
+
+def parse_node_analytics_data(raw_data, request, **kwargs):
+    """Helper function that takes the raw data from the OSF api metrics Node Analytics
+    query and returns a specific piece of data. The Node Analytics query is meant to be
+    used by the Project Analytics page to gather metrics data to build the various
+    graphs on that page for Public projects.
+    """
+    if request == 'page_view_count':
+        # The pages available to public view are: 'overview', 'metadata', 'files',
+        # 'wiki', 'analytics', and 'registrations'.
+        page = kwargs.get('page', 'overview')
+        popular_pages = raw_data['attributes']['popular_pages']
+        # Initialize the page count value to 0 and only override it if there is a
+        # value found in the data. New temporary projects will not have any data for
+        # page views yet.
+        page_count = 0
+        for page_data in popular_pages:
+            if page == 'overview':
+                node_id = kwargs.get('node_id')
+                if page_data['path'] == '/{}'.format(node_id):
+                    page_count = page_data['count']
+                    break
+            elif page in page_data['path']:
+                page_count = page_data['count']
+        return page_count
+    elif request == 'unique_visits_count':
+        # Unique Visits Count is a list by Date in format: YYYY-MM-DD (in UTC timezone)
+        date = kwargs.get('date')
+        unique_visits = raw_data['attributes']['unique_visits']
+        # Initialize the visit count value to 0 and only override it if there is a
+        # value found in the data. New temporary projects will not have any data for
+        # unique visits yet.
+        visit_count = 0
+        for visit in unique_visits:
+            if visit['date'] == date:
+                visit_count = visit['count']
+                break
+        return visit_count
+    elif request == 'time_of_day_count':
+        # Time of Day Count is a list of visits per hour (in UTC timezone)
+        hour = kwargs.get('hour')
+        time_of_day = raw_data['attributes']['time_of_day']
+        # Initialize the tod count value to 0 and only override it if there is a value
+        # found in the data. New temporary projects will not have any data for time of
+        # day visits yet.
+        tod_count = 0
+        for tod in time_of_day:
+            if tod['hour'] == hour:
+                tod_count = tod['count']
+                break
+        return tod_count
+    elif request == 'referrer_domain_count':
+        domain = kwargs.get('domain')
+        referrer_domains = raw_data['attributes']['referer_domain']
+        # Initialize the referrer count value to 0 and only override it if there is a
+        # value found in the data. New temporary projects will not have any data for
+        # the referrer domain count yet.
+        referrer_count = 0
+        for referrer in referrer_domains:
+            if referrer['referer_domain'] == domain:
+                referrer_count = tod['count']
+                break
+        return referrer_count
+
+
+@pytest.fixture()
+def public_project_node(session, driver):
+    """Returns the project node id for a Public project in OSF"""
+    return osf_api.get_most_recent_public_node_id(session)
+
+
+@pytest.mark.usefixtures('hide_footer_slide_in')
+class TestNodeAnalytics:
+    def test_unique_visits_graph(self, session, driver, public_project_node):
+        """Test the Unique Visits Graph on the Project Analytics page. First retrieve
+        the metrics data for a public project using the OSF api and then go to the
+        Analytics page for the project.  Verify that the value displayed for the current
+        day on the Unique Visits Graph matches the expected value from the api.
+        NOTE: For this test we will not change the default date range of 1 week.
+        """
+
+        # First navigate to the Files page for the project so that there will be at
+        # least 1 registered visit on the graph
+        files_page = FilesPage(
+            driver, guid=public_project_node, addon_provider='osfstorage'
+        )
+        files_page.goto()
+        files_page.loading_indicator.here_then_gone()
+
+        # Get the Before unique visits count data from the api
+        before_data = osf_api.get_project_node_analytics_data(
+            session, node_id=public_project_node
+        )
+        now = datetime.now(timezone.utc)
+        date_today = now.strftime('%Y-%m-%d')
+        before_visits_count = parse_node_analytics_data(
+            before_data, 'unique_visits_count', date=date_today
+        )
+
+        # Next navigate to the Analytics page for the project.
+        analytics_page = AnalyticsPage(driver, guid=public_project_node)
+        analytics_page.goto()
+        analytics_page.loading_indicator.here_then_gone()
+
+        # Hover the mouse over the point on the Unique Visits graph that represents the
+        # current day and get the value that is displayed in the tool tip.
+        action_chains = ActionChains(driver)
+        action_chains.move_to_element(
+            analytics_page.unique_visits_week_current_day_point.element
+        ).perform()
+        WebDriverWait(driver, 3).until(
+            EC.visibility_of(analytics_page.unique_visits_tooltip_value)
+        )
+        unique_visits_display = int(analytics_page.unique_visits_tooltip_value.text)
+        assert unique_visits_display == before_visits_count
+
+        # Retrieve the metrics data again and verify that it now registers an additional
+        # unique visit since we went to the Analytics page.
+        after_data = osf_api.get_project_node_analytics_data(
+            session, node_id=public_project_node
+        )
+        after_visits_count = parse_node_analytics_data(
+            after_data, 'unique_visits_count', date=date_today
+        )
+        assert after_visits_count == before_visits_count + 1

--- a/tests/test_project_analytics.py
+++ b/tests/test_project_analytics.py
@@ -8,6 +8,7 @@ from selenium.webdriver.common.action_chains import ActionChains
 from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.support.ui import WebDriverWait
 
+import markers
 from api import osf_api
 from pages.project import (
     AnalyticsPage,
@@ -15,6 +16,7 @@ from pages.project import (
 )
 
 
+@markers.smoke_test
 class TestAnalyticsPage:
     def test_private_project(self, driver, default_project, must_be_logged_in):
         """Test the Analytics page on a Private Project. A message should display at the
@@ -105,6 +107,7 @@ def public_project_node(session, driver):
     return osf_api.get_most_recent_public_node_id(session)
 
 
+@markers.smoke_test
 @pytest.mark.usefixtures('hide_footer_slide_in')
 class TestNodeAnalytics:
     def test_unique_visits_graph(self, session, driver, public_project_node):

--- a/tests/test_project_analytics.py
+++ b/tests/test_project_analytics.py
@@ -223,7 +223,10 @@ class TestNodeAnalytics:
             EC.visibility_of(analytics_page.tod_visits_tooltip_value)
         )
         tod_visits_display = int(analytics_page.tod_visits_tooltip_value.text)
-        assert tod_visits_display == tod_count
+        # When running remotely via BrowserStack or when running the first time in an
+        # environment there may be timing issues with registering the visit to the
+        # Analytics page which may cause the visit count to be off by 1.
+        assert tod_visits_display == tod_count or tod_visits_display == tod_count + 1
 
     # NOTE: At this time we are not creating a test for the Top Referrers Graph. The
     # primary reason is that through Selenium there is no referrer registered. So there
@@ -294,4 +297,7 @@ class TestNodeAnalytics:
             # count by 1 in order to count the current visit
             visit_display = visit_display + 1
 
-        assert visit_display == visit_count
+        # When running remotely via BrowserStack, the goto_with_reload() may cause the
+        # Analytics page to be reloaded in which case the visit count may have one more
+        # additional visit.
+        assert visit_display == visit_count or visit_display == visit_count + 1

--- a/tests/test_project_analytics.py
+++ b/tests/test_project_analytics.py
@@ -22,30 +22,38 @@ def parse_node_analytics_data(raw_data, request, **kwargs):
     graphs on that page for Public projects.
     """
     if request == 'page_view_count':
-        # The pages available to public view are: 'overview', 'metadata', 'files',
-        # 'wiki', 'analytics', and 'registrations'.
-        page = kwargs.get('page', 'overview')
+        # Popular Page Visits count data contains the top 10 most popular pages
+        page = kwargs.get('page')
         popular_pages = raw_data['attributes']['popular_pages']
         # Initialize the page count value to 0 and only override it if there is a
-        # value found in the data. New temporary projects will not have any data for
-        # page views yet.
+        # value found in the data.
         page_count = 0
         for page_data in popular_pages:
-            if page == 'overview':
+            if page == 'home' or page == 'node':
                 node_id = kwargs.get('node_id')
                 if page_data['path'] == '/{}'.format(node_id):
                     page_count = page_data['count']
                     break
+            elif page == 'files':
+                # For Files page count, visits to the various storage provider addons
+                # are aggregated in the graph.
+                if 'files' in page_data['path']:
+                    page_count = page_count + page_data['count']
+            elif page == 'wiki':
+                # For Wiki page count, visits to any individual wiki pages are
+                # aggregated in the graph.
+                if 'wiki' in page_data['path']:
+                    page_count = page_count + page_data['count']
             elif page in page_data['path']:
                 page_count = page_data['count']
+                break
         return page_count
     elif request == 'unique_visits_count':
         # Unique Visits Count is a list by Date in format: YYYY-MM-DD (in UTC timezone)
         date = kwargs.get('date')
         unique_visits = raw_data['attributes']['unique_visits']
         # Initialize the visit count value to 0 and only override it if there is a
-        # value found in the data. New temporary projects will not have any data for
-        # unique visits yet.
+        # value found in the data.
         visit_count = 0
         for visit in unique_visits:
             if visit['date'] == date:
@@ -57,8 +65,7 @@ def parse_node_analytics_data(raw_data, request, **kwargs):
         hour = kwargs.get('hour')
         time_of_day = raw_data['attributes']['time_of_day']
         # Initialize the tod count value to 0 and only override it if there is a value
-        # found in the data. New temporary projects will not have any data for time of
-        # day visits yet.
+        # found in the data.
         tod_count = 0
         for tod in time_of_day:
             if tod['hour'] == hour:
@@ -69,12 +76,11 @@ def parse_node_analytics_data(raw_data, request, **kwargs):
         domain = kwargs.get('domain')
         referrer_domains = raw_data['attributes']['referer_domain']
         # Initialize the referrer count value to 0 and only override it if there is a
-        # value found in the data. New temporary projects will not have any data for
-        # the referrer domain count yet.
+        # value found in the data.
         referrer_count = 0
         for referrer in referrer_domains:
             if referrer['referer_domain'] == domain:
-                referrer_count = tod['count']
+                referrer_count = referrer['count']
                 break
         return referrer_count
 
@@ -187,3 +193,74 @@ class TestNodeAnalytics:
         )
         tod_visits_display = int(analytics_page.tod_visits_tooltip_value.text)
         assert tod_visits_display == tod_count
+
+    # NOTE: At this time we are not creating a test for the Top Referrers Graph. The
+    # primary reason is that through Selenium there is no referrer registered. So there
+    # could be the case that with a brand new public project there would be no referrer
+    # metrics data and therefore no graph. Maybe we could engineer a referrer by
+    # creating a link to the node and adding it to another project or even to an
+    # external website like GitHub and then using the link to go to the project. This
+    # feels like an unnecessary stretch and not worth the effort at this time.
+
+    def test_popular_pages_graph(self, session, driver, public_project_node):
+        """Test the Popular Pages Graph on the Project Analytics page. First navigate
+        to the Analytics page for a public project and determine the most visited page
+        on the Popular Pages graph. Next get the metrics data for the project and use
+        the label for the most popular page bar to get the page visit count from the
+        metrics data. Then verify that the page count displayed on the graph matches
+        the value in the metrics data. NOTE: For this test we will change the date
+        range to 1 month.
+        """
+
+        # Navigate to the Analytics page for the project.
+        analytics_page = AnalyticsPage(driver, guid=public_project_node)
+        analytics_page.goto()
+
+        # Change the analytics date range to 'Past Month'
+        analytics_page.date_range_button.click()
+        analytics_page.month_menu_option.click()
+        analytics_page.loading_indicator.here_then_gone()
+
+        # Scroll down and get the label for the most popular page (top bar) from the
+        # Popular Pages graph
+        analytics_page.scroll_into_view(analytics_page.most_visited_page_label.element)
+        page_label = analytics_page.most_visited_page_label.text
+        if page_label[5:11] == ': Home':
+            # For individual File nodes or Component nodes the label is '<guid>: Home'
+            # NOTE: There is an open PR for this ENG-4455 to change the labels for File
+            # and Component nodes to be clearer. At some point these labels will change
+            # and this test will need to be updated to reflect that change, whatever it
+            # ends up being.
+            parse_node = page_label[0:5]
+            parse_page = 'node'
+        else:
+            parse_node = public_project_node
+            parse_page = page_label.lower()
+
+        # Get the project's metrics data for the last month from the api
+        visit_data = osf_api.get_project_node_analytics_data(
+            session, node_id=public_project_node, timespan='month'
+        )
+
+        # Parse the metrics data to get the page views count for the most popular page
+        visit_count = parse_node_analytics_data(
+            visit_data, 'page_view_count', page=parse_page, node_id=parse_node
+        )
+
+        # Hover the mouse over the top bar on the Popular Pages graph which represents
+        # the most popular page and get the value that is displayed in the tool tip.
+        action_chains = ActionChains(driver)
+        action_chains.move_to_element(
+            analytics_page.most_visited_page_bar.element
+        ).perform()
+        WebDriverWait(driver, 3).until(
+            EC.visibility_of(analytics_page.popular_pages_tooltip_value)
+        )
+        visit_display = int(analytics_page.popular_pages_tooltip_value.text)
+
+        if page_label == 'Analytics':
+            # If the most visited page is the Analytics page then increment the display
+            # count by 1 in order to count the current visit
+            visit_display = visit_display + 1
+
+        assert visit_display == visit_count

--- a/tests/test_project_analytics.py
+++ b/tests/test_project_analytics.py
@@ -138,7 +138,7 @@ class TestNodeAnalytics:
 
         # Next navigate to the Analytics page for the project.
         analytics_page = AnalyticsPage(driver, guid=public_project_node)
-        analytics_page.goto()
+        analytics_page.goto_with_reload()
         analytics_page.loading_indicator.here_then_gone()
 
         analytics_page.scroll_into_view(
@@ -155,7 +155,14 @@ class TestNodeAnalytics:
             EC.visibility_of(analytics_page.unique_visits_tooltip_value)
         )
         unique_visits_display = int(analytics_page.unique_visits_tooltip_value.text)
-        assert unique_visits_display == before_visits_count
+        # When running locally the graph on the Analytics page loads fast enough that
+        # it does not register the visit to the Analytics page. However, when running
+        # remotely through BrowserStack the graph can sometimes load slower and then
+        # it may include the count of the Analytics page visit.
+        assert (
+            unique_visits_display == before_visits_count
+            or unique_visits_display == before_visits_count + 1
+        )
 
         # Retrieve the metrics data again and verify that it now registers an additional
         # unique visit since we went to the Analytics page.
@@ -165,7 +172,14 @@ class TestNodeAnalytics:
         after_visits_count = parse_node_analytics_data(
             after_data, 'unique_visits_count', date=date_today
         )
-        assert after_visits_count == before_visits_count + 1
+        # When running locally the graph on the Analytics page loads fast enough that
+        # it does not register the visit to the Analytics page. However, when running
+        # remotely through BrowserStack the graph can sometimes load slower and then
+        # it may include the count of the Analytics page visit.
+        assert (
+            after_visits_count == before_visits_count
+            or after_visits_count == before_visits_count + 1
+        )
 
     def test_tod_visits_graph(self, session, driver, public_project_node):
         """Test the Time of Day of Visits Graph on the Project Analytics page. First
@@ -180,7 +194,7 @@ class TestNodeAnalytics:
         # first since we are changing the date range which will refresh the graph data
         # and ensure that we register the current visit to the Analytics page.
         analytics_page = AnalyticsPage(driver, guid=public_project_node)
-        analytics_page.goto()
+        analytics_page.goto_with_reload()
         analytics_page.loading_indicator.here_then_gone()
 
         # Get the Time of Day visits count data from the api
@@ -231,7 +245,7 @@ class TestNodeAnalytics:
 
         # Navigate to the Analytics page for the project.
         analytics_page = AnalyticsPage(driver, guid=public_project_node)
-        analytics_page.goto()
+        analytics_page.goto_with_reload()
 
         # Change the analytics date range to 'Past Month'
         analytics_page.date_range_button.click()

--- a/tests/test_project_analytics.py
+++ b/tests/test_project_analytics.py
@@ -15,6 +15,20 @@ from pages.project import (
 )
 
 
+class TestAnalyticsPage:
+    def test_private_project(self, driver, default_project, must_be_logged_in):
+        """Test the Analytics page on a Private Project. A message should display at the
+        top of the page indicating that the project is Private and that Analytics are not
+        available and the graphs should be disabled and blurred.
+        """
+        analytics_page = AnalyticsPage(driver, guid=default_project.id)
+        analytics_page.goto()
+        analytics_page.loading_indicator.here_then_gone()
+        assert analytics_page.private_project_message.present()
+        # Existing bug - ENG-4456 - Graphs on Private Projects should be Disabled
+        # assert analytics_page.disabled_chart.present()
+
+
 def parse_node_analytics_data(raw_data, request, **kwargs):
     """Helper function that takes the raw data from the OSF api metrics Node Analytics
     query and returns a specific piece of data. The Node Analytics query is meant to be


### PR DESCRIPTION
<!-- Before you submit your Pull Request, please confirm that:

     - Any test that will create public data either has the `QAtest` tag or the `dont_run_on_production` marker
     - `core_functionality` is marked as such
     - Your tests will be able to run on *all* servers (all stagings, test)
 -->


## Purpose
To add test coverage for the Project Analytics page which also incorporates the recent replacement of Keen metrics with OSF metrics. 


## Summary of Changes

- api/osf_api.py - add new functions: get_most_recent_public_node_id and get_project_node_analytics_data
- pages/project.py - add several new elements to AnalyticsPage class
- tests/conftest.py - add new fixture: hide_footer_slide_in
- tests/test_project.py - delete old unused test class: TestAnalyticsPage
- tests/test_project_analytics.py - add new test file with a total of 4 new tests


## Reviewer's Actions
`git fetch <remote> pull/242/head:newTest/project-analytics`

Run this test using 
**NOTE: Do not run in Stage2 at this time. The latest Ember Upgrade Release (23.08 Xenon) has changed several elements on the Project Analytics page. A subsequent PR will fix these elements after the eow 23.08 release**.
`tests/test_project_analytics.py -s -v`

## Testing Changes Moving Forward
NA


## Ticket
ENG-3978: SEL: Project Analytics Page Test - Add new test with Keen Replacement metrics
https://openscience.atlassian.net/browse/ENG-3978
