### PR TITLE
[ENG-4973] Fix requests version to limit urllib3 version 

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ pytest==3.5.0
 flake8==3.9.2
 flake8-quotes==3.2.0
 autopep8==1.3.3
-requests>=2.20.0
+requests==2.29.0
 pythosf==0.0.9
 environs==3.0.0
 faker==0.9.0


### PR DESCRIPTION
<!-- Before you submit your Pull Request, please confirm that:

     - Any test that will create public data either has the `QAtest` tag or the `dont_run_on_production` marker
     - `core_functionality` is marked as such
     - Your tests will be able to run on *all* servers (all stagings, test)
 -->


## Purpose
Updated requests version to limit urllib3 version

## Summary of Changes
- Updated `requests` version to 2.29.0
- This is the last version of `requests` that support urllib3 1.x


## Reviewer's Actions
`git fetch <remote> pull/253/head:fix/requirements`

Run this test using
`pip uninstall urllib3`
`pip uninstall requests`
`pip3 install -r requirements.txt`
`pytest tests/test_login.py -s -v`


## Testing Changes Moving Forward



## Ticket

https://openscience.atlassian.net/browse/ENG-4973
