### PR TITLE
[ENG-4581] - Updates for Search Improvements Project Phase 1

### DIFF
--- a/pages/registries.py
+++ b/pages/registries.py
@@ -1,6 +1,5 @@
 from urllib.parse import urljoin
 
-from selenium.common.exceptions import NoSuchElementException
 from selenium.webdriver.common.by import By
 
 import settings
@@ -40,7 +39,7 @@ class BaseRegistriesPage(OSFBasePage):
 
 class RegistriesLandingPage(BaseRegistriesPage):
     identity = Locator(
-        By.CSS_SELECTOR, '._RegistriesHeader_3zbd8x', settings.LONG_TIMEOUT
+        By.CSS_SELECTOR, '[data-test-registries-list-paragraph]', settings.LONG_TIMEOUT
     )
     search_box = Locator(By.ID, 'search')
 
@@ -51,27 +50,11 @@ class RegistriesDiscoverPage(BaseRegistriesPage):
     identity = Locator(
         By.CSS_SELECTOR, 'div[data-analytics-scope="Registries Discover page"]'
     )
-    search_box = Locator(By.ID, 'search')
+    search_box = Locator(By.ID, 'search-input')
     loading_indicator = Locator(By.CSS_SELECTOR, '.ball-scale', settings.LONG_TIMEOUT)
-    osf_filter = Locator(
-        By.CSS_SELECTOR, '[data-test-source-filter-id$="OSF Registries"]'
-    )
-    sort_by_button = Locator(By.CSS_SELECTOR, 'div[data-test-sort-dropdown]')
-    sort_by_date_newest = Locator(
-        By.CSS_SELECTOR, 'button[data-test-sort-option-id="2"]'
-    )
 
     # Group Locators
     search_results = GroupLocator(By.CSS_SELECTOR, '._title_1wvii8')
-
-    def get_first_non_withdrawn_registration(self):
-        for result in self.search_results:
-            try:
-                result.find_element_by_class_name('_label_1wvii8')
-            except NoSuchElementException:
-                return result.find_element_by_css_selector(
-                    '[data-test-result-title-id]'
-                )
 
 
 class BaseSubmittedRegistrationPage(GuidBasePage):

--- a/pages/search.py
+++ b/pages/search.py
@@ -11,9 +11,35 @@ from pages.base import OSFBasePage
 class SearchPage(OSFBasePage):
     url = settings.OSF_HOME + '/search/'
 
-    identity = Locator(By.ID, 'searchPageFullBar')
-    search_bar = Locator(By.ID, 'searchPageFullBar')
+    identity = Locator(By.CSS_SELECTOR, 'div[data-analytics-scope="Search page main"]')
+    search_input = Locator(
+        By.CSS_SELECTOR, '.ember-text-field.ember-view._search-input_fvrbco'
+    )
+    search_button = Locator(By.CSS_SELECTOR, 'button[data-test-search-submit]')
     loading_indicator = Locator(By.CSS_SELECTOR, '.ball-scale')
+    projects_tab_link = Locator(
+        By.CSS_SELECTOR, 'a[data-test-topbar-object-type-link="Projects"]'
+    )
+    registrations_tab_link = Locator(
+        By.CSS_SELECTOR, 'a[data-test-topbar-object-type-link="Registrations"]'
+    )
+    preprints_tab_link = Locator(
+        By.CSS_SELECTOR, 'a[data-test-topbar-object-type-link="Preprints"]'
+    )
+    files_tab_link = Locator(
+        By.CSS_SELECTOR, 'a[data-test-topbar-object-type-link="Files"]'
+    )
+    users_tab_link = Locator(
+        By.CSS_SELECTOR, 'a[data-test-topbar-object-type-link="Users"]'
+    )
+    first_card_object_type_label = Locator(By.CSS_SELECTOR, 'div._type-label_qeqpmj')
+    sort_by_button = Locator(
+        By.CSS_SELECTOR,
+        'div[data-test-topbar-sort-dropdown] > div.ember-view.ember-basic-dropdown-trigger.ember-power-select-trigger',
+    )
+    sort_by_date_newest = Locator(
+        By.CSS_SELECTOR, '#ember-basic-dropdown-wormhole > div > ul > li:nth-child(2)'
+    )
 
     # Group Locators
-    search_results = GroupLocator(By.CSS_SELECTOR, '.search-result')
+    search_results = GroupLocator(By.CSS_SELECTOR, '._result-card-container_qeqpmj')

--- a/pages/search.py
+++ b/pages/search.py
@@ -1,3 +1,4 @@
+from selenium.common.exceptions import NoSuchElementException
 from selenium.webdriver.common.by import By
 
 import settings
@@ -43,3 +44,10 @@ class SearchPage(OSFBasePage):
 
     # Group Locators
     search_results = GroupLocator(By.CSS_SELECTOR, '._result-card-container_qeqpmj')
+
+    def get_first_non_withdrawn_registration(self):
+        for result in self.search_results:
+            try:
+                result.find_element_by_class_name('_withdrawn-label_qeqpmj')
+            except NoSuchElementException:
+                return result.find_element_by_css_selector('div:nth-child(1) > h4 > a')

--- a/pages/search.py
+++ b/pages/search.py
@@ -13,9 +13,7 @@ class SearchPage(OSFBasePage):
     url = settings.OSF_HOME + '/search/'
 
     identity = Locator(By.CSS_SELECTOR, 'div[data-analytics-scope="Search page main"]')
-    search_input = Locator(
-        By.CSS_SELECTOR, '.ember-text-field.ember-view._search-input_fvrbco'
-    )
+    search_input = Locator(By.CSS_SELECTOR, 'input[data-test-search-input]')
     search_button = Locator(By.CSS_SELECTOR, 'button[data-test-search-submit]')
     loading_indicator = Locator(By.CSS_SELECTOR, '.ball-scale')
     projects_tab_link = Locator(
@@ -43,11 +41,13 @@ class SearchPage(OSFBasePage):
     )
 
     # Group Locators
-    search_results = GroupLocator(By.CSS_SELECTOR, '._result-card-container_qeqpmj')
+    search_results = GroupLocator(By.CSS_SELECTOR, 'div[data-test-search-result-card]')
 
     def get_first_non_withdrawn_registration(self):
         for result in self.search_results:
             try:
                 result.find_element_by_class_name('_withdrawn-label_qeqpmj')
             except NoSuchElementException:
-                return result.find_element_by_css_selector('div:nth-child(1) > h4 > a')
+                return result.find_element_by_css_selector(
+                    'a[data-test-search-result-card-title]'
+                )

--- a/tests/test_registries.py
+++ b/tests/test_registries.py
@@ -57,7 +57,7 @@ class TestRegistriesSearch:
         search_page.loading_indicator.here_then_gone()
         WebDriverWait(driver, 10).until(
             EC.visibility_of_element_located(
-                (By.CSS_SELECTOR, '._result-card-container_qeqpmj')
+                (By.CSS_SELECTOR, 'div[data-test-search-result-card]')
             )
         )
         assert search_page.search_input.get_attribute('value') == 'QA Test'
@@ -98,7 +98,7 @@ class TestRegistriesSearch:
         search_page.loading_indicator.here_then_gone()
         WebDriverWait(driver, 10).until(
             EC.visibility_of_element_located(
-                (By.CSS_SELECTOR, '._result-card-container_qeqpmj')
+                (By.CSS_SELECTOR, 'div[data-test-search-result-card]')
             )
         )
         assert len(search_page.search_results) > 0

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -43,7 +43,7 @@ class TestSearchPage:
         )
         assert len(search_page.search_results) > 0
         # Verify that first search result is of Project type
-        assert search_page.first_card_object_type_label.text[:7] == 'Project'
+        assert search_page.first_card_object_type_label.text[:7] == 'PROJECT'
 
     def test_search_results_exist_registrations_tab(self, driver, search_page):
         search_page.search_input.send_keys('test')
@@ -59,7 +59,7 @@ class TestSearchPage:
         )
         assert len(search_page.search_results) > 0
         # Verify that first search result is of Registration type
-        assert search_page.first_card_object_type_label.text[:12] == 'Registration'
+        assert search_page.first_card_object_type_label.text[:12] == 'REGISTRATION'
 
     def test_search_results_exist_preprints_tab(self, driver, search_page):
         search_page.search_input.send_keys('test')
@@ -75,7 +75,7 @@ class TestSearchPage:
         )
         assert len(search_page.search_results) > 0
         # Verify that first search result is of Preprint type
-        assert search_page.first_card_object_type_label.text == 'Preprint'
+        assert search_page.first_card_object_type_label.text == 'PREPRINT'
 
     def test_search_results_exist_files_tab(self, driver, search_page):
         search_page.search_input.send_keys('test')
@@ -91,7 +91,7 @@ class TestSearchPage:
         )
         assert len(search_page.search_results) > 0
         # Verify that first search result is of File type
-        assert search_page.first_card_object_type_label.text == 'File'
+        assert search_page.first_card_object_type_label.text == 'FILE'
 
     def test_search_results_exist_users_tab(self, driver, search_page):
         search_page.loading_indicator.here_then_gone()
@@ -105,4 +105,4 @@ class TestSearchPage:
         )
         assert len(search_page.search_results) > 0
         # Verify that first search result is of User type
-        assert search_page.first_card_object_type_label.text == 'User'
+        assert search_page.first_card_object_type_label.text == 'USER'

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -1,5 +1,8 @@
 import pytest
+from selenium.webdriver.common.by import By
 from selenium.webdriver.common.keys import Keys
+from selenium.webdriver.support import expected_conditions as EC
+from selenium.webdriver.support.ui import WebDriverWait
 
 import markers
 from pages.search import SearchPage
@@ -15,8 +18,91 @@ def search_page(driver):
 class TestSearchPage:
     @markers.smoke_test
     @markers.core_functionality
-    def test_search_results_exist(self, search_page):
-        search_page.search_bar.send_keys('*')
-        search_page.search_bar.send_keys(Keys.ENTER)
+    def test_search_results_exist_all_tab(self, driver, search_page):
+        search_page.search_input.send_keys('test')
+        search_page.search_input.send_keys(Keys.ENTER)
         search_page.loading_indicator.here_then_gone()
-        assert search_page.search_results
+        WebDriverWait(driver, 10).until(
+            EC.visibility_of_element_located(
+                (By.CSS_SELECTOR, '._result-card-container_qeqpmj')
+            )
+        )
+        assert len(search_page.search_results) > 0
+
+    def test_search_results_exist_projects_tab(self, driver, search_page):
+        search_page.search_input.send_keys('test')
+        search_page.search_input.send_keys(Keys.ENTER)
+        search_page.loading_indicator.here_then_gone()
+        # Switch to the Projects Tab
+        search_page.projects_tab_link.click()
+        search_page.loading_indicator.here_then_gone()
+        WebDriverWait(driver, 10).until(
+            EC.visibility_of_element_located(
+                (By.CSS_SELECTOR, '._result-card-container_qeqpmj')
+            )
+        )
+        assert len(search_page.search_results) > 0
+        # Verify that first search result is of Project type
+        assert search_page.first_card_object_type_label.text[:7] == 'Project'
+
+    def test_search_results_exist_registrations_tab(self, driver, search_page):
+        search_page.search_input.send_keys('test')
+        search_page.search_input.send_keys(Keys.ENTER)
+        search_page.loading_indicator.here_then_gone()
+        # Switch to the Registrations Tab
+        search_page.registrations_tab_link.click()
+        search_page.loading_indicator.here_then_gone()
+        WebDriverWait(driver, 10).until(
+            EC.visibility_of_element_located(
+                (By.CSS_SELECTOR, '._result-card-container_qeqpmj')
+            )
+        )
+        assert len(search_page.search_results) > 0
+        # Verify that first search result is of Registration type
+        assert search_page.first_card_object_type_label.text[:12] == 'Registration'
+
+    def test_search_results_exist_preprints_tab(self, driver, search_page):
+        search_page.search_input.send_keys('test')
+        search_page.search_input.send_keys(Keys.ENTER)
+        search_page.loading_indicator.here_then_gone()
+        # Switch to the Preprints Tab
+        search_page.preprints_tab_link.click()
+        search_page.loading_indicator.here_then_gone()
+        WebDriverWait(driver, 10).until(
+            EC.visibility_of_element_located(
+                (By.CSS_SELECTOR, '._result-card-container_qeqpmj')
+            )
+        )
+        assert len(search_page.search_results) > 0
+        # Verify that first search result is of Preprint type
+        assert search_page.first_card_object_type_label.text == 'Preprint'
+
+    def test_search_results_exist_files_tab(self, driver, search_page):
+        search_page.search_input.send_keys('test')
+        search_page.search_input.send_keys(Keys.ENTER)
+        search_page.loading_indicator.here_then_gone()
+        # Switch to the Files Tab
+        search_page.files_tab_link.click()
+        search_page.loading_indicator.here_then_gone()
+        WebDriverWait(driver, 10).until(
+            EC.visibility_of_element_located(
+                (By.CSS_SELECTOR, '._result-card-container_qeqpmj')
+            )
+        )
+        assert len(search_page.search_results) > 0
+        # Verify that first search result is of File type
+        assert search_page.first_card_object_type_label.text == 'File'
+
+    def test_search_results_exist_users_tab(self, driver, search_page):
+        search_page.loading_indicator.here_then_gone()
+        # Switch to the Users Tab
+        search_page.users_tab_link.click()
+        search_page.loading_indicator.here_then_gone()
+        WebDriverWait(driver, 10).until(
+            EC.visibility_of_element_located(
+                (By.CSS_SELECTOR, '._result-card-container_qeqpmj')
+            )
+        )
+        assert len(search_page.search_results) > 0
+        # Verify that first search result is of User type
+        assert search_page.first_card_object_type_label.text == 'User'

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -24,7 +24,7 @@ class TestSearchPage:
         search_page.loading_indicator.here_then_gone()
         WebDriverWait(driver, 10).until(
             EC.visibility_of_element_located(
-                (By.CSS_SELECTOR, '._result-card-container_qeqpmj')
+                (By.CSS_SELECTOR, 'div[data-test-search-result-card]')
             )
         )
         assert len(search_page.search_results) > 0
@@ -38,7 +38,7 @@ class TestSearchPage:
         search_page.loading_indicator.here_then_gone()
         WebDriverWait(driver, 10).until(
             EC.visibility_of_element_located(
-                (By.CSS_SELECTOR, '._result-card-container_qeqpmj')
+                (By.CSS_SELECTOR, 'div[data-test-search-result-card]')
             )
         )
         assert len(search_page.search_results) > 0
@@ -54,7 +54,7 @@ class TestSearchPage:
         search_page.loading_indicator.here_then_gone()
         WebDriverWait(driver, 10).until(
             EC.visibility_of_element_located(
-                (By.CSS_SELECTOR, '._result-card-container_qeqpmj')
+                (By.CSS_SELECTOR, 'div[data-test-search-result-card]')
             )
         )
         assert len(search_page.search_results) > 0
@@ -70,7 +70,7 @@ class TestSearchPage:
         search_page.loading_indicator.here_then_gone()
         WebDriverWait(driver, 10).until(
             EC.visibility_of_element_located(
-                (By.CSS_SELECTOR, '._result-card-container_qeqpmj')
+                (By.CSS_SELECTOR, 'div[data-test-search-result-card]')
             )
         )
         assert len(search_page.search_results) > 0
@@ -86,7 +86,7 @@ class TestSearchPage:
         search_page.loading_indicator.here_then_gone()
         WebDriverWait(driver, 10).until(
             EC.visibility_of_element_located(
-                (By.CSS_SELECTOR, '._result-card-container_qeqpmj')
+                (By.CSS_SELECTOR, 'div[data-test-search-result-card]')
             )
         )
         assert len(search_page.search_results) > 0
@@ -100,7 +100,7 @@ class TestSearchPage:
         search_page.loading_indicator.here_then_gone()
         WebDriverWait(driver, 10).until(
             EC.visibility_of_element_located(
-                (By.CSS_SELECTOR, '._result-card-container_qeqpmj')
+                (By.CSS_SELECTOR, 'div[data-test-search-result-card]')
             )
         )
         assert len(search_page.search_results) > 0


### PR DESCRIPTION
<!-- Before you submit your Pull Request, please confirm that:

     - Any test that will create public data either has the `QAtest` tag or the `dont_run_on_production` marker
     - `core_functionality` is marked as such
     - Your tests will be able to run on *all* servers (all stagings, test)
 -->


## Purpose
To update existing tests in the selenium suite to accommodate changes from the Search Improvements Project Phase 1


## Summary of Changes

- pages/registries.py - update locator for the OSF Registries Landing page and remove elements from the RegistriesDiscoverPage class that are no longer necessary. NOTE: Even though the OSF Registries Discover page is being deprecated with phase 1 of the project, it is still necessary to keep the RegistriesDiscoverPage class for the Branded Registries Discover pages, which will be redesigned in a future phase.
- pages/search.py - updates and additions necessary after the redesign of the OSF Search page
- tests/test_registries.py - renaming of test class from TestRegistriesDiscoverPage to TestRegistriesSearch and refactor of both existing tests to use search functionality of the new OSF Search page instead of the OSF Registries Discover page.
- tests/test_search.py - renaming and refactoring of test_search_results_exist to test_search_results_exist_all_tab and addition of 5 new tests: test_search_results_exist_projects_tab, test_search_results_exist_registrations_tab, test_search_results_exist_preprints_tab, test_search_results_exist_files_tab, and test_search_results_exist_users_tab


## Reviewer's Actions
`git fetch <remote> pull/251/head:testFix/search-improvements`

Run this test using
`tests/test_registries.py::TestRegistriesSearch -s -v`
`tests/test_search.py -s -v`

## Testing Changes Moving Forward
N/A


## Ticket
ENG-4581: SEL: Updates for Search Improvements Project Phase 1
https://openscience.atlassian.net/browse/ENG-4581
