### PR TITLE
[ENG-5016] change reqs pin to work with python3.6

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,8 @@ pytest==3.5.0
 flake8==3.9.2
 flake8-quotes==3.2.0
 autopep8==1.3.3
-requests==2.29.0
+requests>=2.20.0
+urllib3<2
 pythosf==0.0.9
 environs==3.0.0
 faker==0.9.0


### PR DESCRIPTION
 * Revert our old requests pin version from ==2.29.0 to >=2.20.0. Our github actions are currently running under python3.6, which does not support 2.29.0.

 * Pin urllib3 to <2 per the suggestion at [1]. That appears to work on both python3.6 and python3.9.

 [1] https://github.com/psf/requests/releases/tag/v2.30.0

## Purpose

Unbork borkumed github actions.  Our old dep pin didn't work on the ancient version of python we run on GA.

## Summary of Changes

* Swap back old `requests` pin version.
* Pin `urllib3` to `<2`

## Reviewer's Actions
`git fetch <remote> pull/<PR_number>/head:<branch_name>`

Run this test using
`tests/<name_of_test>.py -s -v`

## Testing Changes Moving Forward

None expected, should just (hopefully) be an unbreakum.

## Ticket

[ENG-5016(https://openscience.atlassian.net/browse/ENG-5016)
