### PR TITLE
[ENG-5113] Update GH actions to run on python3.9

### DIFF
--- a/.github/workflows/nightly_core_functionality_tests.yml
+++ b/.github/workflows/nightly_core_functionality_tests.yml
@@ -49,7 +49,7 @@ jobs:
     if: "!contains(github.event.head_commit.message, 'skip ci')"
     strategy:
       matrix:
-        python-version: [3.6]
+        python-version: [3.9]
     steps:
       - name: Git checkout
         uses: actions/checkout@v3
@@ -83,10 +83,10 @@ jobs:
         browser: [chrome, firefox, edge]
     steps:
       - uses: actions/checkout@v3
-      - name: Set up Python 3.6
+      - name: Set up Python 3.9
         uses: actions/setup-python@v4
         with:
-          python-version: 3.6
+          python-version: 3.9
       - name: Cache pip
         uses: actions/cache@v3
         with:

--- a/.github/workflows/nightly_core_functionality_tests.yml
+++ b/.github/workflows/nightly_core_functionality_tests.yml
@@ -52,14 +52,14 @@ jobs:
         python-version: [3.9]
     steps:
       - name: Git checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Cache Build Requirements
         id: pip-cache-step
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ${{ env.pythonLocation }}
           key: ${{ env.GHA_DISTRO }}-${{ env.pythonLocation }}-${{ hashFiles('requirements.txt') }}
@@ -82,13 +82,13 @@ jobs:
       matrix:
         browser: [chrome, firefox, edge]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python 3.9
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: 3.9
       - name: Cache pip
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ${{ env.pythonLocation }}
           key: ${{ env.GHA_DISTRO }}-${{ env.pythonLocation }}-${{ hashFiles('requirements.txt') }}

--- a/.github/workflows/nightly_core_functionality_tests.yml
+++ b/.github/workflows/nightly_core_functionality_tests.yml
@@ -67,7 +67,6 @@ jobs:
         if: steps.pip-cache-step.outputs.cache-hit != 'true'
         run: |
           python -m pip install --upgrade pip
-          python -m pip install "setuptools<58.0.0"
           pip install -r requirements.txt
           invoke requirements
 

--- a/.github/workflows/nightly_core_functionality_tests.yml
+++ b/.github/workflows/nightly_core_functionality_tests.yml
@@ -67,7 +67,7 @@ jobs:
         if: steps.pip-cache-step.outputs.cache-hit != 'true'
         run: |
           python -m pip install --upgrade pip
-          python install "setuptools<58.0.0"
+          python -m pip install "setuptools<58.0.0"
           pip install -r requirements.txt
           invoke requirements
 

--- a/.github/workflows/nightly_core_functionality_tests.yml
+++ b/.github/workflows/nightly_core_functionality_tests.yml
@@ -67,6 +67,7 @@ jobs:
         if: steps.pip-cache-step.outputs.cache-hit != 'true'
         run: |
           python -m pip install --upgrade pip
+          python install "setuptools<58.0.0"
           pip install -r requirements.txt
           invoke requirements
 

--- a/.github/workflows/production_smoke_tests.yml
+++ b/.github/workflows/production_smoke_tests.yml
@@ -48,14 +48,14 @@ jobs:
         python-version: [3.9]
     steps:
       - name: Git checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Cache Build Requirements
         id: pip-cache-step
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ${{ env.pythonLocation }}
           key: ${{ env.GHA_DISTRO }}-${{ env.pythonLocation }}-${{ hashFiles('requirements.txt') }}
@@ -78,13 +78,13 @@ jobs:
       matrix:
         browser: [chrome, firefox, edge]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python 3.9
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: 3.9
       - name: Cache pip
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ${{ env.pythonLocation }}
           key: ${{ env.GHA_DISTRO }}-${{ env.pythonLocation }}-${{ hashFiles('requirements.txt') }}

--- a/.github/workflows/production_smoke_tests.yml
+++ b/.github/workflows/production_smoke_tests.yml
@@ -45,7 +45,7 @@ jobs:
     if: "!contains(github.event.head_commit.message, 'skip ci')"
     strategy:
       matrix:
-        python-version: [3.6]
+        python-version: [3.9]
     steps:
       - name: Git checkout
         uses: actions/checkout@v3
@@ -79,10 +79,10 @@ jobs:
         browser: [chrome, firefox, edge]
     steps:
       - uses: actions/checkout@v3
-      - name: Set up Python 3.6
+      - name: Set up Python 3.9
         uses: actions/setup-python@v4
         with:
-          python-version: 3.6
+          python-version: 3.9
       - name: Cache pip
         uses: actions/cache@v3
         with:

--- a/.github/workflows/two_minute_drill.yml
+++ b/.github/workflows/two_minute_drill.yml
@@ -58,7 +58,7 @@ jobs:
     if: "!contains(github.event.head_commit.message, 'skip ci')"
     strategy:
       matrix:
-        python-version: [3.6]
+        python-version: [3.9]
     steps:
       - name: Git checkout
         uses: actions/checkout@v3
@@ -90,10 +90,10 @@ jobs:
       max-parallel: 1  # run in series
     steps:
       - uses: actions/checkout@v3
-      - name: Set up Python 3.6
+      - name: Set up Python 3.9
         uses: actions/setup-python@v4
         with:
-          python-version: 3.6
+          python-version: 3.9
       - name: Cache pip
         uses: actions/cache@v3
         with:

--- a/.github/workflows/two_minute_drill.yml
+++ b/.github/workflows/two_minute_drill.yml
@@ -61,14 +61,14 @@ jobs:
         python-version: [3.9]
     steps:
       - name: Git checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Cache Build Requirements
         id: pip-cache-step
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ${{ env.pythonLocation }}
           key: ${{ env.GHA_DISTRO }}-${{ env.pythonLocation }}-${{ hashFiles('requirements.txt') }}
@@ -89,13 +89,13 @@ jobs:
       fail-fast: false
       max-parallel: 1  # run in series
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python 3.9
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: 3.9
       - name: Cache pip
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ${{ env.pythonLocation }}
           key: ${{ env.GHA_DISTRO }}-${{ env.pythonLocation }}-${{ hashFiles('requirements.txt') }}

--- a/.github/workflows/weekly_regression_tests.yml
+++ b/.github/workflows/weekly_regression_tests.yml
@@ -90,7 +90,7 @@ jobs:
     if: "!contains(github.event.head_commit.message, 'skip ci')"
     strategy:
       matrix:
-        python-version: [3.6]
+        python-version: [3.9]
     steps:
       - name: Git checkout
         uses: actions/checkout@v3
@@ -157,10 +157,10 @@ jobs:
         browser: ${{ fromJson(needs.set_matrix.outputs.matrix) }}
     steps:
       - uses: actions/checkout@v3
-      - name: Set up Python 3.6
+      - name: Set up Python 3.9
         uses: actions/setup-python@v4
         with:
-          python-version: 3.6
+          python-version: 3.9
       - name: Cache pip
         uses: actions/cache@v3
         with:

--- a/.github/workflows/weekly_regression_tests.yml
+++ b/.github/workflows/weekly_regression_tests.yml
@@ -93,14 +93,14 @@ jobs:
         python-version: [3.9]
     steps:
       - name: Git checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Cache Build Requirements
         id: pip-cache-step
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ${{ env.pythonLocation }}
           key: ${{ env.GHA_DISTRO }}-${{ env.pythonLocation }}-${{ hashFiles('requirements.txt') }}
@@ -156,13 +156,13 @@ jobs:
       matrix:
         browser: ${{ fromJson(needs.set_matrix.outputs.matrix) }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python 3.9
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: 3.9
       - name: Cache pip
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ${{ env.pythonLocation }}
           key: ${{ env.GHA_DISTRO }}-${{ env.pythonLocation }}-${{ hashFiles('requirements.txt') }}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,3 @@
-# to build ipdb on python3.9
-# https://stackoverflow.com/questions/72414481/error-in-anyjson-setup-command-use-2to3-is-invalid
-setuptools<58.0.0
-
 invoke==0.15.0
 selenium==3.141.0
 pytest==3.5.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,7 @@
+# to build ipdb on python3.9
+# https://stackoverflow.com/questions/72414481/error-in-anyjson-setup-command-use-2to3-is-invalid
+setuptools<58.0.0
+
 invoke==0.15.0
 selenium==3.141.0
 pytest==3.5.0
@@ -13,7 +17,3 @@ pre-commit==2.14.0
 ipdb==0.12.2
 black==22.3.0
 isort==5.9.3
-
-# to build ipdb on python3.9
-# https://stackoverflow.com/questions/72414481/error-in-anyjson-setup-command-use-2to3-is-invalid
-setuptools<58.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,7 @@ pre-commit==2.14.0
 ipdb==0.12.2
 black==22.3.0
 isort==5.9.3
+
+# to build ipdb on python3.9
+# https://stackoverflow.com/questions/72414481/error-in-anyjson-setup-command-use-2to3-is-invalid
+setuptools<58.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,6 @@ pythosf==0.0.9
 environs==3.0.0
 faker==0.9.0
 pre-commit==2.14.0
-ipdb==0.12.2
+ipdb==0.13.13
 black==22.3.0
 isort==5.9.3


### PR DESCRIPTION
## Purpose

Update selenium test suite to run on python 3.9 in github actions.

## Summary of Changes

* Update selenium test suite to run on python 3.9 in github actions.
* Bump ipdb dep so that it will install on python3.9
* Bump versions of `checkout`, `setup-python`, and `cache` GH actions. The prior versions are deprecated.

## Reviewer's Actions

Kick off a Workflow run for our workflows and verify that it runs successfully.

## Testing Changes Moving Forward

None expected.

## Ticket

https://openscience.atlassian.net/browse/ENG-5113
