### PR TITLE
Update data-test locators for preprints to eow rework

### DIFF
--- a/pages/preprints.py
+++ b/pages/preprints.py
@@ -270,7 +270,6 @@ class PreprintDetailPage(GuidBasePage, BasePreprintPage):
         settings.LONG_TIMEOUT,
     )
 
-    # This locator needs a data-test-selector from software devs
     title = Locator(
         By.CSS_SELECTOR, 'h1[data-test-preprint-title]', settings.LONG_TIMEOUT
     )
@@ -280,7 +279,6 @@ class PreprintDetailPage(GuidBasePage, BasePreprintPage):
     download_button = Locator(By.CSS_SELECTOR, '[data-test-download-button]')
     edit_preprint_button = Locator(By.CSS_SELECTOR, 'div[class="edit-preprint-button"]')
     default_citation = Locator(By.CSS_SELECTOR, '[data-test-default-citation="apa"]')
-    response_404 = Locator(By.CSS_SELECTOR, 'pre[style]')
 
     # Locators for the reviews app preprint detail page
     status = Locator(By.CSS_SELECTOR, 'span._status-badge_7ivjq4')

--- a/pages/preprints.py
+++ b/pages/preprints.py
@@ -266,14 +266,26 @@ class PreprintDetailPage(GuidBasePage, BasePreprintPage):
     url_base = urljoin(settings.OSF_HOME, '{guid}')
     identity = Locator(
         By.CSS_SELECTOR,
-        '[data-analytics-scope="preprints detail page"]',
+        '[data-test-preprint-header]',
         settings.LONG_TIMEOUT,
     )
 
     # This locator needs a data-test-selector from software devs
-    title = Locator(By.CSS_SELECTOR, 'h1', settings.LONG_TIMEOUT)
+    title = Locator(
+        By.CSS_SELECTOR, 'h1[data-test-preprint-title]', settings.LONG_TIMEOUT
+    )
+    view_page = Locator(By.ID, 'view-page')
+    views_count = Locator(By.CSS_SELECTOR, '[data-test-view-count]')
+    downloads_count = Locator(By.CSS_SELECTOR, '[data-test-download-count]')
+    download_button = Locator(By.CSS_SELECTOR, '[data-test-download-button]')
+    edit_preprint_button = Locator(By.CSS_SELECTOR, 'div[class="edit-preprint-button"]')
+    default_citation = Locator(By.CSS_SELECTOR, '[data-test-default-citation="apa"]')
+    response_404 = Locator(By.CSS_SELECTOR, 'pre[style]')
+
+    # Locators for the reviews app preprint detail page
     status = Locator(By.CSS_SELECTOR, 'span._status-badge_7ivjq4')
     status_explanation = Locator(By.CSS_SELECTOR, 'div.status-explanation')
+    withdraw_reason = Locator(By.CSS_SELECTOR, '[data-test-withdrawal-justification]')
     make_decision_button = Locator(
         By.CSS_SELECTOR, 'button.btn.dropdown-toggle.btn-success'
     )
@@ -282,19 +294,11 @@ class PreprintDetailPage(GuidBasePage, BasePreprintPage):
     withdraw_radio_button = Locator(By.CSS_SELECTOR, 'input[value="withdrawn"]')
     reason_textarea = Locator(By.CSS_SELECTOR, 'textarea.form-control.ember-text-area')
     submit_decision_button = Locator(By.ID, 'submit-btn')
-    view_page = Locator(By.ID, 'view-page')
-    views_downloads_counts = Locator(
-        By.CSS_SELECTOR, 'div.share-row.p-sm.osf-box-lt.clearfix > div'
-    )
-    download_button = Locator(
-        By.CSS_SELECTOR, 'div.share-row.p-sm.osf-box-lt.clearfix > a'
-    )
-    edit_preprint_button = Locator(By.CSS_SELECTOR, 'div[class="edit-preprint-button"]')
 
     # Group Locators
     subjects = GroupLocator(
         By.CSS_SELECTOR,
-        '#view-page > div.container > div > div.col-md-5 > div:nth-child(6) > span',
+        '[class="subject-preview"]',
     )
     tags = GroupLocator(By.CSS_SELECTOR, 'div.tag-section.p-t-xs > span')
 

--- a/pages/preprints.py
+++ b/pages/preprints.py
@@ -413,7 +413,7 @@ class ReviewsWithdrawalsPage(BaseReviewsPage):
             url = row.find_element_by_css_selector('a').get_attribute('href')
             node_id = url.split(provider_id + '/', 1)[1]
             if node_id == preprint_id:
-                row.click()
+                row.find_element_by_css_selector('div[title]').click()
                 break
 
 

--- a/tests/test_preprints.py
+++ b/tests/test_preprints.py
@@ -580,7 +580,10 @@ class TestPreprintModeration:
         assert PreprintDetailPage(driver, verify=True)
         WebDriverWait(driver, 5).until(EC.visibility_of(preprint_page.title))
         assert preprint_page.title.text == preprint_title
-        # Add assert for "This preprint has been withdrawn" after [ENG-5092] is fixed.
+        # TODO: Re-enable assert after [ENG-5092] is fixed.
+        # assert (
+        #         preprint_page.status_explanation.text == 'This preprint has been withdrawn.'
+        # )
         assert preprint_page.withdraw_reason.present()
 
     def test_decline_withdrawal_request_pre_moderated_preprint(
@@ -844,7 +847,10 @@ class TestPreprintModeration:
         assert PreprintDetailPage(driver, verify=True)
         WebDriverWait(driver, 5).until(EC.visibility_of(preprint_page.title))
         assert preprint_page.title.text == preprint_title
-        # Add assert for "This preprint has been withdrawn" after [ENG-5092] is fixed.
+        # TODO: Re-enable assert after [ENG-5092] is fixed.
+        # assert (
+        #         preprint_page.status_explanation.text == 'This preprint has been withdrawn.'
+        # )
         assert preprint_page.withdraw_reason.present()
 
     def test_approve_withdrawal_request_post_moderated_preprint(
@@ -1097,15 +1103,6 @@ class TestPreprintMetrics:
         preprint_page.goto()
         assert PreprintDetailPage(driver, verify=True)
 
-        # Preprint page shows a string on the front end and api returns a non-string value from the db
-        assert preprint_page.views_count.text == str(api_views_count)
-        # Wait for most of the page to finish loading before reloading page
-        WebDriverWait(driver, 10).until(
-            EC.visibility_of(preprint_page.default_citation)
-        )
-        # "response 404 (backend NotFound), service rules for the path non-existent"
-        # error message shows when the preprint fails to load
-        assert not preprint_page.response_404
         # Don't reload the page in Production since we don't want to artificially
         # inflate the metrics
         if not settings.PRODUCTION:
@@ -1138,7 +1135,7 @@ class TestPreprintMetrics:
         preprint_page = PreprintDetailPage(driver, guid=latest_preprint_node)
         preprint_page.goto()
         assert PreprintDetailPage(driver, verify=True)
-        assert str(api_downloads_count) == preprint_page.downloads_count.text
+        assert api_downloads_count == int(preprint_page.downloads_count.text)
         # Don't download the Preprint in Production since we don't want to artificially
         # inflate the metrics
         if not settings.PRODUCTION:


### PR DESCRIPTION
<!-- Before you submit your Pull Request, please confirm that:

     - Any test that will create public data either has the `QAtest` tag or the `dont_run_on_production` marker
     - `core_functionality` is marked as such
     - Your tests will be able to run on *all* servers (all stagings, test)
 -->


## Purpose
Update our selenium test to match the new Preprint `data-test` css selectors.

During testing we discovered a pagination bug [ENG-5129] that was failing the preprints moderation workflows. We documented the bug and found a better locator to continue running our moderation tests while we wait for the bug to be resolved. 


## Summary of Changes
- Update to new `data-test` locators
- Unblock tests that were waiting on [ENG-5046] and [ENG-5055]
- Preprints moderation tests update

## Reviewer's Actions
`git fetch <remote> pull/160/head:feature/data-test-preprints`

Run this test using
`pytest tests/test_preprints.py -sv`
`pytest tests/test_navbar.py -sv`

## Testing Changes Moving Forward
N/A


## Ticket

https://openscience.atlassian.net/browse/ENG-5046


[ENG-5046]: https://openscience.atlassian.net/browse/ENG-5046?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ENG-5055]: https://openscience.atlassian.net/browse/ENG-5055?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[ENG-5129]: https://openscience.atlassian.net/browse/ENG-5129?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ