### PR TITLE
Refactor addons test to parameterize the addon providers

### DIFF
--- a/pages/project.py
+++ b/pages/project.py
@@ -51,6 +51,9 @@ class ProjectPage(GuidBasePage):
     make_public_link = Locator(By.LINK_TEXT, 'Make Public')
     make_private_link = Locator(By.LINK_TEXT, 'Make Private')
     loading_indicator = Locator(By.CSS_SELECTOR, '.ball-pulse')
+
+    # top level files & folders
+    fangorn_row = Locator(By.CSS_SELECTOR, '[data-level="3"]')
     add_component_button = Locator(
         By.CSS_SELECTOR, '#newComponent > span > div.btn.btn-sm.btn-default'
     )

--- a/settings.py
+++ b/settings.py
@@ -77,6 +77,7 @@ EXPECTED_PROVIDERS = env.list(
         'googledrive',
         'osfstorage',
         'onedrive',
+        'owncloud',
         's3',
     ],
 )

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -116,25 +116,20 @@ class TestProjectDetailPage:
         not settings.PREFERRED_NODE,
         reason='Only run this test if addons are set up on a specific node.',
     )
-    def test_addon_files_load(self, project_page, session, driver):
-        """This test is very fragile and makes assumptions about your setup.
-        You must have all of the addons in `EXPECTED_PROVIDERS` connected to your `PREFERRED_NODE`.
+    @pytest.mark.parametrize('provider', settings.EXPECTED_PROVIDERS)
+    def test_addon_files_load(self, project_page, session, driver, provider):
+        """This test is fragile and makes some assumptions about your setup.
+        You must have all the addons in `EXPECTED_PROVIDERS` connected to your `PREFERRED_NODE`.
         In each provider you must have a file named `<provider_name>.txt`.
-
-        The test will fail if you do not have the expected providers connected.
-        The test will also fail if you have not named your files correctly.
         """
-        providers = osf_api.get_node_addons(session, project_page.guid)
-        assert set(providers) == set(settings.EXPECTED_PROVIDERS)
         project_page.file_widget.loading_indicator.here_then_gone()
         project_page.file_widget.file_expander.here_then_gone()
         project_page.file_widget.filter_button.click()
-        for provider in providers:
-            project_page.file_widget.filter_input.clear()
-            project_page.file_widget.filter_input.send_keys_deliberately(provider)
-            driver.find_element_by_xpath(
-                "//*[contains(text(), '{}')]".format(provider + '.txt')
-            )
+        project_page.file_widget.filter_input.clear()
+        project_page.file_widget.filter_input.send_keys_deliberately(provider)
+        driver.find_element_by_xpath(
+            "//*[contains(text(), '{}')]".format(provider + '.txt')
+        )
 
 
 @pytest.mark.usefixtures('must_be_logged_in_as_user_two')

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -122,12 +122,18 @@ class TestProjectDetailPage:
         You must have all the addons in `EXPECTED_PROVIDERS` connected to your `PREFERRED_NODE`.
         In each provider you must have a file named `<provider_name>.txt`.
         """
-        project_page.file_widget.loading_indicator.here_then_gone()
-        project_page.file_widget.file_expander.here_then_gone()
+        # scroll down enough so the viewer can see the full files widget
+        project_page.scroll_into_view(project_page.log_widget.log_feed.element)
+
+        # Wait for the rows with content to show up in the files widget
+        WebDriverWait(driver, 10).until(EC.visibility_of(project_page.fangorn_row))
         project_page.file_widget.filter_button.click()
         project_page.file_widget.filter_input.clear()
         project_page.file_widget.filter_input.send_keys_deliberately(provider)
-        driver.find_element_by_xpath(
+
+        # Wait for a small (but not zero) amount of time after typing in the filter to wait for results to show
+        WebDriverWait(driver, 5).until(EC.visibility_of(project_page.fangorn_row))
+        assert driver.find_element_by_xpath(
             "//*[contains(text(), '{}')]".format(provider + '.txt')
         )
 


### PR DESCRIPTION
<!-- Before you submit your Pull Request, please confirm that:

     - Any test that will create public data either has the `QAtest` tag or the `dont_run_on_production` marker
     - `core_functionality` is marked as such
     - Your tests will be able to run on *all* servers (all stagings, test)
 -->


## Purpose
Refactor addons test to verify each addon provider is connected properly. Breaking down selenium tests into smaller components makes them more reliable and easier to troubleshoot in the future. 


## Summary of Changes
- Parameterize addons from settings configs


## Reviewer's Actions
`git fetch <remote> pull/259/head:fix/addons`

Run this test using
`pytest tests/test_project.py::TestProjectDetailPage::test_addon_files_load -sv -m smoke_test`

## Testing Changes Moving Forward
N/A


## Ticket

https://openscience.atlassian.net/browse/ENG-5088
