### PR TITLE
Selenium maintenance fixes

### DIFF
--- a/api/osf_api.py
+++ b/api/osf_api.py
@@ -643,7 +643,7 @@ def create_preprint(
     # then the Edit Preprint page thinks that the preprint has unsaved changes even if
     # you have made no changes on the form page. There is a ticket for this issue:
     # ENG-3782.
-    current_year = datetime.datetime.now().year
+    current_year = datetime.now().year
     # Get subject id for the subject_name parameter. NOTE: Currently we are creating
     # the preprint with only a single subject, which is the minimum required to publish.
     subject_id = get_subject_id_for_provider(

--- a/api/osf_api.py
+++ b/api/osf_api.py
@@ -1,7 +1,7 @@
-import datetime
 import json
 import logging
 import os
+from datetime import datetime
 from urllib.parse import quote
 
 import requests
@@ -1210,7 +1210,7 @@ def get_registration_resource_id(registration_id):
     if data:
         for i in range(0, len(data)):
             date_created = data[i]['attributes']['date_created']
-            now = datetime.datetime.now()
+            now = datetime.now()
             current_date = now.strftime('%Y-%m-%d')
             if current_date in date_created:
                 return data[i]['id']

--- a/pages/base.py
+++ b/pages/base.py
@@ -1,5 +1,6 @@
 import urllib.parse
 from time import sleep
+from urllib.parse import quote
 
 from selenium.common.exceptions import NoSuchElementException
 from selenium.webdriver.common.action_chains import ActionChains
@@ -38,7 +39,10 @@ class BasePage(BaseElement):
         self.driver.get(self.url)
 
         if expect_redirect_to:
-            if self.url not in self.driver.current_url:
+            if (
+                self.url not in self.driver.current_url
+                and quote(self.url, safe='') not in self.driver.current_url
+            ):
                 raise PageException(
                     'Unexpected url structure: `{}`'.format(self.driver.current_url)
                 )

--- a/pages/preprints.py
+++ b/pages/preprints.py
@@ -234,9 +234,7 @@ class PreprintDiscoverPage(BasePreprintPage):
     loading_indicator = Locator(By.CSS_SELECTOR, '.ball-scale')
     search_box = Locator(By.CSS_SELECTOR, 'input[data-test-search-input]')
     sort_button = Locator(By.CSS_SELECTOR, 'div[data-test-topbar-sort-dropdown]')
-    sort_option_newest_to_oldest = Locator(
-        By.CSS_SELECTOR, '#sortByOptionList > li:nth-child(3) > button'
-    )
+    sort_option_newest_to_oldest = Locator(By.CSS_SELECTOR, '[data-option-index="3"]')
 
     # Group Locators
     search_results = GroupLocator(By.CSS_SELECTOR, 'div[data-test-search-result-card]')
@@ -253,9 +251,7 @@ class BrandedPreprintsDiscoverPage(BasePreprintPage):
     loading_indicator = Locator(By.CSS_SELECTOR, '.ball-scale')
     search_box = Locator(By.CSS_SELECTOR, 'input[data-test-search-input]')
     sort_button = Locator(By.CSS_SELECTOR, 'div[data-test-topbar-sort-dropdown]')
-    sort_option_newest_to_oldest = Locator(
-        By.CSS_SELECTOR, '#sortByOptionList > li:nth-child(3) > button'
-    )
+    sort_option_newest_to_oldest = Locator(By.CSS_SELECTOR, '[data-option-index="3"]')
     no_results = Locator(By.CSS_SELECTOR, 'div[_no-results_fvrbco]')
 
     # Group Locators

--- a/tests/test_preprints.py
+++ b/tests/test_preprints.py
@@ -579,7 +579,8 @@ class TestPreprintModeration:
         preprint_page.goto()
         assert PreprintDetailPage(driver, verify=True)
         WebDriverWait(driver, 5).until(EC.visibility_of(preprint_page.title))
-        assert preprint_page.title.text == preprint_title
+        assert preprint_title in preprint_page.title.text
+        assert 'Withdrawn' in preprint_page.title.text
         # TODO: Re-enable assert after [ENG-5092] is fixed.
         # assert (
         #         preprint_page.status_explanation.text == 'This preprint has been withdrawn.'
@@ -846,7 +847,8 @@ class TestPreprintModeration:
         preprint_page.goto()
         assert PreprintDetailPage(driver, verify=True)
         WebDriverWait(driver, 5).until(EC.visibility_of(preprint_page.title))
-        assert preprint_page.title.text == preprint_title
+        assert preprint_title in preprint_page.title.text
+        assert 'Withdrawn' in preprint_page.title.text
         # TODO: Re-enable assert after [ENG-5092] is fixed.
         # assert (
         #         preprint_page.status_explanation.text == 'This preprint has been withdrawn.'
@@ -943,7 +945,8 @@ class TestPreprintModeration:
         preprint_page.goto()
         assert PreprintDetailPage(driver, verify=True)
         WebDriverWait(driver, 5).until(EC.visibility_of(preprint_page.title))
-        assert preprint_page.title.text == preprint_title
+        assert preprint_title in preprint_page.title.text
+        assert 'Withdrawn' in preprint_page.title.text
         # Add assert for "This preprint has been withdrawn" after [ENG-5092] is fixed.
         assert preprint_page.withdraw_reason.present()
 


### PR DESCRIPTION
<!-- Before you submit your Pull Request, please confirm that:

     - Any test that will create public data either has the `QAtest` tag or the `dont_run_on_production` marker
     - `core_functionality` is marked as such
     - Your tests will be able to run on *all* servers (all stagings, test)
 -->


## Purpose
Improve coverage for outdated tests. 


## Summary of Changes
1. Test withdrawn preprints include the prefix `Withdrawn: `
2. Update the search page `Sort by newest` locator
3. Add support for encoded URLs when testing redirects


## Reviewer's Actions
`git fetch <remote> pull/269/head:fix/sel-maintenance`

Run this test using
`tests/test_login.py -sv`
`tests/test_preprints.py::TestPreprintSearch.py -sv`
`tests/test_preprints.py::TestPreprintModeration -sv`

## Testing Changes Moving Forward
- Any random failures that show up should be included in this release


## Tickets

https://openscience.atlassian.net/browse/ENG-5714
https://openscience.atlassian.net/browse/ENG-5719
https://openscience.atlassian.net/browse/ENG-5720
