### PR TITLE
[ENG-4623] - Add Log Verification to Project Tests

### DIFF
--- a/pages/project.py
+++ b/pages/project.py
@@ -211,6 +211,16 @@ def verify_log_entry(session, driver, node_id, action, **kwargs):
         # log item row is always the add affiliation log entry whenever we create a new
         # project or node in OSF.
         log_item_1_text = project_page.log_widget.log_items[1].text
+    elif action == 'node_removed':
+        # For the deletion of a Component node from a Project
+        node_guid = kwargs.get('node_guid')
+        node_title = kwargs.get('node_title')
+        assert log_params['params_node']['id'] == node_guid
+        assert log_params['params_node']['title'] == node_title
+        log_text = 'removed {}'.format(node_title)
+        # override project_title since the log entry has title of the component node
+        # not the parent project
+        project_title = node_title
 
     # Verify the text displayed in the Log Widget
     assert log_text in log_item_1_text

--- a/pages/project.py
+++ b/pages/project.py
@@ -190,6 +190,27 @@ def verify_log_entry(session, driver, node_id, action, **kwargs):
         # override project_title since the log entry has title of the original project
         # node not the new forked node
         project_title = orig_title
+    elif action == 'affiliated_institution_added':
+        # For when a Project is affiliated with an institution. Typically this happens
+        # upon creation of the node.
+        node_guid = kwargs.get('node_guid')
+        node_title = kwargs.get('node_title')
+        institution_name = kwargs.get('institution_name')
+        assert log_params['params_node']['id'] == node_guid
+        assert log_params['params_node']['title'] == node_title
+        assert log_params['institution']['name'] == institution_name
+        log_text = 'added {} affiliation to {}'.format(institution_name, node_title)
+    elif action == 'project_created':
+        # For the creation of a new Project or Component node
+        node_guid = kwargs.get('node_guid')
+        node_title = kwargs.get('node_title')
+        assert log_params['params_node']['id'] == node_guid
+        assert log_params['params_node']['title'] == node_title
+        log_text = 'created {}'.format(node_title)
+        # Need to override the log item text with the 2nd log item row since the first
+        # log item row is always the add affiliation log entry whenever we create a new
+        # project or node in OSF.
+        log_item_1_text = project_page.log_widget.log_items[1].text
 
     # Verify the text displayed in the Log Widget
     assert log_text in log_item_1_text

--- a/pages/project.py
+++ b/pages/project.py
@@ -177,6 +177,9 @@ def verify_log_entry(session, driver, node_id, action, **kwargs):
         assert log_params['title_original'] == orig_title
         assert log_params['title_new'] == new_title
         log_text = 'changed the title from {} to {}'.format(orig_title, new_title)
+    elif action == 'made_public':
+        # For making a Project node Public
+        log_text = 'made {} public'.format(project_title)
 
     # Verify the text displayed in the Log Widget
     assert log_text in log_item_1_text

--- a/pages/project.py
+++ b/pages/project.py
@@ -170,6 +170,13 @@ def verify_log_entry(session, driver, node_id, action, **kwargs):
         anonymous = kwargs.get('anonymous')
         assert log_params['anonymous_link'] == anonymous
         log_text = 'created a view-only link to'
+    elif action == 'edit_title':
+        # For changing the Title on a Project
+        orig_title = kwargs.get('orig_title')
+        new_title = kwargs.get('new_title')
+        assert log_params['title_original'] == orig_title
+        assert log_params['title_new'] == new_title
+        log_text = 'changed the title from {} to {}'.format(orig_title, new_title)
 
     # Verify the text displayed in the Log Widget
     assert log_text in log_item_1_text

--- a/pages/project.py
+++ b/pages/project.py
@@ -180,6 +180,16 @@ def verify_log_entry(session, driver, node_id, action, **kwargs):
     elif action == 'made_public':
         # For making a Project node Public
         log_text = 'made {} public'.format(project_title)
+    elif action == 'node_forked':
+        # For a node that has been Forked from another Project node
+        orig_guid = kwargs.get('orig_guid')
+        orig_title = kwargs.get('orig_title')
+        assert log_params['params_node']['id'] == orig_guid
+        assert log_params['params_node']['title'] == orig_title
+        log_text = 'created fork from {}'.format(orig_title)
+        # override project_title since the log entry has title of the original project
+        # node not the new forked node
+        project_title = orig_title
 
     # Verify the text displayed in the Log Widget
     assert log_text in log_item_1_text
@@ -289,6 +299,7 @@ class ForksPage(GuidBasePage):
     base_url = settings.OSF_HOME + '/{guid}/forks/'
 
     identity = Locator(By.CSS_SELECTOR, '._Forks_1xlord')
+    project_title = Locator(By.CSS_SELECTOR, 'div.ember-view._Hero_widcfp > h1')
     new_fork_button = Locator(By.CSS_SELECTOR, '[data-test-new-fork-button]')
     create_fork_modal_button = Locator(
         By.CSS_SELECTOR, '[data-test-confirm-create-fork]'

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -379,6 +379,16 @@ class TestProjectComponents:
                 == 'Component has been successfully deleted.'
             )
             assert len(project_page.components) == 0
+
+            # Verify log entry for deleting the component
+            verify_log_entry(
+                session,
+                driver,
+                default_project.id,
+                'node_removed',
+                node_guid=component.id,
+                node_title='API Created Component',
+            )
         finally:
             # We must make sure that in the event of an error that we delete the
             # component so that the dummy project can also be deleted.

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -174,8 +174,24 @@ class TestForksPage:
         forks_page.fork_authors.present()
         assert len(forks_page.listed_forks) == 1
 
-        # Clean-up leftover fork
+        orig_title = forks_page.project_title.text
         fork_guid = forks_page.fork_link.get_attribute('data-test-node-title')
+
+        # Click the Title link on the Fork Card to navigate to the new Forked Project
+        forks_page.fork_link.click()
+        assert ProjectPage(driver, verify=True)
+
+        # Verify log entry for the new Forked Project
+        verify_log_entry(
+            session,
+            driver,
+            fork_guid,
+            'node_forked',
+            orig_guid=forks_page.guid,
+            orig_title=orig_title,
+        )
+
+        # Clean-up leftover fork
         osf_api.delete_project(session, fork_guid, None)
 
 

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -75,7 +75,7 @@ class TestProjectDetailPage:
     @markers.dont_run_on_prod
     @markers.dont_run_on_preferred_node
     @markers.core_functionality
-    def test_make_public(self, driver, project_page):
+    def test_make_public(self, session, driver, project_page):
         # Set project to public
         WebDriverWait(driver, 5).until(
             EC.element_to_be_clickable(
@@ -94,6 +94,9 @@ class TestProjectDetailPage:
         project_page.make_public_link.click()
         project_page.confirm_privacy_change_modal.confirm_link.click()
         assert project_page.make_private_link.present()
+
+        # Verify log entry for making the project public
+        verify_log_entry(session, driver, project_page.guid, 'made_public')
 
         # Confirm logged out user can now see project
         logout(driver)

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -39,10 +39,11 @@ def project_page_with_file(driver, project_with_file):
 class TestProjectDetailPage:
     @markers.smoke_test
     @markers.core_functionality
-    def test_change_title(self, project_page, fake):
+    def test_change_title(self, session, driver, project_page, fake):
 
         new_title = fake.sentence(nb_words=4)
-        assert project_page.title.text != new_title
+        orig_title = project_page.title.text
+        assert orig_title != new_title
         # In some cases (especially with Chrome) the test steps are executed faster than the web page is
         # really ready for them.  In this particular case the test clicks the title of the project which
         # is supposed to then produce an input box in which you can change the title.  If the click is
@@ -55,6 +56,15 @@ class TestProjectDetailPage:
         project_page.title_edit_submit_button.click()
         project_page.verify()  # Wait for the page to reload
         assert project_page.title.text == new_title
+        # Verify log entry for changing project title
+        verify_log_entry(
+            session,
+            driver,
+            project_page.guid,
+            'edit_title',
+            orig_title=orig_title,
+            new_title=new_title,
+        )
 
     @markers.smoke_test
     @markers.core_functionality

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -252,8 +252,29 @@ class TestProjectComponents:
                 == 'This component was added by an automated selenium test.'
             )
 
+            # Verify log entries for creating component and its institution affiliation
+            verify_log_entry(
+                session,
+                driver,
+                component_guid,
+                'project_created',
+                node_guid=component_guid,
+                node_title='Selenium Component',
+            )
+            institution_names = osf_api.get_user_institutions(session)
+            verify_log_entry(
+                session,
+                driver,
+                component_guid,
+                'affiliated_institution_added',
+                node_guid=component_guid,
+                node_title='Selenium Component',
+                institution_name=institution_names[0],
+            )
+
             # Click the link to the parent project at the top of the page to navigate
             # back to the original parent Project Overview page.
+            component_page.scroll_into_view(component_page.parent_project_link.element)
             component_page.parent_project_link.click()
             assert project_page
 


### PR DESCRIPTION
<!-- Before you submit your Pull Request, please confirm that:

     - Any test that will create public data either has the `QAtest` tag or the `dont_run_on_production` marker
     - `core_functionality` is marked as such
     - Your tests will be able to run on *all* servers (all stagings, test)
 -->


## Purpose
To expand selenium test coverage to include the verification of various log entries when certain Project related tasks are performed in OSF.


## Summary of Changes

- pages/project.py - add 6 new project log actions to verify_log_entry()
- tests/test_project.py - add function call verify_log_entry() to several tests including: test_change_title, test_make_public, test_create_fork, test_add_component, and test_delete_component_from_project.


## Reviewer's Actions
`git fetch <remote> pull/249/head:testFix/project-logs`

Run this test using
`tests/test_project.py -s -v`

## Testing Changes Moving Forward
N/A


## Ticket
ENG-4623: SEL: Project Test - Add Log Verification to Various Project Tests
https://openscience.atlassian.net/browse/ENG-4623
