### PR TITLE
[ENG-4606] - Delete Registered Reports Landing page tests

### DIFF
--- a/pages/landing.py
+++ b/pages/landing.py
@@ -40,26 +40,3 @@ class LandingPage(OSFBasePage):
     # Components
     navbar = ComponentLocator(EmberNavbar)
     sign_up_form = ComponentLocator(SignUpForm)
-
-
-class RegisteredReportsLandingPage(OSFBasePage):
-    url = settings.OSF_HOME + '/rr/'
-
-    identity = Locator(By.CSS_SELECTOR, '.reg-landing-page-logo')
-
-    create_registered_report_button = Locator(
-        By.CSS_SELECTOR,
-        'body > div.watermarked > div > div > div.row.hidden-xs > table > tbody > tr:nth-child(1) > td > a > div',
-    )
-    cos_rr_link = Locator(
-        By.CSS_SELECTOR,
-        'body > div.watermarked > div > div > div:nth-child(8) > a:nth-child(1)',
-    )
-    osf_registries_link = Locator(
-        By.CSS_SELECTOR,
-        'body > div.watermarked > div > div > div:nth-child(8) > a:nth-child(2)',
-    )
-    cos_prereg_link = Locator(
-        By.CSS_SELECTOR,
-        'body > div.watermarked > div > div > div:nth-child(8) > a:nth-child(3)',
-    )

--- a/tests/test_landing.py
+++ b/tests/test_landing.py
@@ -3,12 +3,8 @@ from selenium.webdriver.common.keys import Keys
 
 import markers
 import settings
-from pages.landing import (
-    LandingPage,
-    RegisteredReportsLandingPage,
-)
+from pages.landing import LandingPage
 from pages.register import RegisterPage
-from pages.registries import RegistriesDiscoverPage
 from pages.search import SearchPage
 from pages.user import UserProfilePage
 
@@ -139,28 +135,3 @@ class TestHomeLandingPage:
         landing_page.testimonial_view_research_links[2].click()
         UserProfilePage(driver, verify=True)
         assert '2u4tf' in driver.current_url
-
-
-@pytest.fixture()
-def rr_landing_page(driver):
-    rr_landing_page = RegisteredReportsLandingPage(driver)
-    rr_landing_page.goto_with_reload()
-    return rr_landing_page
-
-
-class TestRegisteredReportsLandingPage:
-    def test_create_registered_report_button(self, driver, rr_landing_page):
-        rr_landing_page.create_registered_report_button.click()
-        RegisterPage(driver, verify=True)
-
-    def test_cos_rr_link(self, driver, rr_landing_page):
-        rr_landing_page.cos_rr_link.click()
-        assert 'https://www.cos.io/initiatives/registered-reports' in driver.current_url
-
-    def test_osf_registries_link(self, driver, rr_landing_page):
-        rr_landing_page.osf_registries_link.click()
-        RegistriesDiscoverPage(driver, verify=True)
-
-    def test_cos_prereg_link(self, driver, rr_landing_page):
-        rr_landing_page.cos_prereg_link.click()
-        assert 'https://www.cos.io/initiatives/prereg' in driver.current_url


### PR DESCRIPTION
<!-- Before you submit your Pull Request, please confirm that:

     - Any test that will create public data either has the `QAtest` tag or the `dont_run_on_production` marker
     - `core_functionality` is marked as such
     - Your tests will be able to run on *all* servers (all stagings, test)
 -->


## Purpose
To delete the Registered Reports Landing page tests now that the /rr page is being retired with the release of ENG-3919 (https://openscience.atlassian.net/browse/ENG-3919)


## Summary of Changes

- pages/landing.py - delete RegisteredReportsLandingPage class
- tests/test_landing.py - delete TestRegisteredReportsLandingPage class and all associated fixtures and tests.


## Reviewer's Actions
`git fetch <remote> pull/248/head:testFix/retire-rr`

Run this test using
`tests/test_landing.py -s -v`

## Testing Changes Moving Forward
N/A


## Ticket
ENG-4606: SEL: Landing Page - Remove Registered Reports Landing Page Tests
https://openscience.atlassian.net/browse/ENG-4606
