### PR TITLE
Added file metadata tests

### DIFF
--- a/api/osf_api.py
+++ b/api/osf_api.py
@@ -1073,8 +1073,8 @@ def get_existing_file_data(session, node_id=settings.PREFERRED_NODE):
 
 
 def update_custom_project_metadata(session, node_id):
-    """Updates project metadata fields resource_type,
-    resource_language  and support funder information with custom values"""
+    """Updates project metadata fields resource_type and
+    resource_language and support funder info with custom values"""
     url = 'v2/custom_item_metadata_records/{}/'.format(node_id)
     raw_payload = {
         'data': {
@@ -1148,7 +1148,7 @@ def get_most_recent_registration_node_id_by_user(user_name, session):
 
 
 def update_registration_metadata_with_custom_data(registration_id):
-    """Updates project metadata fields resource_type,
+    """Updates project metadata fields resource_type and
     resource_language and support funder info with custom values"""
     session = client.Session(
         api_base_url=settings.API_DOMAIN,
@@ -1171,3 +1171,15 @@ def update_registration_metadata_with_custom_data(registration_id):
         item_type='registrations',
         item_id=registration_id,
     )
+
+
+def get_funder_data_project(session, project_guid):
+    """Returns the funder name for a project/registration
+    if project/registration already has funder information data
+    otherwise returns none"""
+
+    url = 'v2/custom_item_metadata_records/{}/'.format(project_guid)
+    data = session.get(url)['data']
+    if not data['attributes']['funders']:
+        return None
+    return data['attributes']['funders'][0]['funder_name']

--- a/api/osf_api.py
+++ b/api/osf_api.py
@@ -1070,3 +1070,62 @@ def get_existing_file_data(session, node_id=settings.PREFERRED_NODE):
     data = session.get(files_url + 'osfstorage/')
     name = data['data'][0]['attributes']['name']
     return name, data
+
+
+def update_custom_project_metadata(session, node_id):
+    """Updates project metadata fields resource_type and
+    resource_language with custom values"""
+    url = 'v2/custom_item_metadata_records/{}/'.format(node_id)
+    raw_payload = {
+        'data': {
+            'id': node_id,
+            'type': 'custom-item-metadata-records',
+            'attributes': {
+                'language': 'eng',
+                'resource_type_general': 'Collection',
+                'funders': [
+                    {
+                        'funder_name': 'American Society for Quality',
+                        'funder_identifier': 'http://dx.doi.org/10.13039/100007495',
+                        'funder_identifier_type': 'Crossref Funder ID',
+                        'award_number': '',
+                        'award_uri': 'https://test.osf.io',
+                        'award_title': 'Quality Assurance Award',
+                    }
+                ],
+            },
+        }
+    }
+    session.put(url=url, raw_body=json.dumps(raw_payload))
+
+
+def delete_project_contributor(session, node_id, user_name):
+    """This method deletes the given contributor
+    from contributors of the given project guid"""
+
+    url = '/v2/nodes/{}/contributors/'.format(node_id)
+    data = session.get(url)['data']
+
+    for i in range(0, len(data)):
+        if data[i]['embeds']['users']['data']['attributes']['full_name'] == user_name:
+            user_id = data[i]['embeds']['users']['data']['id']
+            delete_url = '/v2/nodes/{}/contributors/{}/'.format(node_id, user_id)
+            session.delete(delete_url, item_type='users')
+            break
+
+
+def delete_registration_contributor(session, registration_id, user_name):
+    """This method deletes the given contributor
+    from contributors of the given project guid"""
+
+    url = '/v2/registrations/{}/contributors/'.format(registration_id)
+    data = session.get(url)['data']
+
+    for i in range(0, len(data)):
+        if data[i]['embeds']['users']['data']['attributes']['full_name'] == user_name:
+            user_id = data[i]['embeds']['users']['data']['id']
+            delete_url = '/v2/registrations/{}/contributors/{}/'.format(
+                registration_id, user_id
+            )
+            session.delete(delete_url, item_type='users')
+            break

--- a/api/osf_api.py
+++ b/api/osf_api.py
@@ -1105,8 +1105,8 @@ def delete_project_contributor(session, node_id, user_name):
 
 
 def update_registration_metadata_with_custom_data(registration_id):
-    """Updates project metadata fields resource_type and
-    resource_language and support funder info with custom values"""
+    """Updates registration metadata fields resource_type and
+    resource_language  with custom values"""
     session = client.Session(
         api_base_url=settings.API_DOMAIN,
         auth=(settings.REGISTRATIONS_USER, settings.REGISTRATIONS_USER_PASSWORD),
@@ -1166,9 +1166,33 @@ def get_registration_by_title(encoded_registration_title):
         auth=(settings.REGISTRATIONS_USER, settings.REGISTRATIONS_USER_PASSWORD),
     )
 
-    url = '/v2/registrations/?filter[title]=' + encoded_registration_title
+    url = '/v2/registrations/?filter[title] =' + encoded_registration_title
     data = session.get(url)['data']
     if data:
         return data[0]['id']
 
     return None
+
+
+def update_file_metadata(session, file_guid):
+    """Updates file metadata with custom values"""
+    url = 'v2/custom_file_metadata_records/{}/'.format(file_guid)
+    raw_payload = {
+        'data': {
+            'id': file_guid,
+            'type': 'custom-item-metadata-records',
+            'attributes': {
+                'language': 'eng',
+                'resource_type_general': 'Book',
+                'funders': [],
+                'title': 'Selenium Files metadata test',
+                'description': 'This File is created temporarily to verify Files metadata test',
+            },
+        }
+    }
+    session.patch(
+        url=url,
+        raw_body=json.dumps(raw_payload),
+        item_type='registrations',
+        item_id=file_guid,
+    )

--- a/api/osf_api.py
+++ b/api/osf_api.py
@@ -1083,16 +1083,6 @@ def update_custom_project_metadata(session, node_id):
             'attributes': {
                 'language': 'eng',
                 'resource_type_general': 'Collection',
-                'funders': [
-                    {
-                        'funder_name': 'American Society for Quality',
-                        'funder_identifier': 'http://dx.doi.org/10.13039/100007495',
-                        'funder_identifier_type': 'Crossref Funder ID',
-                        'award_number': '',
-                        'award_uri': 'https://test.osf.io',
-                        'award_title': 'Quality Assurance Award',
-                    }
-                ],
             },
         }
     }
@@ -1172,16 +1162,6 @@ def update_registration_metadata_with_custom_data(registration_id):
             'attributes': {
                 'language': 'eng',
                 'resource_type_general': 'Collection',
-                'funders': [
-                    {
-                        'funder_name': 'American Society for Quality',
-                        'funder_identifier': 'http://dx.doi.org/10.13039/100007495',
-                        'funder_identifier_type': 'Crossref Funder ID',
-                        'award_number': '',
-                        'award_uri': 'https://test.osf.io',
-                        'award_title': 'Quality Assurance Award',
-                    }
-                ],
             },
         }
     }

--- a/api/osf_api.py
+++ b/api/osf_api.py
@@ -1050,3 +1050,23 @@ def get_project_node_analytics_data(session, node_id=None, timespan='week'):
     url = '_/metrics/query/node_analytics/{}/{}/'.format(node_id, timespan)
     data = session.get(url)['data']
     return data or None
+
+
+def get_fake_file_guid(session, file_id):
+
+    url = '/v2/files' + file_id
+    data = session.get(url=url)
+    file_guid = data['data']['attributes']['guid']
+    return file_guid
+
+
+def get_existing_file_data(session, node_id=settings.PREFERRED_NODE):
+    """Return the id of the first file in OSFStorage on a given node.
+    Uploads a new file if one does not exist.
+    """
+    node = client.Node(session=session, id=node_id)
+    node.get()
+    files_url = node.relationships.files['links']['related']['href']
+    data = session.get(files_url + 'osfstorage/')
+    name = data['data'][0]['attributes']['name']
+    return name, data

--- a/api/osf_api.py
+++ b/api/osf_api.py
@@ -1104,24 +1104,6 @@ def delete_project_contributor(session, node_id, user_name):
             break
 
 
-def get_most_recent_registration_node_id_by_user(user_name, registration_card):
-    """Return the most recently approved public registration
-    node id by the given user and having the title as given in registration_card
-    """
-    session = client.Session(
-        api_base_url=settings.API_DOMAIN,
-        auth=(settings.REGISTRATIONS_USER, settings.REGISTRATIONS_USER_PASSWORD),
-    )
-    url = '/v2/registrations/?filter[title][icontains]=selenium'
-    data = session.get(url)['data']
-    if data:
-        for registration in data:
-            if registration['attributes']['title'] == registration_card:
-                return registration['id']
-
-    return None
-
-
 def update_registration_metadata_with_custom_data(registration_id):
     """Updates project metadata fields resource_type and
     resource_language and support funder info with custom values"""
@@ -1173,3 +1155,20 @@ def get_funder_data_registration(registration_guid):
     if not data['attributes']['funders']:
         return None
     return data['attributes']['funders'][0]['funder_name']
+
+
+def get_registration_by_title(encoded_registration_title):
+    """Return the registration node id having the title as given in encoded_registration_title
+    ToDo: Handle URL encoding in python
+    """
+    session = client.Session(
+        api_base_url=settings.API_DOMAIN,
+        auth=(settings.REGISTRATIONS_USER, settings.REGISTRATIONS_USER_PASSWORD),
+    )
+
+    url = '/v2/registrations/?filter[title]=' + encoded_registration_title
+    data = session.get(url)['data']
+    if data:
+        return data[0]['id']
+
+    return None

--- a/pages/project.py
+++ b/pages/project.py
@@ -490,3 +490,47 @@ class RegistrationsPage(GuidBasePage):
     delete_draft_registration_modal = ComponentLocator(
         ConfirmDeleteDraftRegistrationModal
     )
+
+
+class FilesMetadataPage(GuidBasePage):
+
+    base_url = settings.OSF_HOME + '/{guid}'
+
+    identity = Locator(By.CSS_SELECTOR, '[data-test-filename]', settings.LONG_TIMEOUT)
+    metadata_identity = Locator(By.CSS_SELECTOR, '[data-test-metadata-tab]')
+    heading = Locator(By.CSS_SELECTOR, '[h2._metadata-heading_oqi4qj]')
+    files_metadata_edit_button = Locator(
+        By.CSS_SELECTOR, '[data-test-edit-metadata-button]'
+    )
+    files_metadata_download_button = Locator(
+        By.CSS_SELECTOR, '[svg.svg-inline--fa.fa-download]'
+    )
+    files_metadata_title = Locator(By.CSS_SELECTOR, '[data-test-file-title]')
+    files_metadata_description = Locator(
+        By.CSS_SELECTOR, '[data-test-file-description]'
+    )
+    files_metadata_resource_type = Locator(
+        By.CSS_SELECTOR, '[data-test-file-resource-type]'
+    )
+    files_metadata_resource_language = Locator(
+        By.CSS_SELECTOR, '[data-test-file-language]'
+    )
+
+    files_metadata_edit_identity = Locator(
+        By.CSS_SELECTOR, '[div._metadata-pane_gdsp72]'
+    )
+    edit_title = Locator(By.CSS_SELECTOR, '[data-test-title-field]')
+    title_input = Locator(By.CSS_SELECTOR, '[data-test-title-field] textarea')
+    edit_description = Locator(By.CSS_SELECTOR, '[data-test-description-field]')
+    description_input = Locator(
+        By.CSS_SELECTOR,
+        '[textarea#ember148__title.ember-text-area.ember-view.form-control]',
+    )
+    resource_type = Locator(By.CSS_SELECTOR, '[data-test-select-resource-type]')
+    resource_type_option = Locator(By.XPATH, '//li/span[text()="Book"]')
+    resource_language = Locator(By.CSS_SELECTOR, '[data-test-select-resource-language]')
+    resource_language_option = Locator(By.XPATH, '//li/span[text()="English"]')
+    cancel_editing_button = Locator(
+        By.CSS_SELECTOR, '[data-test-cancel-editing-metadata-button]'
+    )
+    save_metadata_button = Locator(By.CSS_SELECTOR, '[data-test-save-metadata-button]')

--- a/pages/project.py
+++ b/pages/project.py
@@ -597,7 +597,7 @@ class ProjectMetadataPage(GuidBasePage):
     )
 
     funder_name = Locator(By.XPATH, '//span[@class="ember-power-select-status-icon"]')
-    funder_name_serach_input = Locator(
+    funder_name_search_input = Locator(
         By.XPATH, '//input[@class="ember-power-select-search-input"]'
     )
     award_title = Locator(By.XPATH, '//input[@name="award_title"]')

--- a/pages/project.py
+++ b/pages/project.py
@@ -527,10 +527,95 @@ class FilesMetadataPage(GuidBasePage):
         '[textarea#ember148__title.ember-text-area.ember-view.form-control]',
     )
     resource_type = Locator(By.CSS_SELECTOR, '[data-test-select-resource-type]')
-    resource_type_option = Locator(By.XPATH, '//li/span[text()="Book"]')
+
     resource_language = Locator(By.CSS_SELECTOR, '[data-test-select-resource-language]')
-    resource_language_option = Locator(By.XPATH, '//li/span[text()="English"]')
+    dropdown_options = GroupLocator(
+        By.CSS_SELECTOR,
+        '#ember-basic-dropdown-wormhole > div > ul > li>span',
+    )
+
+    def select_from_dropdown_listbox(self, selection):
+        for option in self.dropdown_options:
+            if option.text == selection:
+                option.click()
+                break
+
     cancel_editing_button = Locator(
         By.CSS_SELECTOR, '[data-test-cancel-editing-metadata-button]'
     )
     save_metadata_button = Locator(By.CSS_SELECTOR, '[data-test-save-metadata-button]')
+
+
+class ProjectMetadataPage(GuidBasePage):
+    base_url = settings.OSF_HOME + '/{guid}/metadata/osf'
+
+    identity = Locator(
+        By.CSS_SELECTOR, '[data-test-metadata-header]', settings.LONG_TIMEOUT
+    )
+    description = Locator(By.CSS_SELECTOR, '[data-test-display-node-description]')
+    save_description_button = Locator(
+        By.CSS_SELECTOR, '[data-test-save-node-description-button]'
+    )
+    cancel_description_button = Locator(
+        By.CSS_SELECTOR, '[data-test-cancel-editing-node-description-button]'
+    )
+    contributors_list = Locator(By.CSS_SELECTOR, '[data-test-contributor-name]')
+    edit_contributors_button = Locator(By.CSS_SELECTOR, '[data-test-edit-contributors]')
+    add_contributor_button = Locator(
+        By.CSS_SELECTOR, 'a.btn.btn-success.btn-sm.m-l-md[href="#addContributors"]'
+    )
+    contributor_search_button = Locator(By.XPATH, '//input[@class="btn btn-default"]')
+    add_displayed_contributor_button = Locator(
+        By.CSS_SELECTOR, '[a.btn.btn-success.contrib-button.btn-mini]'
+    )
+    search_input = Locator(By.XPATH, '//input[@class="form-control"]')
+    resource_type = Locator(
+        By.CSS_SELECTOR, '[data-test-display-resource-type-general]'
+    )
+    resource_language = Locator(
+        By.CSS_SELECTOR, '[data-test-display-resource-language]'
+    )
+    resource_type_dropdown = Locator(
+        By.CSS_SELECTOR, '[data-test-select-resource-type]'
+    )
+    resource_language_dropdown = Locator(
+        By.CSS_SELECTOR, '[data-test-select-resource-language]'
+    )
+
+    dropdown_options = GroupLocator(
+        By.CSS_SELECTOR,
+        '#ember-basic-dropdown-wormhole > div > ul > li>span',
+    )
+
+    def select_from_dropdown_listbox(self, selection):
+        for option in self.dropdown_options:
+            if option.text == selection:
+                option.click()
+                break
+
+    resource_information_save_button = Locator(
+        By.CSS_SELECTOR, '[data-test-save-resource-metadata-button]'
+    )
+
+    funder_name = Locator(By.XPATH, '//span[@class="ember-power-select-status-icon"]')
+    funder_name_serach_input = Locator(
+        By.XPATH, '//input[@class="ember-power-select-search-input"]'
+    )
+    award_title = Locator(By.XPATH, '//input[@name="award_title"]')
+    award_info_URI = Locator(By.XPATH, '//input[@name="award_uri"]')
+    award_number = Locator(By.XPATH, '//input[@name="award_number"]')
+    add_funder_button = Locator(By.XPATH, '//button[text()="Add funder"]')
+    delete_funder_button = Locator(By.XPATH, '//button[text()="Delete funder"][2]')
+    save_funder_info_button = Locator(
+        By.CSS_SELECTOR, '[data-test-save-funding-metadata-button]'
+    )
+    display_funder_name = Locator(By.CSS_SELECTOR, '[data-test-display-funder-name]')
+    display_award_title = Locator(
+        By.CSS_SELECTOR, '[data-test-display-funder-award-title]'
+    )
+    display_award_number = Locator(
+        By.CSS_SELECTOR, '[data-test-display-funder-award-number]'
+    )
+    dispaly_award_info_uri = Locator(
+        By.CSS_SELECTOR, '[data-test-display-funder-award-uri]'
+    )

--- a/pages/project.py
+++ b/pages/project.py
@@ -497,7 +497,6 @@ class FilesMetadataPage(GuidBasePage):
     base_url = settings.OSF_HOME + '/{guid}'
 
     identity = Locator(By.CSS_SELECTOR, '[data-test-filename]', settings.LONG_TIMEOUT)
-    metadata_identity = Locator(By.CSS_SELECTOR, '[data-test-metadata-tab]')
     heading = Locator(By.CSS_SELECTOR, '[h2._metadata-heading_oqi4qj]')
     files_metadata_edit_button = Locator(
         By.CSS_SELECTOR, '[data-test-edit-metadata-button]'

--- a/pages/registries.py
+++ b/pages/registries.py
@@ -103,6 +103,71 @@ class RegistrationMetadataPage(BaseSubmittedRegistrationPage):
     url_addition = 'metadata'
     identity = Locator(By.CSS_SELECTOR, '[data-test-display-resource-type-general]')
 
+    metadata_description = Locator(
+        By.CSS_SELECTOR, '[data-test-display-node-description]'
+    )
+    edit_metadata_description_button = Locator(
+        By.CSS_SELECTOR, '[data-test-edit-node-description-button]'
+    )
+    save_metadata_description_button = Locator(
+        By.CSS_SELECTOR, '[data-test-save-node-description-button]'
+    )
+    contributors_list = Locator(By.CSS_SELECTOR, '[data-test-contributors-list]')
+    contributor_search_button = Locator(By.XPATH, '//input[@class="btn btn-default"]')
+    add_displayed_contributor_button = Locator(
+        By.CSS_SELECTOR, '[a.btn.btn-success.contrib-button.btn-mini]'
+    )
+    search_input = Locator(By.XPATH, '//input[@class="form-control"]')
+    resource_type = Locator(
+        By.CSS_SELECTOR, '[data-test-display-resource-type-general]'
+    )
+    resource_language = Locator(
+        By.CSS_SELECTOR, '[data-test-display-resource-language]'
+    )
+    resource_type_dropdown = Locator(
+        By.CSS_SELECTOR, '[data-test-select-resource-type]'
+    )
+    resource_language_dropdown = Locator(
+        By.CSS_SELECTOR, '[data-test-select-resource-language]'
+    )
+
+    dropdown_options = GroupLocator(
+        By.CSS_SELECTOR,
+        '#ember-basic-dropdown-wormhole > div > ul > li>span',
+    )
+
+    def select_from_dropdown_listbox(self, selection):
+        for option in self.dropdown_options:
+            if option.text == selection:
+                option.click()
+                break
+
+    resource_information_save_button = Locator(
+        By.CSS_SELECTOR, '[data-test-save-resource-metadata-button]'
+    )
+    funder_name = Locator(By.XPATH, '//span[@class="ember-power-select-status-icon"]')
+    funder_name_serach_input = Locator(
+        By.XPATH, '//input[@class="ember-power-select-search-input"]'
+    )
+    award_title = Locator(By.XPATH, '//input[@name="award_title"]')
+    award_info_URI = Locator(By.XPATH, '//input[@name="award_uri"]')
+    award_number = Locator(By.XPATH, '//input[@name="award_number"]')
+    add_funder_button = Locator(By.XPATH, '//button[text()="Add funder"]')
+    delete_funder_button = Locator(By.XPATH, '//button[text()="Delete funder"][2]')
+    save_funder_info_button = Locator(
+        By.CSS_SELECTOR, '[data-test-save-funding-metadata-button]'
+    )
+    display_funder_name = Locator(By.CSS_SELECTOR, '[data-test-display-funder-name]')
+    display_award_title = Locator(
+        By.CSS_SELECTOR, '[data-test-display-funder-award-title]'
+    )
+    display_award_number = Locator(
+        By.CSS_SELECTOR, '[data-test-display-funder-award-number]'
+    )
+    dispaly_award_info_uri = Locator(
+        By.CSS_SELECTOR, '[data-test-display-funder-award-uri]'
+    )
+
 
 class RegistrationFilesListPage(BaseSubmittedRegistrationPage):
     url_addition = 'files'

--- a/pages/registries.py
+++ b/pages/registries.py
@@ -146,7 +146,7 @@ class RegistrationMetadataPage(BaseSubmittedRegistrationPage):
         By.CSS_SELECTOR, '[data-test-save-resource-metadata-button]'
     )
     funder_name = Locator(By.XPATH, '//span[@class="ember-power-select-status-icon"]')
-    funder_name_serach_input = Locator(
+    funder_name_search_input = Locator(
         By.XPATH, '//input[@class="ember-power-select-search-input"]'
     )
     award_title = Locator(By.XPATH, '//input[@name="award_title"]')

--- a/settings.py
+++ b/settings.py
@@ -54,6 +54,7 @@ DOMAIN = env('DOMAIN', 'stage1')
 
 NEW_USER_EMAIL = env('NEW_USER_EMAIL')
 
+
 # Preferred node must be set to run tests on production
 PREFERRED_NODE = env('PREFERRED_NODE', None)
 # Initialize Popular Pages environment variable to None which is what it should be for
@@ -146,6 +147,7 @@ STAGE2 = DOMAIN == 'stage2'
 STAGE3 = DOMAIN == 'stage3'
 TEST = DOMAIN == 'test'
 PRODUCTION = DOMAIN == 'prod'
+FUNDER_INFO_URL = 'https://staging-share.osf.io/api/v3/index-value-search?valueSearchPropertyPath=funder&acceptMediatype=application%2Fvnd.api%2Bjson'
 
 # Users for testing CAS login scemarios
 DEACTIVATED_USER = env('DEACTIVATED_USER')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -185,3 +185,12 @@ def default_project_with_metadata(session):
         osf_api.update_custom_project_metadata(session, node_id=project.id)
         yield project
         project.delete()
+
+
+@pytest.fixture(scope='class')
+def must_be_logged_in_as_registration_user(driver):
+    safe_login(
+        driver,
+        user=settings.REGISTRATIONS_USER,
+        password=settings.REGISTRATIONS_USER_PASSWORD,
+    )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -169,3 +169,19 @@ def project_with_file(session, default_project):
     else:
         osf_api.upload_fake_file(session, default_project)
     return default_project
+
+
+@pytest.fixture
+def default_project_with_metadata(session):
+    """Creates a new project through the api and returns it. Deletes the project at the end of the test run.
+    If PREFERRED_NODE is set, returns the APIDetail of preferred node.
+    """
+    if settings.PREFERRED_NODE:
+        project = osf_api.get_node(session)
+        osf_api.update_custom_project_metadata(session, node_id=project.id)
+        yield project
+    else:
+        project = osf_api.create_project(session, title='OSF Test Project')
+        osf_api.update_custom_project_metadata(session, node_id=project.id)
+        yield project
+        project.delete()

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -1,0 +1,283 @@
+import pytest
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support import expected_conditions as EC
+from selenium.webdriver.support.ui import WebDriverWait
+
+import markers
+import settings
+import utils
+from api import osf_api
+from pages.project import (
+    FilesMetadataPage,
+    FilesPage,
+)
+
+
+@pytest.fixture()
+def file_guid(driver, default_project, session, provider='osfstorage'):
+
+    node_id = default_project.id
+    node = osf_api.get_node(session, node_id=node_id)
+
+    if settings.PREFERRED_NODE:
+        new_file, metadata = osf_api.get_existing_file_data(session)
+        files_page = FilesPage(
+            driver, guid=settings.PREFERRED_NODE, addon_provider=provider
+        )
+        files_page.goto()
+        # Wait for File List items to load
+        WebDriverWait(driver, 15).until(
+            EC.visibility_of_element_located(
+                (By.CSS_SELECTOR, '[data-test-file-list-item]')
+            )
+        )
+        row = utils.find_row_by_name(files_page, new_file)
+
+        file_link = row.find_element_by_css_selector('[data-test-file-list-link]')
+        file_link.click()
+        driver.switch_to.window(driver.window_handles[0])
+        file_id = metadata['data'][0]['attributes']['path']
+
+    else:
+        new_file, metadata = osf_api.upload_fake_file(
+            session=session,
+            node=node,
+            name='files_metadata_test.txt',
+            provider=provider,
+        )
+        files_page = FilesPage(driver, guid=node_id, addon_provider=provider)
+        files_page.goto()
+        # Wait for File List items to load
+        WebDriverWait(driver, 15).until(
+            EC.visibility_of_element_located(
+                (By.CSS_SELECTOR, '[data-test-file-list-item]')
+            )
+        )
+        row = utils.find_row_by_name(files_page, new_file)
+
+        file_link = row.find_element_by_css_selector('[data-test-file-list-link]')
+        file_link.click()
+        driver.switch_to.window(driver.window_handles[0])
+        file_id = metadata['data']['attributes']['path']
+
+    file_guid = osf_api.get_fake_file_guid(session, file_id)
+    return file_guid
+
+
+@pytest.fixture()
+def file_metadata_page(driver, file_guid):
+    file_metadata_page = FilesMetadataPage(driver, guid=file_guid)
+    file_metadata_page.goto()
+    return file_metadata_page
+
+
+@pytest.mark.usefixtures('must_be_logged_in')
+class TestFilesMetadata:
+    @pytest.fixture()
+    def file_metadata_page_with_data(self, driver, file_metadata_page, fake):
+        title = fake.sentence(nb_words=1)
+        description = fake.sentence(nb_words=4)
+
+        file_metadata_page.files_metadata_edit_button.click()
+        file_metadata_page.edit_title.click()
+        title_input = driver.find_element_by_css_selector(
+            '[data-test-title-field] textarea'
+        )
+        title_input.send_keys(title)
+
+        description_input = driver.find_element_by_css_selector(
+            '[data-test-description-field] textarea'
+        )
+        description_input.send_keys(description)
+
+        file_metadata_page.resource_type.click()
+
+        WebDriverWait(driver, 5).until(
+            EC.visibility_of_element_located(
+                (By.CSS_SELECTOR, '[data-test-option="Book"]')
+            )
+        ).click()
+        file_metadata_page.resource_language.click()
+        WebDriverWait(driver, 5).until(
+            EC.visibility_of_element_located((By.XPATH, '//li/span[text()="English"]'))
+        ).click()
+
+        file_metadata_page.save_metadata_button.click()
+        return file_metadata_page
+
+    @markers.smoke_test
+    @markers.core_functionality
+    def test_change_file_metadata_title(
+        self, driver, file_metadata_page_with_data, fake
+    ):
+        """This test verifies that the file metadata field
+        title is editable and changes are saved."""
+
+        new_title = fake.sentence(nb_words=1)
+        orig_title = file_metadata_page_with_data.files_metadata_title.text
+        assert orig_title != new_title
+        WebDriverWait(driver, 5).until(
+            EC.element_to_be_clickable(
+                (By.CSS_SELECTOR, '[data-test-edit-metadata-button]')
+            )
+        ).click()
+
+        file_metadata_page_with_data.edit_title.click()
+        title_input = driver.find_element_by_css_selector(
+            '[data-test-title-field] textarea'
+        )
+        title_input.clear()
+        title_input.send_keys(new_title)
+
+        file_metadata_page_with_data.save_metadata_button.click()
+
+        assert new_title == file_metadata_page_with_data.files_metadata_title.text
+
+    @markers.smoke_test
+    @markers.core_functionality
+    def test_change_file_metadata_description(
+        self, driver, file_metadata_page_with_data, fake
+    ):
+        """This test verifies that the file metadata field
+        description is editable and changes are saved."""
+
+        new_description = fake.sentence(nb_words=1)
+        orig_description = file_metadata_page_with_data.files_metadata_description.text
+        assert orig_description != new_description
+
+        WebDriverWait(driver, 5).until(
+            EC.element_to_be_clickable(
+                (By.CSS_SELECTOR, '[data-test-edit-metadata-button]')
+            )
+        ).click()
+
+        description_input = driver.find_element_by_css_selector(
+            '[data-test-description-field] textarea'
+        )
+        description_input.clear()
+        description_input.send_keys(new_description)
+        file_metadata_page_with_data.save_metadata_button.click()
+        assert (
+            new_description
+            == file_metadata_page_with_data.files_metadata_description.text
+        )
+
+    @markers.smoke_test
+    @markers.core_functionality
+    def test_change_file_metadata_resource_type(
+        self, driver, file_metadata_page_with_data
+    ):
+        """This test verifies that the file metadata field
+        resource type is editable and changes are saved."""
+
+        orig_resource_type = (
+            file_metadata_page_with_data.files_metadata_resource_type.text
+        )
+
+        WebDriverWait(driver, 5).until(
+            EC.element_to_be_clickable(
+                (By.CSS_SELECTOR, '[data-test-edit-metadata-button]')
+            )
+        ).click()
+        file_metadata_page_with_data.resource_type.click()
+
+        WebDriverWait(driver, 5).until(
+            EC.visibility_of_element_located(
+                (By.CSS_SELECTOR, '[data-test-option="Collection"]')
+            )
+        ).click()
+
+        file_metadata_page_with_data.save_metadata_button.click()
+        assert (
+            orig_resource_type
+            != file_metadata_page_with_data.files_metadata_resource_type.text
+        )
+
+    @markers.smoke_test
+    @markers.core_functionality
+    def test_change_file_metadata_resource_language(
+        self, driver, file_metadata_page_with_data
+    ):
+        """This test verifies that the file metadata field
+        resource language is editable and changes are saved."""
+        orig_resource_language = (
+            file_metadata_page_with_data.files_metadata_resource_language.text
+        )
+
+        WebDriverWait(driver, 5).until(
+            EC.element_to_be_clickable(
+                (By.CSS_SELECTOR, '[data-test-edit-metadata-button]')
+            )
+        ).click()
+        file_metadata_page_with_data.resource_language.click()
+        WebDriverWait(driver, 5).until(
+            EC.visibility_of_element_located((By.XPATH, '//li/span[text()="Bengali"]'))
+        ).click()
+
+        file_metadata_page_with_data.save_metadata_button.click()
+        assert (
+            orig_resource_language
+            != file_metadata_page_with_data.files_metadata_resource_language.text
+        )
+
+    @markers.smoke_test
+    @markers.core_functionality
+    def test_cancel_file_metadata_changes(
+        self, driver, file_metadata_page_with_data, fake
+    ):
+        """This test verifies the file metadata fields
+        title, Description, Resource Type and Resource Language are editable
+        and changes can be cancelled without saving.
+        """
+        new_title = fake.sentence(nb_words=1)
+        orig_title = file_metadata_page_with_data.files_metadata_title.text
+        assert orig_title != new_title
+        WebDriverWait(driver, 5).until(
+            EC.element_to_be_clickable(
+                (By.CSS_SELECTOR, '[data-test-edit-metadata-button]')
+            )
+        ).click()
+
+        file_metadata_page_with_data.edit_title.click()
+        title_input = driver.find_element_by_css_selector(
+            '[data-test-title-field] textarea'
+        )
+        title_input.clear()
+        title_input.send_keys(new_title)
+        file_metadata_page_with_data.cancel_editing_button.click()
+        assert new_title != file_metadata_page_with_data.files_metadata_title.text
+
+    def test_download_file_metadata(self, driver, file_metadata_page_with_data):
+        """This test verifies download file metadata
+        functinality and verifies that latest downloaded
+        file exists in the folder
+        """
+        try:
+            WebDriverWait(driver, 5).until(
+                EC.element_to_be_clickable(
+                    (By.CSS_SELECTOR, '[data-test-download-button]')
+                )
+            ).click()
+
+            if '404' in driver.page_source:
+                raise Exception
+            else:
+                file_metadata_page_with_data.reload()
+                WebDriverWait(driver, 10).until(
+                    EC.visibility_of_element_located(
+                        (By.CSS_SELECTOR, '[data-test-filename')
+                    )
+                )
+                # Verify File Download Functionality
+                if settings.DRIVER != 'Remote':
+                    url = driver.find_element_by_css_selector(
+                        '[data-test-download-button]'
+                    ).get_attribute('href')
+                    guid = utils.get_guid_from_url(url, 3)
+                    filename = utils.latest_download_file()
+                    assert guid in filename
+                else:
+                    utils.verify_file_download(driver, file_name='')
+
+        except Exception:
+            print('404 Page not found error.')

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -478,7 +478,7 @@ class TestProjectMetadata:
             )
         )
         project_metadata_page.select_from_dropdown_listbox('Book')
-        # Select 'Benagli' from the resource language listbox
+        # Select 'Bengali' from the resource language listbox
         project_metadata_page.resource_language_dropdown.click()
         WebDriverWait(driver, 5).until(
             EC.element_to_be_clickable(
@@ -522,9 +522,9 @@ class TestProjectMetadata:
                     (By.XPATH, '//button[text()="Delete funder"]')
                 )
             ).click()
-        WebDriverWait(driver, 5).until(
-            EC.element_to_be_clickable((By.XPATH, '//button[text()="Add funder"]'))
-        ).click()
+            WebDriverWait(driver, 5).until(
+                EC.element_to_be_clickable((By.XPATH, '//button[text()="Add funder"]'))
+            ).click()
 
         project_metadata_page.funder_name.click()
 
@@ -544,6 +544,7 @@ class TestProjectMetadata:
         project_metadata_page.scroll_into_view(
             project_metadata_page.delete_funder_button.element
         )
+
         project_metadata_page.delete_funder_button.click()
         project_metadata_page.save_funder_info_button.click()
 
@@ -565,9 +566,9 @@ class TestProjectMetadata:
 class TestRegistrationMetadata:
     @pytest.fixture()
     def registration_metadata_page(self, driver, session):
-        registration_card = 'Selenium Registration for Metadata tests'
-        registration_guid = osf_api.get_most_recent_registration_node_id_by_user(
-            user_name='OSF Selenium Registrations', registration_card=registration_card
+
+        registration_guid = osf_api.get_registration_by_title(
+            'Selenium%20Registration%20for%20Metadata%20tests'
         )
         osf_api.update_registration_metadata_with_custom_data(
             registration_id=registration_guid
@@ -655,9 +656,8 @@ class TestRegistrationMetadata:
                 (By.CSS_SELECTOR, '[data-test-edit-funding-metadata-button]')
             )
         ).click()
-        registration_guid = osf_api.get_most_recent_registration_node_id_by_user(
-            user_name='OSF Selenium Registrations',
-            registration_card='Selenium Registration for Metadata tests',
+        registration_guid = osf_api.get_registration_by_title(
+            'Selenium%20Registration%20for%20Metadata%20tests'
         )
         funder_info = osf_api.get_funder_data_registration(registration_guid)
         if funder_info is None:
@@ -693,6 +693,7 @@ class TestRegistrationMetadata:
         registration_metadata_page.scroll_into_view(
             registration_metadata_page.delete_funder_button.element
         )
+
         registration_metadata_page.delete_funder_button.click()
 
         registration_metadata_page.save_funder_info_button.click()

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -82,7 +82,7 @@ def file_metadata_page(driver, file_guid):
 def get_funder_information(funder_name):
     """This method is used to get the funder information for the
     given funder name using api link"""
-    url = 'https://staging-share.osf.io/api/v3/index-value-search?valueSearchPropertyPath=funder&acceptMediatype=application%2Fvnd.api%2Bjson'
+    url = settings.FUNDER_INFO_URL
     response = requests.get(url)
     data = response.json()
     for funder in data['included']:
@@ -311,11 +311,8 @@ class TestFilesMetadata:
                 raise Exception
             else:
                 file_metadata_page_with_data.reload()
-                WebDriverWait(driver, 10).until(
-                    EC.visibility_of_element_located(
-                        (By.CSS_SELECTOR, '[data-test-filename')
-                    )
-                )
+                FilesMetadataPage(driver, verify=True)
+
                 # Verify File Download Functionality
                 if settings.DRIVER != 'Remote':
                     url = driver.find_element_by_css_selector(

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -522,10 +522,10 @@ class TestProjectMetadata:
                 (By.CSS_SELECTOR, '[data-test-edit-funding-metadata-button]')
             )
         ).click()
-
-        WebDriverWait(driver, 5).until(
-            EC.element_to_be_clickable((By.XPATH, '//button[text()="Add funder"]'))
-        ).click()
+        if settings.DOMAIN != 'prod':
+            WebDriverWait(driver, 5).until(
+                EC.element_to_be_clickable((By.XPATH, '//button[text()="Add funder"]'))
+            ).click()
 
         project_metadata_page.funder_name.click()
 
@@ -545,6 +545,7 @@ class TestProjectMetadata:
         project_metadata_page.scroll_into_view(
             project_metadata_page.delete_funder_button.element
         )
+
         project_metadata_page.delete_funder_button.click()
         project_metadata_page.save_funder_info_button.click()
 
@@ -659,10 +660,10 @@ class TestRegistrationMetadata:
                 (By.CSS_SELECTOR, '[data-test-edit-funding-metadata-button]')
             )
         ).click()
-
-        WebDriverWait(driver, 5).until(
-            EC.element_to_be_clickable((By.XPATH, '//button[text()="Add funder"]'))
-        ).click()
+        if settings.DOMAIN != 'prod':
+            WebDriverWait(driver, 5).until(
+                EC.element_to_be_clickable((By.XPATH, '//button[text()="Add funder"]'))
+            ).click()
 
         registration_metadata_page.funder_name.click()
 
@@ -684,8 +685,8 @@ class TestRegistrationMetadata:
             registration_metadata_page.delete_funder_button.element
         )
         registration_metadata_page.delete_funder_button.click()
-        registration_metadata_page.save_funder_info_button.click()
 
+        registration_metadata_page.save_funder_info_button.click()
         WebDriverWait(driver, 5).until(
             EC.visibility_of_element_located(
                 (By.CSS_SELECTOR, '[data-test-metadata-header]')

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -233,7 +233,7 @@ class TestFilesMetadata:
     def test_cancel_file_metadata_changes(self, driver, file_metadata_page, fake):
         """This test verifies the file metadata fields
         title, Description, Resource Type and Resource Language are editable
-        and changes can be cancelled without saving.
+        and changes are cancelled without saving.
         """
         new_title = fake.sentence(nb_words=1)
         orig_title = file_metadata_page.files_metadata_title.text
@@ -255,8 +255,13 @@ class TestFilesMetadata:
         file_metadata_tab = utils.switch_to_new_tab(driver)
         utils.close_current_tab(driver, file_metadata_tab)
 
+    @pytest.mark.skipif(
+        settings.env('TEST_BUILD') == 'edge',
+        reason='Test fails on remote edge browser because of download popup window',
+    )
     def test_download_file_metadata(self, driver, file_metadata_page):
-        """This test verifies download functinality."""
+        """This test verifies download functionality for file metadata."""
+
         try:
             WebDriverWait(driver, 5).until(
                 EC.element_to_be_clickable(

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -59,7 +59,7 @@ def file_guid(driver, default_project, session, provider='osfstorage'):
 
             files_page = FilesPage(driver, guid=node_id, addon_provider=provider)
             files_page.goto()
-            if '502' in driver.page_source:
+            if '404' in driver.page_source:
                 raise Exception
             else:
                 # Wait for File List items to load

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -59,7 +59,7 @@ def file_guid(driver, default_project, session, provider='osfstorage'):
 
             files_page = FilesPage(driver, guid=node_id, addon_provider=provider)
             files_page.goto()
-            if '404' in driver.page_source:
+            if '502' in driver.page_source:
                 raise Exception
             else:
                 # Wait for File List items to load

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -106,9 +106,10 @@ def get_funder_information(funder_name):
                 funder['attributes']['resourceMetadata']['name'][0]['@value']
                 == funder_name
             ):
-                award_title = funder['attributes']['resourceMetadata']['resourceType'][
-                    0
-                ]['@id']
+
+                award_title = funder['attributes']['resourceMetadata']['rdf:type'][0][
+                    '@id'
+                ]
                 award_uri = funder['attributes']['resourceIdentifier'][0]
                 award_number = funder['id']
 

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -115,6 +115,8 @@ def get_funder_information(funder_name):
 
 
 @pytest.mark.usefixtures('must_be_logged_in')
+@markers.smoke_test
+@markers.core_functionality
 class TestFilesMetadata:
     @pytest.fixture()
     def file_metadata_page_with_data(self, driver, file_metadata_page, fake):
@@ -158,8 +160,6 @@ class TestFilesMetadata:
         file_metadata_page.save_metadata_button.click()
         return file_metadata_page
 
-    @markers.smoke_test
-    @markers.core_functionality
     def test_change_file_metadata_title(
         self, driver, file_metadata_page_with_data, fake
     ):
@@ -186,8 +186,6 @@ class TestFilesMetadata:
         file_metadata_tab = utils.switch_to_new_tab(driver)
         utils.close_current_tab(driver, file_metadata_tab)
 
-    @markers.smoke_test
-    @markers.core_functionality
     def test_change_file_metadata_description(
         self, driver, file_metadata_page_with_data, fake
     ):
@@ -217,8 +215,6 @@ class TestFilesMetadata:
         file_metadata_tab = utils.switch_to_new_tab(driver)
         utils.close_current_tab(driver, file_metadata_tab)
 
-    @markers.smoke_test
-    @markers.core_functionality
     def test_change_file_metadata_resource_type(
         self, driver, file_metadata_page_with_data
     ):
@@ -254,8 +250,6 @@ class TestFilesMetadata:
         file_metadata_tab = utils.switch_to_new_tab(driver)
         utils.close_current_tab(driver, file_metadata_tab)
 
-    @markers.smoke_test
-    @markers.core_functionality
     def test_change_file_metadata_resource_language(
         self, driver, file_metadata_page_with_data
     ):
@@ -290,8 +284,6 @@ class TestFilesMetadata:
         file_metadata_tab = utils.switch_to_new_tab(driver)
         utils.close_current_tab(driver, file_metadata_tab)
 
-    @markers.smoke_test
-    @markers.core_functionality
     def test_cancel_file_metadata_changes(
         self, driver, file_metadata_page_with_data, fake
     ):
@@ -352,6 +344,8 @@ class TestFilesMetadata:
 
 
 @pytest.mark.usefixtures('must_be_logged_in')
+@markers.smoke_test
+@markers.core_functionality
 class TestProjectMetadata:
     @pytest.fixture()
     def project_metadata_page(self, driver, default_project_with_metadata):
@@ -361,8 +355,6 @@ class TestProjectMetadata:
         project_metadata_page.goto()
         return project_metadata_page
 
-    @markers.smoke_test
-    @markers.core_functionality
     def test_edit_metadata_description(self, driver, project_metadata_page, fake):
         """This test verifies that the node level metadata field
         description is editable and changes are saved."""
@@ -383,8 +375,6 @@ class TestProjectMetadata:
         project_metadata_page.save_description_button.click()
         assert new_description == project_metadata_page.description.text
 
-    @markers.smoke_test
-    @markers.core_functionality
     def test_edit_contributors(
         self, session, driver, project_metadata_page, default_project_with_metadata
     ):
@@ -465,8 +455,6 @@ class TestProjectMetadata:
         )
         assert new_user in user.text
 
-    @markers.smoke_test
-    @markers.core_functionality
     def test_edit_resource_information(self, driver, project_metadata_page):
         """This test verifies that user can add/remove
         resource information to project metadata."""
@@ -506,8 +494,6 @@ class TestProjectMetadata:
         assert orig_resource_type != project_metadata_page.resource_type.text
         assert orig_resource_language != project_metadata_page.resource_language.text
 
-    @markers.smoke_test
-    @markers.core_functionality
     def test_edit_support_funding_information(
         self, session, driver, project_metadata_page, default_project_with_metadata
     ):
@@ -522,7 +508,7 @@ class TestProjectMetadata:
                 (By.CSS_SELECTOR, '[data-test-edit-funding-metadata-button]')
             )
         ).click()
-
+        # Delete funder info if already exists
         funder_info = osf_api.get_funder_data_project(
             session, project_guid=default_project_with_metadata.id
         )
@@ -530,10 +516,19 @@ class TestProjectMetadata:
             WebDriverWait(driver, 5).until(
                 EC.element_to_be_clickable((By.XPATH, '//button[text()="Add funder"]'))
             ).click()
+        else:
+            WebDriverWait(driver, 5).until(
+                EC.element_to_be_clickable(
+                    (By.XPATH, '//button[text()="Delete funder"]')
+                )
+            ).click()
+        WebDriverWait(driver, 5).until(
+            EC.element_to_be_clickable((By.XPATH, '//button[text()="Add funder"]'))
+        ).click()
 
         project_metadata_page.funder_name.click()
 
-        project_metadata_page.funder_name_serach_input.send_keys(funder_name)
+        project_metadata_page.funder_name_search_input.send_keys(funder_name)
         WebDriverWait(driver, 10).until(
             EC.visibility_of_element_located(
                 (By.CSS_SELECTOR, '[data-option-index="0"]')
@@ -549,7 +544,6 @@ class TestProjectMetadata:
         project_metadata_page.scroll_into_view(
             project_metadata_page.delete_funder_button.element
         )
-
         project_metadata_page.delete_funder_button.click()
         project_metadata_page.save_funder_info_button.click()
 
@@ -566,11 +560,14 @@ class TestProjectMetadata:
 
 
 @pytest.mark.usefixtures('must_be_logged_in_as_registration_user')
+@markers.dont_run_on_prod
+@markers.core_functionality
 class TestRegistrationMetadata:
     @pytest.fixture()
     def registration_metadata_page(self, driver, session):
+        registration_card = 'Selenium Registration for Metadata tests'
         registration_guid = osf_api.get_most_recent_registration_node_id_by_user(
-            user_name='OSF Selenium Registrations', session=session
+            user_name='OSF Selenium Registrations', registration_card=registration_card
         )
         osf_api.update_registration_metadata_with_custom_data(
             registration_id=registration_guid
@@ -581,8 +578,6 @@ class TestRegistrationMetadata:
         registration_metadata_page.goto()
         return registration_metadata_page
 
-    @markers.smoke_test
-    @markers.core_functionality
     def test_edit_metadata_description(self, driver, registration_metadata_page, fake):
         """This test verifies that the registration metadata field
         description is editable and changes are saved."""
@@ -603,8 +598,6 @@ class TestRegistrationMetadata:
         registration_metadata_page.save_metadata_description_button.click()
         assert new_description == registration_metadata_page.metadata_description.text
 
-    @markers.smoke_test
-    @markers.core_functionality
     def test_edit_resource_information(self, driver, registration_metadata_page):
         """This test verifies that user can add/remove
         resource information to registration metadata."""
@@ -647,8 +640,6 @@ class TestRegistrationMetadata:
             orig_resource_language != registration_metadata_page.resource_language.text
         )
 
-    @markers.smoke_test
-    @markers.core_functionality
     def test_edit_support_funding_information(
         self, driver, registration_metadata_page, session
     ):
@@ -665,9 +656,10 @@ class TestRegistrationMetadata:
             )
         ).click()
         registration_guid = osf_api.get_most_recent_registration_node_id_by_user(
-            user_name='OSF Selenium Registrations', session=session
+            user_name='OSF Selenium Registrations',
+            registration_card='Selenium Registration for Metadata tests',
         )
-        funder_info = osf_api.get_funder_data_project(session, registration_guid)
+        funder_info = osf_api.get_funder_data_registration(registration_guid)
         if funder_info is None:
             WebDriverWait(driver, 5).until(
                 EC.element_to_be_clickable((By.XPATH, '//button[text()="Add funder"]'))
@@ -684,7 +676,7 @@ class TestRegistrationMetadata:
 
         registration_metadata_page.funder_name.click()
 
-        registration_metadata_page.funder_name_serach_input.send_keys(funder_name)
+        registration_metadata_page.funder_name_search_input.send_keys(funder_name)
         WebDriverWait(driver, 10).until(
             EC.visibility_of_element_located(
                 (By.CSS_SELECTOR, '[data-option-index="0"]')

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -167,10 +167,10 @@ class TestFilesMetadata:
         )
         title_input.clear()
         title_input.send_keys(new_title)
-
         file_metadata_page_with_data.save_metadata_button.click()
-
         assert new_title == file_metadata_page_with_data.files_metadata_title.text
+        file_metadata_tab = utils.switch_to_new_tab(driver)
+        utils.close_current_tab(driver, file_metadata_tab)
 
     @markers.smoke_test
     @markers.core_functionality
@@ -200,6 +200,8 @@ class TestFilesMetadata:
             new_description
             == file_metadata_page_with_data.files_metadata_description.text
         )
+        file_metadata_tab = utils.switch_to_new_tab(driver)
+        utils.close_current_tab(driver, file_metadata_tab)
 
     @markers.smoke_test
     @markers.core_functionality
@@ -235,6 +237,8 @@ class TestFilesMetadata:
             orig_resource_type
             != file_metadata_page_with_data.files_metadata_resource_type.text
         )
+        file_metadata_tab = utils.switch_to_new_tab(driver)
+        utils.close_current_tab(driver, file_metadata_tab)
 
     @markers.smoke_test
     @markers.core_functionality
@@ -269,6 +273,8 @@ class TestFilesMetadata:
             orig_resource_language
             != file_metadata_page_with_data.files_metadata_resource_language.text
         )
+        file_metadata_tab = utils.switch_to_new_tab(driver)
+        utils.close_current_tab(driver, file_metadata_tab)
 
     @markers.smoke_test
     @markers.core_functionality
@@ -296,6 +302,8 @@ class TestFilesMetadata:
         title_input.send_keys(new_title)
         file_metadata_page_with_data.cancel_editing_button.click()
         assert new_title != file_metadata_page_with_data.files_metadata_title.text
+        file_metadata_tab = utils.switch_to_new_tab(driver)
+        utils.close_current_tab(driver, file_metadata_tab)
 
     def test_download_file_metadata(self, driver, file_metadata_page_with_data):
         """This test verifies download functinality."""
@@ -326,6 +334,8 @@ class TestFilesMetadata:
 
         except Exception:
             logger.error('404 Exception caught')
+        file_metadata_tab = utils.switch_to_new_tab(driver)
+        utils.close_current_tab(driver, file_metadata_tab)
 
 
 @pytest.mark.usefixtures('must_be_logged_in')

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -509,7 +509,7 @@ class TestProjectMetadata:
     @markers.smoke_test
     @markers.core_functionality
     def test_edit_support_funding_information(
-        self, driver, project_metadata_page, fake
+        self, session, driver, project_metadata_page, default_project_with_metadata
     ):
         """This test verifies that user can add/remove
         funder information to project metadata."""
@@ -522,7 +522,11 @@ class TestProjectMetadata:
                 (By.CSS_SELECTOR, '[data-test-edit-funding-metadata-button]')
             )
         ).click()
-        if settings.DOMAIN != 'prod':
+
+        funder_info = osf_api.get_funder_data_project(
+            session, project_guid=default_project_with_metadata.id
+        )
+        if funder_info is None:
             WebDriverWait(driver, 5).until(
                 EC.element_to_be_clickable((By.XPATH, '//button[text()="Add funder"]'))
             ).click()
@@ -646,7 +650,7 @@ class TestRegistrationMetadata:
     @markers.smoke_test
     @markers.core_functionality
     def test_edit_support_funding_information(
-        self, driver, registration_metadata_page, fake
+        self, driver, registration_metadata_page, session
     ):
         """This test verifies that user can add/remove
         funder information to registration metadata."""
@@ -660,7 +664,20 @@ class TestRegistrationMetadata:
                 (By.CSS_SELECTOR, '[data-test-edit-funding-metadata-button]')
             )
         ).click()
-        if settings.DOMAIN != 'prod':
+        registration_guid = osf_api.get_most_recent_registration_node_id_by_user(
+            user_name='OSF Selenium Registrations', session=session
+        )
+        funder_info = osf_api.get_funder_data_project(session, registration_guid)
+        if funder_info is None:
+            WebDriverWait(driver, 5).until(
+                EC.element_to_be_clickable((By.XPATH, '//button[text()="Add funder"]'))
+            ).click()
+        else:
+            WebDriverWait(driver, 5).until(
+                EC.element_to_be_clickable(
+                    (By.XPATH, '//button[text()="Delete funder"]')
+                )
+            ).click()
             WebDriverWait(driver, 5).until(
                 EC.element_to_be_clickable((By.XPATH, '//button[text()="Add funder"]'))
             ).click()

--- a/utils.py
+++ b/utils.py
@@ -181,3 +181,25 @@ def get_guid_from_url(url, itemno):
     url_string_list = url.split('/')
     guid = url_string_list[itemno]
     return guid
+
+
+def read_data_from_table(driver, table_path, check_match, item_match=None):
+    datalist = []
+    table_data = driver.find_element_by_xpath(table_path)
+    path1 = table_path + '/tbody/tr'
+    rows = table_data.find_elements_by_xpath(path1)
+    rlen = len(rows)
+
+    for i in range(1, rlen + 1):
+        path2 = path1 + '[' + str(i) + ']/td'
+        items = driver.find_elements_by_xpath(path2)
+        clen = len(items)
+        for j in range(1, clen + 1):
+            path3 = path2 + '[' + str(j) + ']'
+            cell_data = driver.find_element_by_xpath(path3).text
+            datalist.append(cell_data)
+            if check_match:
+                if item_match in cell_data:
+                    return i, datalist
+
+    return rlen, datalist


### PR DESCRIPTION
<!-- Before you submit your Pull Request, please confirm that:

     - Any test that will create public data either has the `QAtest` tag or the `dont_run_on_production` marker
     - `core_functionality` is marked as such
     - Your tests will be able to run on *all* servers (all stagings, test)
 -->


## Purpose
Add the following checks to the selenium test automation suite:

1. First Test: Edit Metadata Tab
- Title field
- Description field
- Resource Type field
- Resource Language field

2. Second test: Download
- Download Metadata Button

## Summary of Changes

Added new test_metadata.py - 6 new tests added to verify title, description, resource type and resource language changes, cancel changes funtionality and download functionality
Updated project.py - added new FilesMetadataPage class , and ProjectMetadataPage class
Updated registries.py - updated RegistrationMetadataPage class
Updated osf_api.py — Added 2 new methods get_fake_file_guid and get_existing_file_data
Updated utils.py - Added 3 new methods verify_file_download, latest_download_file and get_guid_from_url


## Reviewer's Actions
`git fetch <remote> pull/265/head:feature/test_metadata`

Run this test using
`pytest tests/test_metadata.py -s -v`

## Testing Changes Moving Forward
N/A


## Ticket

https://openscience.atlassian.net/browse/ENG-4276
https://openscience.atlassian.net/browse/ENG-4277