### PR TITLE
[ENG-3661] - Project Files Test - Add Check of Project Log Entries for File Actions

### DIFF
--- a/api/osf_api.py
+++ b/api/osf_api.py
@@ -67,6 +67,14 @@ def get_node(session, node_id=settings.PREFERRED_NODE):
     return client.Node(session=session, id=node_id)
 
 
+def get_node_logs(session, node_id):
+    """Return the log entries for a given node"""
+    if not session:
+        session = get_default_session()
+    url = '/v2/nodes/{}/logs'.format(node_id)
+    return session.get(url)['data']
+
+
 def get_user_institutions(session, user=None):
     if not user:
         user = current_user(session)

--- a/components/helpers.py
+++ b/components/helpers.py
@@ -1,0 +1,11 @@
+def format_addon_name(addon_id):
+    """Helper function that returns a formatted addon name for a given addon id"""
+    if addon_id == 's3':
+        return 'Amazon S3'
+    elif addon_id == 'osfstorage':
+        return 'OSF Storage'
+    elif addon_id == 'owncloud':
+        return 'ownCloud'
+    else:
+        # Capitalize all others (i.e. 'Box', 'Dropbox')
+        return addon_id.capitalize()

--- a/components/project.py
+++ b/components/project.py
@@ -23,6 +23,7 @@ class FileWidget(BaseElement):
 
 class LogWidget(BaseElement):
     loading_indicator = Locator(By.CSS_SELECTOR, '#logFeed .ball-scale')
+    log_feed = Locator(By.ID, 'logFeed')
 
     # Group Locators
     log_items = GroupLocator(By.CSS_SELECTOR, '#logFeed .db-activity-item')

--- a/pages/project.py
+++ b/pages/project.py
@@ -128,8 +128,8 @@ def verify_log_entry(session, driver, node_id, action, **kwargs):
                     log_text = 'removed ' + file_name + ' in Amazon S3 bucket'
                 else:
                     log_text = 'removed file ' + file_name + ' from ' + provider
-            elif action == 'addon_file_moved':
-                # For File Move actions
+            elif action == 'addon_file_moved' or action == 'addon_file_copied':
+                # For File Move or Copy actions
                 file_name = kwargs.get('file_name')
                 source = kwargs.get('source')
                 if source == 'Owncloud':
@@ -137,7 +137,7 @@ def verify_log_entry(session, driver, node_id, action, **kwargs):
                 elif source == 'S3':
                     source = 'Amazon S3'
                 destination = kwargs.get('destination')
-                # Verify move specific attributes in the api log entry
+                # Verify move or copy specific attributes in the api log entry
                 assert (
                     entry['attributes']['params']['destination']['materialized']
                     == file_name
@@ -150,7 +150,7 @@ def verify_log_entry(session, driver, node_id, action, **kwargs):
                 )
                 assert entry['attributes']['params']['source']['addon'] == source
                 # Verify that the first log item in the log widget describes the correct
-                # file move action
+                # file move or copy action
                 log_text = (
                     action[11:]
                     + ' '

--- a/pages/project.py
+++ b/pages/project.py
@@ -15,6 +15,7 @@ from components.dashboard import (
     DeleteCollectionModal,
     ProjectCreatedModal,
 )
+from components.helpers import format_addon_name
 from components.project import (
     ComponentCreatedModal,
     ComponentsPrivacyChangeModal,
@@ -108,117 +109,74 @@ def verify_log_entry(session, driver, node_id, action, **kwargs):
     if action == 'osfstorage_file_removed':
         action = 'osf_storage_file_removed'
 
-    # Look for the appropriate log entry and verify relevant details specific to the
-    # log action type
+    # Look for the appropriate log entry in the api data
     for entry in logs:
         if entry['attributes']['action'] == action:
-            if 'file_removed' in action:
-                # For File Deletion actions
-                file_name = kwargs.get('file_name')
-                provider = kwargs.get('provider')
-                # Verify file name is in the path parameter attribute
-                assert file_name in entry['attributes']['params']['path']
-                # Verify that the first log item in the log widget describes the correct
-                # file deletion action
-                if provider == 'Owncloud':
-                    log_text = 'removed file ' + file_name + ' from ownCloud'
-                elif provider == 'Osfstorage':
-                    log_text = 'removed file ' + file_name + ' from OSF Storage'
-                elif provider == 'S3':
-                    log_text = 'removed ' + file_name + ' in Amazon S3 bucket'
-                else:
-                    log_text = 'removed file ' + file_name + ' from ' + provider
-            elif action == 'addon_file_moved' or action == 'addon_file_copied':
-                # For File Move or Copy actions
-                file_name = kwargs.get('file_name')
-                source = kwargs.get('source')
-                if source == 'Owncloud':
-                    source = 'ownCloud'
-                elif source == 'S3':
-                    source = 'Amazon S3'
-                destination = kwargs.get('destination')
-                # Verify move or copy specific attributes in the api log entry
-                assert (
-                    entry['attributes']['params']['destination']['materialized']
-                    == file_name
-                )
-                assert (
-                    entry['attributes']['params']['destination']['addon'] == destination
-                )
-                assert (
-                    entry['attributes']['params']['source']['materialized'] == file_name
-                )
-                assert entry['attributes']['params']['source']['addon'] == source
-                # Verify that the first log item in the log widget describes the correct
-                # file move or copy action
-                log_text = (
-                    action[11:]
-                    + ' '
-                    + file_name
-                    + ' in '
-                    + source
-                    + ' to '
-                    + file_name
-                    + ' in '
-                    + destination
-                )
-            elif action == 'addon_file_renamed':
-                # For File Rename actions
-                file_name = kwargs.get('file_name')
-                renamed_file = kwargs.get('renamed_file')
-                source = kwargs.get('source')
-                destination = kwargs.get('destination')
-                if source == 'Osfstorage':
-                    source = 'OSF Storage'
-                    destination = 'OSF Storage'
-                elif source == 'Owncloud':
-                    source = 'ownCloud'
-                    destination = 'ownCloud'
-                elif source == 'S3':
-                    source = 'Amazon S3'
-                    destination = 'Amazon S3'
-                # Verify rename specific attributes in the api log entry
-                assert (
-                    entry['attributes']['params']['destination']['materialized']
-                    == renamed_file
-                )
-                assert (
-                    entry['attributes']['params']['destination']['addon'] == destination
-                )
-                assert (
-                    entry['attributes']['params']['source']['materialized'] == file_name
-                )
-                assert entry['attributes']['params']['source']['addon'] == source
-                # Verify that the first log item in the log widget describes the correct
-                # file rename action
-                log_text = (
-                    action[11:]
-                    + ' '
-                    + file_name
-                    + ' in '
-                    + source
-                    + ' to '
-                    + renamed_file
-                    + ' in '
-                    + destination
-                )
-
-            assert log_text in log_item_1_text
+            log_data = entry
+            log_params = entry['attributes']['params']
             break
+
+    # Verify relevant details specific to the log action type
+    if 'file_removed' in action:
+        # For File Deletion actions
+        file_name = kwargs.get('file_name')
+        provider = format_addon_name(kwargs.get('provider'))
+        # Verify file name is in the path parameter attribute
+        assert file_name in log_params['path']
+        # Build the expected text string to find in the Log Widget text line
+        # EX: 'removed file delete_chrome_box.txt from Box'
+        if provider == 'Amazon S3':
+            log_text = 'removed {} in {} bucket'.format(file_name, provider)
+        else:
+            log_text = 'removed file {} from {}'.format(file_name, provider)
+    elif action == 'addon_file_moved' or action == 'addon_file_copied':
+        # For File Move or Copy actions
+        file_name = kwargs.get('file_name')
+        source = format_addon_name(kwargs.get('source'))
+        destination = format_addon_name(kwargs.get('destination'))
+        # Verify move or copy specific attributes in the api log entry
+        assert log_params['destination']['materialized'] == file_name
+        assert log_params['destination']['addon'] == destination
+        assert log_params['source']['materialized'] == file_name
+        assert log_params['source']['addon'] == source
+        # Build the expected text string to find in the Log Widget text line
+        # EX: 'moved move_chrome_box.txt in Box to move_chrome_box.txt in OSF Storage'
+        log_text = '{} {} in {} to {} in {}'.format(
+            action[11:], file_name, source, file_name, destination
+        )
+    elif action == 'addon_file_renamed':
+        # For File Rename actions
+        file_name = kwargs.get('file_name')
+        renamed_file = kwargs.get('renamed_file')
+        source = format_addon_name(kwargs.get('source'))
+        destination = format_addon_name(kwargs.get('destination'))
+        # Verify rename specific attributes in the api log entry
+        assert log_params['destination']['materialized'] == renamed_file
+        assert log_params['destination']['addon'] == destination
+        assert log_params['source']['materialized'] == file_name
+        assert log_params['source']['addon'] == source
+        # Build the expected text string to find in the Log Widget text line
+        # EX: 'renamed rename_chrome_box.txt in Box to chrome_box_renamed.txt in Box'
+        log_text = 'renamed {} in {} to {} in {}'.format(
+            file_name, source, renamed_file, destination
+        )
+
+    # Verify the text displayed in the Log Widget
+    assert log_text in log_item_1_text
 
     # The following data should be in all log entries:
     # Verify the log entry begins with the user name
     user = osf_api.current_user()
     assert log_item_1_text.startswith(user.full_name)
-    assert entry['relationships']['user']['data']['id'] == user.id
+    assert log_data['relationships']['user']['data']['id'] == user.id
     # Verify project title is in the log entry
     assert project_title in log_item_1_text
-    assert entry['attributes']['params']['params_node']['title'] == project_title
+    assert log_params['params_node']['title'] == project_title
     # Verify current date is also in the log entry
     now = datetime.now()
     date_today = now.strftime('%Y-%m-%d')
     assert date_today in log_item_1_text
-    assert date_today in entry['attributes']['date']
+    assert date_today in log_data['attributes']['date']
 
 
 class RequestAccessPage(GuidBasePage):

--- a/pages/project.py
+++ b/pages/project.py
@@ -162,6 +162,46 @@ def verify_log_entry(session, driver, node_id, action, **kwargs):
                     + ' in '
                     + destination
                 )
+            elif action == 'addon_file_renamed':
+                # For File Rename actions
+                file_name = kwargs.get('file_name')
+                renamed_file = kwargs.get('renamed_file')
+                source = kwargs.get('source')
+                destination = kwargs.get('destination')
+                if source == 'Osfstorage':
+                    source = 'OSF Storage'
+                    destination = 'OSF Storage'
+                elif source == 'Owncloud':
+                    source = 'ownCloud'
+                    destination = 'ownCloud'
+                elif source == 'S3':
+                    source = 'Amazon S3'
+                    destination = 'Amazon S3'
+                # Verify rename specific attributes in the api log entry
+                assert (
+                    entry['attributes']['params']['destination']['materialized']
+                    == renamed_file
+                )
+                assert (
+                    entry['attributes']['params']['destination']['addon'] == destination
+                )
+                assert (
+                    entry['attributes']['params']['source']['materialized'] == file_name
+                )
+                assert entry['attributes']['params']['source']['addon'] == source
+                # Verify that the first log item in the log widget describes the correct
+                # file rename action
+                log_text = (
+                    action[11:]
+                    + ' '
+                    + file_name
+                    + ' in '
+                    + source
+                    + ' to '
+                    + renamed_file
+                    + ' in '
+                    + destination
+                )
 
             assert log_text in log_item_1_text
             break

--- a/tests/test_project_files.py
+++ b/tests/test_project_files.py
@@ -440,6 +440,16 @@ class TestFilesPage:
             files_page.loading_indicator.here_then_gone()
             destination_row = find_row_by_name(files_page, new_file)
             assert new_file in destination_row.text
+            # Verify Project Log Entry
+            verify_log_entry(
+                session,
+                driver,
+                node_id,
+                'addon_file_copied',
+                file_name=new_file,
+                source=provider.capitalize(),
+                destination='OSF Storage',
+            )
         finally:
             osf_api.delete_addon_files(session, provider, current_browser, guid=node_id)
 

--- a/tests/test_project_files.py
+++ b/tests/test_project_files.py
@@ -114,6 +114,17 @@ class TestFilesPage:
             # Test that new file name is present and visible
             renamed_file = find_row_by_name(files_page, new_name)
             assert new_name in renamed_file.text
+            # Verify Project Log Entry
+            verify_log_entry(
+                session,
+                driver,
+                node_id,
+                'addon_file_renamed',
+                file_name=new_file,
+                renamed_file=new_name,
+                source=provider.capitalize(),
+                destination=provider.capitalize(),
+            )
         finally:
             osf_api.delete_addon_files(session, provider, current_browser, guid=node_id)
 

--- a/tests/test_project_files.py
+++ b/tests/test_project_files.py
@@ -122,8 +122,8 @@ class TestFilesPage:
                 'addon_file_renamed',
                 file_name=new_file,
                 renamed_file=new_name,
-                source=provider.capitalize(),
-                destination=provider.capitalize(),
+                source=provider,
+                destination=provider,
             )
         finally:
             osf_api.delete_addon_files(session, provider, current_browser, guid=node_id)
@@ -179,7 +179,7 @@ class TestFilesPage:
                 node_id,
                 provider + '_file_removed',
                 file_name=new_file,
-                provider=provider.capitalize(),
+                provider=provider,
             )
         finally:
             osf_api.delete_addon_files(session, provider, current_browser, guid=node_id)
@@ -315,8 +315,8 @@ class TestFilesPage:
                 node_id,
                 'addon_file_moved',
                 file_name=new_file,
-                source=provider.capitalize(),
-                destination='OSF Storage',
+                source=provider,
+                destination='osfstorage',
             )
         finally:
             osf_api.delete_addon_files(session, provider, current_browser, guid=node_id)
@@ -458,8 +458,8 @@ class TestFilesPage:
                 node_id,
                 'addon_file_copied',
                 file_name=new_file,
-                source=provider.capitalize(),
-                destination='OSF Storage',
+                source=provider,
+                destination='osfstorage',
             )
         finally:
             osf_api.delete_addon_files(session, provider, current_browser, guid=node_id)

--- a/tests/test_project_files.py
+++ b/tests/test_project_files.py
@@ -297,6 +297,16 @@ class TestFilesPage:
             files_page.loading_indicator.here_then_gone()
             moved_row = find_row_by_name(files_page, new_file)
             assert new_file in moved_row.text
+            # Verify Project Log Entry
+            verify_log_entry(
+                session,
+                driver,
+                node_id,
+                'addon_file_moved',
+                file_name=new_file,
+                source=provider.capitalize(),
+                destination='OSF Storage',
+            )
         finally:
             osf_api.delete_addon_files(session, provider, current_browser, guid=node_id)
 

--- a/tests/test_project_files.py
+++ b/tests/test_project_files.py
@@ -10,7 +10,10 @@ from selenium.webdriver.support.ui import WebDriverWait
 import markers
 import settings
 from api import osf_api
-from pages.project import FilesPage
+from pages.project import (
+    FilesPage,
+    verify_log_entry,
+)
 from utils import find_current_browser
 
 
@@ -158,6 +161,15 @@ class TestFilesPage:
             # Verify file has been deleted from the files list
             deleted_row = find_row_by_name(files_page, new_file)
             assert deleted_row is None
+            # Verify Project Log Entry
+            verify_log_entry(
+                session,
+                driver,
+                node_id,
+                provider + '_file_removed',
+                file_name=new_file,
+                provider=provider.capitalize(),
+            )
         finally:
             osf_api.delete_addon_files(session, provider, current_browser, guid=node_id)
 


### PR DESCRIPTION
<!-- Before you submit your Pull Request, please confirm that:

     - Any test that will create public data either has the `QAtest` tag or the `dont_run_on_production` marker
     - `core_functionality` is marked as such
     - Your tests will be able to run on *all* servers (all stagings, test)
 -->


## Purpose
To expand the selenium test suite to include the verification of Project Log entries which we have not been verifying up to this point.


## Summary of Changes

- api/osf_api.py - add new function 'get_node_logs'
- components/helpers.py - new file for helper functions with new function: format_addon_name
- components/project.py - add new element to LogWidget component
- pages/project.py - add new function 'verify_log_entry' 
- tests/test_project_files.py - add function call 'verify_log_entry' to 4 tests: test_rename_file, test_delete_single_file, test_move_single_file, and test_copy_single_file


## Reviewer's Actions
`git fetch <remote> pull/243/head:feature/project-logs`

Run this test using
`tests/test_project_files.py::TestFilesPage::test_rename_file -s -v`
`tests/test_project_files.py::TestFilesPage::test_delete_single_file -s -v`
`tests/test_project_files.py::TestFilesPage::test_move_single_file -s -v`
`tests/test_project_files.py::TestFilesPage::test_copy_single_file -s -v`

## Testing Changes Moving Forward
Can add call of 'verify_log_entry" function to other tests that create Project Log entries (i.e. test that creates project, creates component, etc.)


## Ticket
ENG-3661: SEL: Project Files Test - Add Check of Project Log Entries for File Actions
https://openscience.atlassian.net/browse/ENG-3661
