### PR TITLE
[ENG-5139] Added navbar tests to collections and projects details pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,7 @@ cover/
 .konchrc
 *.pyc
 *.log
+.python-version
 
 # Private Info
 variables.py

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@ repos:
       # Should be a command that runs python3.6+
       language_version: python3
 - repo: https://github.com/pycqa/isort
-  rev: 5.9.3
+  rev: 5.11.5
   hooks:
   - id: isort
     args: ["--profile=black",

--- a/components/navbars.py
+++ b/components/navbars.py
@@ -29,6 +29,7 @@ class HomeNavbar(BaseElement):
     sign_up_button = Locator(By.CSS_SELECTOR, 'a.btn-success:nth-child(1)')
     sign_in_button = Locator(By.CSS_SELECTOR, '.btn-top-login')
     current_service = Locator(By.CSS_SELECTOR, '#navbarScope .current-service > strong')
+    projectdetails_my_project_link = Locator(By.XPATH, '//a[text()="My Projects"]')
 
     def verify(self):
         return len(self.driver.find_elements(By.ID, 'navbarScope')) == 1

--- a/pages/collections.py
+++ b/pages/collections.py
@@ -46,10 +46,11 @@ class CollectionDiscoverPage(BaseCollectionPage):
 
     identity = Locator(By.CSS_SELECTOR, 'div[data-test-provider-branding]')
     loading_indicator = Locator(By.CSS_SELECTOR, '.ball-scale')
-    search_link =Locator(By.XPATH, '//span[text()="Search"]')
+    search_link = Locator(By.XPATH, '//span[text()="Search"]')
     donate_link = Locator(By.XPATH, '//a[text()="Donate"]')
     collections_my_projects_link = Locator(By.XPATH, '//a[text()="My OSF Projects"]')
-    add_to_collections_link=Locator(By.XPATH, '//span[text()="Add to Collection"]')
+    add_to_collections_link = Locator(By.XPATH, '//span[text()="Add to Collection"]')
+
 
 class CollectionSubmitPage(BaseCollectionPage):
     url_addition = 'submit'
@@ -117,9 +118,9 @@ class CollectionEditPage(BaseCollectionPage):
     @property
     def url(self):
         return (
-            urljoin(self.base_url, self.provider_id)
-            + '/'
-            + self.url_addition.format(guid=self.guid)
+                urljoin(self.base_url, self.provider_id)
+                + '/'
+                + self.url_addition.format(guid=self.guid)
         )
 
 

--- a/pages/collections.py
+++ b/pages/collections.py
@@ -46,7 +46,10 @@ class CollectionDiscoverPage(BaseCollectionPage):
 
     identity = Locator(By.CSS_SELECTOR, 'div[data-test-provider-branding]')
     loading_indicator = Locator(By.CSS_SELECTOR, '.ball-scale')
-
+    search_link =Locator(By.XPATH, '//span[text()="Search"]')
+    donate_link = Locator(By.XPATH, '//a[text()="Donate"]')
+    collections_my_projects_link = Locator(By.XPATH, '//a[text()="My OSF Projects"]')
+    add_to_collections_link=Locator(By.XPATH, '//span[text()="Add to Collection"]')
 
 class CollectionSubmitPage(BaseCollectionPage):
     url_addition = 'submit'

--- a/pages/collections.py
+++ b/pages/collections.py
@@ -118,9 +118,9 @@ class CollectionEditPage(BaseCollectionPage):
     @property
     def url(self):
         return (
-                urljoin(self.base_url, self.provider_id)
-                + '/'
-                + self.url_addition.format(guid=self.guid)
+            urljoin(self.base_url, self.provider_id)
+            + '/'
+            + self.url_addition.format(guid=self.guid)
         )
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,4 +12,4 @@ faker==0.9.0
 pre-commit==2.14.0
 ipdb==0.13.13
 black==22.3.0
-isort==5.9.3
+isort==5.11.5

--- a/tests/test_navbar.py
+++ b/tests/test_navbar.py
@@ -398,15 +398,15 @@ class TestProjectsNavbarLoggedIn:
         page.goto()
         return page
 
-    def test_search_link(self, session, driver, page, fake):
+    def test_search_link(self, session, driver, page):
         page.navbar.search_link.click()
         SearchPage(driver, verify=True)
 
-    def test_support_link(self, session, driver, page, fake):
+    def test_support_link(self, session, driver, page):
         page.navbar.support_link.click()
         SupportPage(driver, verify=True)
 
-    def test_donate_link(self, session, driver, page, fake):
+    def test_donate_link(self, session, driver, page):
         page.navbar.donate_link.click()
         donate_page = COSDonatePage(driver, verify=False)
         assert_donate_page(driver, donate_page)

--- a/tests/test_navbar.py
+++ b/tests/test_navbar.py
@@ -319,6 +319,7 @@ def assert_donate_page(driver, donate_page):
     assert meta_tag.get_attribute('property') == 'og:title'
     assert meta_tag.get_attribute('content') == 'Support COS'
 
+
 @markers.smoke_test
 @markers.core_functionality
 class TestCollectionsNavbarLoggedOut():
@@ -327,20 +328,21 @@ class TestCollectionsNavbarLoggedOut():
         return osf_api.get_provider(type='collections', provider_id='selenium')
 
     @pytest.fixture()
-    def collectionsdiscover_page(self, driver, provider):
+    def collections_discover_page(self, driver, provider):
         discover_page = CollectionDiscoverPage(driver, provider=provider)
         discover_page.goto()
         discover_page.loading_indicator.here_then_gone()
         return discover_page
 
-    def test_search_link(self, driver, collectionsdiscover_page):
-        collectionsdiscover_page.search_link.click()
+    def test_search_link(self, driver, collections_discover_page):
+        collections_discover_page.search_link.click()
         assert 'discover' in driver.current_url
 
-    def test_donate_link(self, session, driver, collectionsdiscover_page):
-        collectionsdiscover_page.donate_link.click()
+    def test_donate_link(self, session, driver, collections_discover_page):
+        collections_discover_page.donate_link.click()
         donate_page = COSDonatePage(driver, verify=False)
         assert_donate_page(driver, donate_page)
+
 
 @markers.smoke_test
 @markers.core_functionality
@@ -380,19 +382,15 @@ class TestCollectionsNavbarLoggedIn():
 @pytest.mark.usefixtures('log_in_if_not_already')
 class TestProjectsNavbarLoggedIn():
     @pytest.fixture()
-    def project_page(self,driver, default_project_page):
-         default_project_page.goto()
-         return default_project_page
+    def project_page(self, driver, default_project_page):
+        default_project_page.goto()
+        return default_project_page
 
     @pytest.fixture()
     def page(self, driver, project_with_file):
         page = ProjectPage(driver, guid=project_with_file.id)
         page.goto()
         return page
-
-    def test_my_projects_link(self, page, driver, fake):
-        page.navbar.projectdetails_my_project_link.click()
-        assert MyProjectsPage(driver, verify=True)
 
     def test_search_link(self, session, driver, page, fake):
         page.navbar.search_link.click()
@@ -406,5 +404,3 @@ class TestProjectsNavbarLoggedIn():
         page.navbar.donate_link.click()
         donate_page = COSDonatePage(driver, verify=False)
         assert_donate_page(driver, donate_page)
-
-

--- a/tests/test_navbar.py
+++ b/tests/test_navbar.py
@@ -1,6 +1,7 @@
 import pytest
 
 import markers
+import settings
 from api import osf_api
 from pages.collections import (
     CollectionDiscoverPage,
@@ -331,7 +332,10 @@ def assert_donate_page(driver, donate_page):
 class TestCollectionsNavbarLoggedOut:
     @pytest.fixture
     def provider(self, driver):
-        return osf_api.get_provider(type='collections', provider_id='selenium')
+        if settings.DOMAIN == 'prod':
+            return osf_api.get_provider(type='collections', provider_id='metascience')
+        else:
+            return osf_api.get_provider(type='collections', provider_id='selenium')
 
     @pytest.fixture()
     def collections_discover_page(self, driver, provider):
@@ -356,7 +360,10 @@ class TestCollectionsNavbarLoggedOut:
 class TestCollectionsNavbarLoggedIn:
     @pytest.fixture
     def provider(self, driver):
-        return osf_api.get_provider(type='collections', provider_id='selenium')
+        if settings.DOMAIN == 'prod':
+            return osf_api.get_provider(type='collections', provider_id='metascience')
+        else:
+            return osf_api.get_provider(type='collections', provider_id='selenium')
 
     @pytest.fixture()
     def page(self, driver, provider):

--- a/tests/test_navbar.py
+++ b/tests/test_navbar.py
@@ -1,4 +1,6 @@
 import pytest
+from selenium.webdriver.support import expected_conditions as EC
+from selenium.webdriver.support.wait import WebDriverWait
 
 import markers
 import settings
@@ -341,7 +343,7 @@ class TestCollectionsNavbarLoggedOut:
     def collections_discover_page(self, driver, provider):
         discover_page = CollectionDiscoverPage(driver, provider=provider)
         discover_page.goto()
-        discover_page.loading_indicator.here_then_gone()
+        WebDriverWait(driver, 5).until(EC.visibility_of(discover_page.identity))
         return discover_page
 
     def test_search_link(self, driver, collections_discover_page):
@@ -369,7 +371,7 @@ class TestCollectionsNavbarLoggedIn:
     def page(self, driver, provider):
         discover_page = CollectionDiscoverPage(driver, provider=provider)
         discover_page.goto()
-        discover_page.loading_indicator.here_then_gone()
+        WebDriverWait(driver, 5).until(EC.visibility_of(discover_page.identity))
         return discover_page
 
     def test_my_projects_link(self, page, driver):

--- a/tests/test_navbar.py
+++ b/tests/test_navbar.py
@@ -2,6 +2,10 @@ import pytest
 
 import markers
 from api import osf_api
+from pages.collections import (
+    CollectionDiscoverPage,
+    CollectionSubmitPage,
+)
 from pages.cos import COSDonatePage
 from pages.dashboard import DashboardPage
 from pages.institutions import InstitutionsLandingPage
@@ -14,14 +18,16 @@ from pages.preprints import (
     PreprintSubmitPage,
     ReviewsDashboardPage,
 )
-from pages.project import MyProjectsPage, ProjectPage
+from pages.project import (
+    MyProjectsPage,
+    ProjectPage,
+)
 from pages.register import RegisterPage
 from pages.registrations import MyRegistrationsPage
 from pages.registries import (
     RegistrationAddNewPage,
     RegistriesLandingPage,
 )
-from pages.collections import CollectionDiscoverPage, CollectionSubmitPage
 from pages.search import SearchPage
 from pages.support import SupportPage
 from pages.user import (
@@ -322,7 +328,7 @@ def assert_donate_page(driver, donate_page):
 
 @markers.smoke_test
 @markers.core_functionality
-class TestCollectionsNavbarLoggedOut():
+class TestCollectionsNavbarLoggedOut:
     @pytest.fixture
     def provider(self, driver):
         return osf_api.get_provider(type='collections', provider_id='selenium')
@@ -347,7 +353,7 @@ class TestCollectionsNavbarLoggedOut():
 @markers.smoke_test
 @markers.core_functionality
 @pytest.mark.usefixtures('log_in_if_not_already')
-class TestCollectionsNavbarLoggedIn():
+class TestCollectionsNavbarLoggedIn:
     @pytest.fixture
     def provider(self, driver):
         return osf_api.get_provider(type='collections', provider_id='selenium')
@@ -380,7 +386,7 @@ class TestCollectionsNavbarLoggedIn():
 @markers.smoke_test
 @markers.core_functionality
 @pytest.mark.usefixtures('log_in_if_not_already')
-class TestProjectsNavbarLoggedIn():
+class TestProjectsNavbarLoggedIn:
     @pytest.fixture()
     def project_page(self, driver, default_project_page):
         default_project_page.goto()


### PR DESCRIPTION
## Purpose
Update our selenium test to add new navbar tests to collections discover page and project details page

Product team requested to add these tests to verify search, donate and support link on project details page and collections discover page.

## Summary of Changes

For Collections-

- Updated collections.py - added few locators for Search, Add to collections and Donate buttons
- test_navbar.py — Added new classes TestCollectionsNavbarLoggedOut and TestCollectionsNavbarLoggedIn

For Project Details page

Updated test_navbar.py- Added new tests
navbars.py- Added locator for my_projects link 
 

## Reviewer's Actions
`git fetch <remote> pull/262/head:feature/add-navbartests-to-collections-project`

Run this test using
`pytest tests/test_navbar.py::TestCollectionsNavbarLoggedIn -sv `
`pytest tests/test_navbar.py::TestCollectionsNavbarLoggedOut -sv `
`pytest tests/test_navbar.py::TestProjectsNavbarLoggedIn -sv `

## Testing Changes Moving Forward
N/A


## Ticket

https://openscience.atlassian.net/browse/ENG-5139
