### PR TITLE
[ENG-5628] Update testimonial buttons on the logged out homepage

### DIFF
--- a/pages/landing.py
+++ b/pages/landing.py
@@ -19,20 +19,13 @@ class LandingPage(OSFBasePage):
     learn_more_button = Locator(
         By.CSS_SELECTOR, '[data-analytics-name="Learn more button"]'
     )
-    testimonial_1_button = Locator(
-        By.CSS_SELECTOR, '[data-analytics-name="Go to slide 1"]'
-    )
-    testimonial_2_button = Locator(
-        By.CSS_SELECTOR, '[data-analytics-name="Go to slide 2"]'
-    )
-    testimonial_3_button = Locator(
-        By.CSS_SELECTOR, '[data-analytics-name="Go to slide 3"]'
-    )
     testimonial_1_slide = Locator(By.CSS_SELECTOR, '[data-test-testimonials-slide-1]')
     testimonial_2_slide = Locator(By.CSS_SELECTOR, '[data-test-testimonials-slide-2]')
     testimonial_3_slide = Locator(By.CSS_SELECTOR, '[data-test-testimonials-slide-3]')
     previous_testimonial_arrow = Locator(By.CSS_SELECTOR, '[data-test-previous-arrow]')
     next_testimonial_arrow = Locator(By.CSS_SELECTOR, '[data-test-next-arrow]')
+
+    testimonial_buttons = GroupLocator(By.CSS_SELECTOR, '[data-test-navigation-item]')
     testimonial_view_research_links = GroupLocator(
         By.CSS_SELECTOR, '[data-analytics-name="View research"]'
     )

--- a/tests/test_landing.py
+++ b/tests/test_landing.py
@@ -37,23 +37,23 @@ class TestHomeLandingPage:
         assert 'https://www.cos.io/products/osf' in driver.current_url
 
     def test_testimonials_by_buttons(self, driver, landing_page):
-        landing_page.scroll_into_view(landing_page.testimonial_3_button.element)
+        landing_page.scroll_into_view(landing_page.testimonial_1_slide.element)
         # Verify that Testimonial 1 slide is initially visible
         assert landing_page.testimonial_1_slide.present()
         assert landing_page.testimonial_2_slide.absent()
         assert landing_page.testimonial_3_slide.absent()
         # Click the button above the testimonial carousel to go to Testimonial 3
-        landing_page.testimonial_3_button.click()
+        landing_page.testimonial_buttons[2].click()
         assert landing_page.testimonial_3_slide.present()
         assert landing_page.testimonial_1_slide.absent()
         assert landing_page.testimonial_2_slide.absent()
         # Click the button above the testimonial carousel to go to Testimonial 2
-        landing_page.testimonial_2_button.click()
+        landing_page.testimonial_buttons[1].click()
         assert landing_page.testimonial_2_slide.present()
         assert landing_page.testimonial_1_slide.absent()
         assert landing_page.testimonial_3_slide.absent()
         # Click the button above the testimonial carousel to go to Testimonial 1
-        landing_page.testimonial_1_button.click()
+        landing_page.testimonial_buttons[0].click()
         assert landing_page.testimonial_1_slide.present()
         assert landing_page.testimonial_2_slide.absent()
         assert landing_page.testimonial_3_slide.absent()
@@ -128,7 +128,7 @@ class TestHomeLandingPage:
         landing_page.scroll_into_view(landing_page.testimonial_view_research_links[0])
         assert landing_page.testimonial_1_slide.present()
         # Click the button above the testimonial carousel to go to Testimonial 3
-        landing_page.testimonial_3_button.click()
+        landing_page.testimonial_buttons[2].click()
         assert landing_page.testimonial_3_slide.present()
         # Click the "See his research" link and verify that you are navigated to the User
         # Profile page for Philip Cohen (guid=2u4tf)


### PR DESCRIPTION
<!-- Before you submit your Pull Request, please confirm that:

     - Any test that will create public data either has the `QAtest` tag or the `dont_run_on_production` marker
     - `core_functionality` is marked as such
     - Your tests will be able to run on *all* servers (all stagings, test)
 -->


## Purpose
Fix broken production tests that check testimonials on the logged out home page. 
_Context: Data analytics locators were removed from the homepage during an a11y fix_

- https://osf.io/

## Summary of Changes

- Delete old `[data-analytics-name="Go to slide X"]` locators
- Grab all the testimonial buttons using a group locator


## Reviewer's Actions
`git fetch <remote> pull/266/head:fix/testimonials`

Run this test using
`tests/test_landing.py::TestHomeLandingPage -sv`

## Testing Changes Moving Forward
- hopefully none. 

## Ticket

https://openscience.atlassian.net/browse/ENG-5628
