### PR TITLE
[ENG-4582] - Fix Navbar Tests for New COS Donate page

### DIFF
--- a/pages/cos.py
+++ b/pages/cos.py
@@ -6,12 +6,6 @@ from pages.base import BasePage
 
 
 class COSDonatePage(BasePage):
-    url = 'https://www.cos.io/about/support-cos'
+    url = 'https://www.cos.io/donate-to-cos'
 
-    # This meta tag is unique to the donate page but cannot be verified as a 'visible' locator
-    # See https://github.com/cos-qa/osf-selenium-tests/blob/b7f3f21376b7d6f751993cdcffea9262856263e3/base/locators.py#L157-L163
-    identity = Locator(
-        By.XPATH,
-        '//meta[@name="cos:id" and @content="donate-page"]',
-        settings.LONG_TIMEOUT,
-    )
+    identity = Locator(By.ID, 'Yourdonationtitle', settings.LONG_TIMEOUT)

--- a/tests/test_navbar.py
+++ b/tests/test_navbar.py
@@ -308,11 +308,11 @@ class TestInstitutionsNavbarLoggedIn(NavbarTestLoggedInMixin):
 
 def assert_donate_page(driver, donate_page):
     # locators.py does not currently support invisible elements as identity
-    # https://github.com/cos-qa/osf-selenium-tests/blob/b7f3f21376b7d6f751993cdcffea9262856263e3/base/locators.py#L151
+    # https://github.com/cos-qa/osf-selenium-tests/blob/b7f3f21376b7d6f751993cdcffea9262856263e3/base/locators.py#L138
     meta_tag = driver.find_element_by_xpath(
-        '//meta[@name="cos:id" and @content="donate-page"]'
+        '//meta[@property="og:title" and @content="Donate To Cos"]'
     )
 
     assert driver.current_url == donate_page.url
-    assert meta_tag.get_attribute('name') == 'cos:id'
-    assert meta_tag.get_attribute('content') == 'donate-page'
+    assert meta_tag.get_attribute('property') == 'og:title'
+    assert meta_tag.get_attribute('content') == 'Donate To Cos'


### PR DESCRIPTION
<!-- Before you submit your Pull Request, please confirm that:

     - Any test that will create public data either has the `QAtest` tag or the `dont_run_on_production` marker
     - `core_functionality` is marked as such
     - Your tests will be able to run on *all* servers (all stagings, test)
 -->


## Purpose
To fix test failures in the Navbar test due to a new version of the COS Donate page.


## Summary of Changes

- pages/cos.py - update url and identifty locator for COSDonatePage.
- tests/test_navbar.py - update assert_donate_page function to use different meta element


## Reviewer's Actions
`git fetch <remote> pull/245/head:testFix/cos-donate-page`

Run this test using
**NOTE: Test will not pass in Stage2 or Stage3 due to Ember Upgrades.**
`tests/test_navbar.py -s -v`

## Testing Changes Moving Forward
N/A


## Ticket
ENG-4582: SEL: Navbar - Fix Test Failures Due to New COS Donate Page
https://openscience.atlassian.net/browse/ENG-4582
