### PR TITLE
Feature/integrating safari browser

### DIFF
--- a/api/osf_api.py
+++ b/api/osf_api.py
@@ -1284,3 +1284,22 @@ def create_registration_resource(registration_guid, resource_type):
         item_id=resource_id,
         item_type='resources',
     )['data']
+
+
+def delete_registration_resources(registration_id):
+    """This function deletes all the resources added to the given registration"""
+    session = client.Session(
+        api_base_url=settings.API_DOMAIN,
+        auth=(settings.REGISTRATIONS_USER, settings.REGISTRATIONS_USER_PASSWORD),
+    )
+    url = '/v2/registrations/{}/resources/'.format(registration_id)
+    data = session.get(url)['data']
+    if data:
+        for i in range(0, len(data)):
+            date_created = data[i]['attributes']['date_created']
+            now = datetime.now()
+            current_date = now.strftime('%Y-%m-%d')
+            if current_date in date_created:
+                registration_resource_id = data[i]['id']
+                delete_url = '/v2/resources/{}'.format(registration_resource_id)
+                session.delete(delete_url, item_type='resources')

--- a/components/project.py
+++ b/components/project.py
@@ -1,6 +1,7 @@
 from selenium.webdriver.common.by import By
 
 import settings
+import utils
 from base.locators import (
     BaseElement,
     GroupLocator,
@@ -96,7 +97,7 @@ class CreateRegistrationModal(BaseElement):
 
     def get_schema_names_list(self):
         """Returns the schema names from the schema list"""
-        return [schema.text for schema in self.schema_list]
+        return [utils.clean_text(schema.text) for schema in self.schema_list]
 
     def select_schema_radio_button(self, schema_name='Open-Ended Registration'):
         """Selects the radio button corresponding to the given schema name"""

--- a/pages/cos.py
+++ b/pages/cos.py
@@ -8,4 +8,4 @@ from pages.base import BasePage
 class COSDonatePage(BasePage):
     url = 'https://www.cos.io/support-cos'
 
-    identity = Locator(By.ID, 'Yourdonationtitle', settings.LONG_TIMEOUT)
+    identity = Locator(By.CSS_SELECTOR, 'h2#Yourdonationtitle', settings.LONG_TIMEOUT)

--- a/pages/preprints.py
+++ b/pages/preprints.py
@@ -4,6 +4,7 @@ import pytest
 from selenium.webdriver.common.by import By
 
 import settings
+import utils
 from base.locators import (
     ComponentLocator,
     GroupLocator,
@@ -101,7 +102,7 @@ class PreprintSubmitPage(BasePreprintPage):
 
     def select_from_dropdown_listbox(self, selection):
         for option in self.dropdown_options:
-            if option.text == selection:
+            if utils.clean_text(option.text) == selection:
                 option.click()
                 break
 
@@ -114,7 +115,7 @@ class PreprintSubmitPage(BasePreprintPage):
 
     def select_top_level_subject(self, selection):
         for subject in self.top_level_subjects:
-            if subject.text == selection:
+            if utils.clean_text(subject.text) == selection:
                 # Find the checkbox element and click it to select the subject
                 checkbox = subject.find_element_by_css_selector(
                     'input.ember-checkbox.ember-view'
@@ -325,7 +326,7 @@ class ReviewsDashboardPage(OSFBasePage):
             group_name = provider_group.find_element_by_css_selector(
                 'span._provider-name_gp8jcl'
             )
-            if provider_name == group_name.text:
+            if provider_name == utils.clean_text(group_name.text):
                 links = provider_group.find_elements_by_css_selector(
                     'ul._provider-links_gp8jcl > li > a'
                 )

--- a/pages/project.py
+++ b/pages/project.py
@@ -8,6 +8,7 @@ from datetime import (
 from selenium.webdriver.common.by import By
 
 import settings
+import utils
 from api import osf_api
 from base.locators import (
     ComponentLocator,
@@ -535,7 +536,7 @@ class FilesMetadataPage(GuidBasePage):
 
     def select_from_dropdown_listbox(self, selection):
         for option in self.dropdown_options:
-            if option.text == selection:
+            if utils.clean_text(option.text) == selection:
                 option.click()
                 break
 
@@ -588,7 +589,7 @@ class ProjectMetadataPage(GuidBasePage):
 
     def select_from_dropdown_listbox(self, selection):
         for option in self.dropdown_options:
-            if option.text == selection:
+            if utils.clean_text(option.text) == selection:
                 option.click()
                 break
 

--- a/pages/project.py
+++ b/pages/project.py
@@ -44,7 +44,7 @@ from pages.base import (
 
 class ProjectPage(GuidBasePage):
 
-    identity = Locator(By.ID, 'projectScope')
+    identity = Locator(By.ID, 'projectScope', settings.LONG_TIMEOUT)
     title = Locator(By.ID, 'nodeTitleEditable', settings.LONG_TIMEOUT)
     title_input = Locator(By.CSS_SELECTOR, '.form-inline input')
     title_edit_submit_button = Locator(By.CSS_SELECTOR, '.editable-submit')

--- a/pages/registries.py
+++ b/pages/registries.py
@@ -3,6 +3,7 @@ from urllib.parse import urljoin
 from selenium.webdriver.common.by import By
 
 import settings
+import utils
 from base.locators import (
     ComponentLocator,
     GroupLocator,
@@ -114,7 +115,7 @@ class RegistrationDetailPage(BaseSubmittedRegistrationPage):
 
     def select_from_dropdown_listbox(self, selection):
         for option in self.dropdown_options:
-            if option.text == selection:
+            if utils.clean_text(option.text) == selection:
                 option.click()
                 break
 
@@ -179,7 +180,7 @@ class RegistrationMetadataPage(BaseSubmittedRegistrationPage):
 
     def select_from_dropdown_listbox(self, selection):
         for option in self.dropdown_options:
-            if option.text == selection:
+            if utils.clean_text(option.text) == selection:
                 option.click()
                 break
 

--- a/pages/registries.py
+++ b/pages/registries.py
@@ -367,7 +367,7 @@ class RegistrationAddNewPage(BaseRegistriesPage):
 
     def select_from_dropdown_listbox(self, selection):
         for option in self.dropdown_options:
-            if option.text == selection:
+            if utils.clean_text(option.text) == selection:
                 option.click()
                 break
 
@@ -439,13 +439,13 @@ class DraftRegistrationMetadataPage(BaseRegistrationDraftPage):
 
     def select_from_dropdown_listbox(self, selection):
         for option in self.dropdown_options:
-            if option.text == selection:
+            if utils.clean_text(option.text) == selection:
                 option.click()
                 break
 
     def select_top_level_subject(self, selection):
         for subject in self.top_level_subjects:
-            if subject.text == selection:
+            if utils.clean_text(subject.text) == selection:
                 # Find the checkbox element and click it to select the subject
                 checkbox = subject.find_element_by_css_selector(
                     'input.ember-checkbox.ember-view'
@@ -475,10 +475,8 @@ class DraftRegistrationDesignPlanPage(BaseRegistrationDraftPage):
     """Draft Design Plan Page for an OSF Preregistration Template"""
 
     url_addition = '2-design-plan'
-    identity = Locator(
-        By.CSS_SELECTOR, 'input[id^="radio-Experiment"]', settings.LONG_TIMEOUT
-    )
-    other_radio_button = Locator(By.CSS_SELECTOR, 'input[id^="radio-Other"]')
+    identity = Locator(By.CSS_SELECTOR, '[data-test-page-heading]')
+    other_radio_button = Locator(By.XPATH, '//div/input[@value="Other"]')
     no_blinding_checkbox = Locator(
         By.CSS_SELECTOR, 'div._Checkboxes_qxt8ij > div:nth-child(1) > input'
     )
@@ -493,12 +491,12 @@ class DraftRegistrationSamplingPlanPage(BaseRegistrationDraftPage):
 
     url_addition = '3-sampling-plan'
     identity = Locator(
-        By.CSS_SELECTOR,
-        'input[id^="radio-Registration prior to creation"]',
+        By.XPATH,
+        '//input[@value="Registration following analysis of the data"]',
         settings.LONG_TIMEOUT,
     )
     reg_following_radio_button = Locator(
-        By.CSS_SELECTOR, 'input[id^="radio-Registration following"]'
+        By.XPATH, '//input[@value="Registration following analysis of the data"]'
     )
     data_procedures_textbox = Locator(By.NAME, '__responseKey_q10|question')
     sample_size_textbox = Locator(By.NAME, '__responseKey_q11')

--- a/pages/registries.py
+++ b/pages/registries.py
@@ -255,7 +255,7 @@ class RegistrationFileDetailPage(GuidBasePage):
 
     def get_tag(self, tag_value):
         for tag in self.tags:
-            if tag.text == tag_value:
+            if utils.clean_text(tag.text) == tag_value:
                 return tag
         return None
 

--- a/pages/user.py
+++ b/pages/user.py
@@ -83,9 +83,13 @@ class AccountSettingsPage(BaseUserSettingsPage):
     storage_location_listbox = Locator(
         By.CSS_SELECTOR, 'div[data-test-region-selector] > div'
     )
+    affiliation_help_text = Locator(
+        By.CSS_SELECTOR, '[data-test-affiliated-institutions-help-text]'
+    )
     first_affiliated_institution = Locator(
         By.CSS_SELECTOR, 'span[data-test-affiliated-institutions-item]'
     )
+
     first_aff_inst_delete_button = Locator(
         By.CSS_SELECTOR, 'span[data-test-affiliated-institutions-delete] > button'
     )
@@ -110,6 +114,7 @@ class AccountSettingsPage(BaseUserSettingsPage):
     configure_2fa_button = Locator(
         By.CSS_SELECTOR, 'button[data-test-two-factor-enable-button]'
     )
+    two_factor_help = Locator(By.CSS_SELECTOR, '[data-test-why-two-factor]')
     two_factor_qr_code_img = Locator(By.CSS_SELECTOR, 'div[data-test-2f-qr-code] > img')
     cancel_2fa_button = Locator(
         By.CSS_SELECTOR, 'button[data-test-two-factor-verify-cancel-button]'
@@ -127,7 +132,6 @@ class AccountSettingsPage(BaseUserSettingsPage):
     unconfirmed_emails = GroupLocator(
         By.CSS_SELECTOR, 'div[data-test-unconfirmed-email-item]'
     )
-
     configure_2fa_modal = ComponentLocator(Configure2FAModal)
     confirm_deactivation_modal = ComponentLocator(ConfirmDeactivationRequestModal)
     undo_deactivation_modal = ComponentLocator(UndoDeactivationRequestModal)
@@ -147,7 +151,7 @@ class AccountSettingsPage(BaseUserSettingsPage):
 class ConfigureAddonsPage(BaseUserSettingsPage):
     url = settings.OSF_HOME + '/settings/addons/'
 
-    identity = Locator(By.CSS_SELECTOR, '#configureAddons')
+    identity = Locator(By.CSS_SELECTOR, 'div._profile-container_1pqro5')
 
 
 class NotificationsPage(BaseUserSettingsPage):

--- a/pages/user.py
+++ b/pages/user.py
@@ -151,7 +151,7 @@ class AccountSettingsPage(BaseUserSettingsPage):
 class ConfigureAddonsPage(BaseUserSettingsPage):
     url = settings.OSF_HOME + '/settings/addons/'
 
-    identity = Locator(By.CSS_SELECTOR, 'div._profile-container_1pqro5')
+    identity = Locator(By.CSS_SELECTOR, 'div[data-analytics-scope="User addons"]')
 
 
 class NotificationsPage(BaseUserSettingsPage):

--- a/settings.py
+++ b/settings.py
@@ -111,6 +111,15 @@ caps = {
         'resolution': '2048x1536',
         'timezone': 'UTC',
     },
+    'safari': {
+        'browser': 'Safari',
+        'browser_version': '14',
+        'os': 'OS X',
+        'os_version': 'Big Sur',
+        'timezone': 'UTC',
+        'networkLogs': 'true',
+        'enablePopups': 'false',
+    },
 }
 
 BUILD = DRIVER

--- a/settings.py
+++ b/settings.py
@@ -113,9 +113,9 @@ caps = {
     },
     'safari': {
         'browser': 'Safari',
-        'browser_version': '14',
+        'browser_version': '18',
         'os': 'OS X',
-        'os_version': 'Big Sur',
+        'os_version': 'Sequoia',
         'timezone': 'UTC',
         'networkLogs': 'true',
         'enablePopups': 'false',

--- a/settings.py
+++ b/settings.py
@@ -113,9 +113,9 @@ caps = {
     },
     'safari': {
         'browser': 'Safari',
-        'browser_version': '18',
+        'browser_version': '17',
         'os': 'OS X',
-        'os_version': 'Sequoia',
+        'os_version': 'Sonoma',
         'timezone': 'UTC',
         'networkLogs': 'true',
         'enablePopups': 'false',

--- a/settings.py
+++ b/settings.py
@@ -117,8 +117,9 @@ caps = {
         'os': 'OS X',
         'os_version': 'Sonoma',
         'timezone': 'UTC',
-        'networkLogs': 'true',
-        'enablePopups': 'false',
+        'networkLogs': True,
+        'enablePopups': False,
+        'acceptInsecureCerts': True,
     },
 }
 

--- a/tests/test_collections.py
+++ b/tests/test_collections.py
@@ -6,6 +6,7 @@ from selenium.webdriver.support.ui import WebDriverWait
 
 import markers
 import settings
+import utils
 from api import osf_api
 from pages.collections import (
     CollectionDiscoverPage,
@@ -326,9 +327,11 @@ class TestCollectionModeration:
             # first).
             rejected_card = rejected_page.get_submission_card(collection_project.id)
             assert (
-                rejected_card.find_element_by_css_selector(
-                    '[data-test-review-action-comment]'
-                ).text
+                utils.clean_text(
+                    rejected_card.find_element_by_css_selector(
+                        '[data-test-review-action-comment]'
+                    ).text
+                )
                 == '— Rejecting collection submission via selenium automated test.'
             )
             rejected_card.find_element_by_css_selector(
@@ -354,12 +357,12 @@ class TestCollectionModeration:
             assert project_page.collections_container.present()
             project_page.collections_container.click()
             assert (
-                project_page.first_collection_label.text
+                utils.clean_text(project_page.first_collection_label.text)
                 == "Rejected from Selenium Testing Collection's Collection"
             )
             project_page.collection_justification_link.click()
             assert (
-                project_page.collection_justification_reason.text
+                utils.clean_text(project_page.collection_justification_reason.text)
                 == 'Rejecting collection submission via selenium automated test.'
             )
         finally:
@@ -436,9 +439,11 @@ class TestCollectionModeration:
             # first).
             removed_card = removed_page.get_submission_card(collection_project.id)
             assert (
-                removed_card.find_element_by_css_selector(
-                    '[data-test-review-action-comment]'
-                ).text
+                utils.clean_text(
+                    removed_card.find_element_by_css_selector(
+                        '[data-test-review-action-comment]'
+                    ).text
+                )
                 == '— Removing collection submission via selenium automated test.'
             )
             removed_card.find_element_by_css_selector(
@@ -567,9 +572,11 @@ class TestCollectionModeration:
             # in the table since the default sort order is by Date (newest first).
             removed_card = removed_page.get_submission_card(collection_project.id)
             assert (
-                removed_card.find_element_by_css_selector(
-                    '[data-test-review-action-comment]'
-                ).text
+                utils.clean_text(
+                    removed_card.find_element_by_css_selector(
+                        '[data-test-review-action-comment]'
+                    ).text
+                )
                 == '— Project admin removing project from collection via selenium automated test.'
             )
             removed_card.find_element_by_css_selector(

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -1,5 +1,6 @@
 import re
 
+import ipdb
 import pytest
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support import expected_conditions as EC
@@ -80,7 +81,8 @@ class TestDashboardPage:
         # and switch focus to it.
         WebDriverWait(driver, 3).until(EC.number_of_windows_to_be(2))
         driver.switch_to.window(driver.window_handles[1])
-        WebDriverWait(driver, 3).until(
+        ipdb.set_trace()
+        WebDriverWait(driver, 5).until(
             EC.visibility_of_element_located((By.CLASS_NAME, 'hs-menu-wrapper'))
         )
         assert 'https://www.cos.io/products/osf-collections' in driver.current_url

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -1,6 +1,5 @@
 import re
 
-import ipdb
 import pytest
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support import expected_conditions as EC
@@ -81,7 +80,6 @@ class TestDashboardPage:
         # and switch focus to it.
         WebDriverWait(driver, 3).until(EC.number_of_windows_to_be(2))
         driver.switch_to.window(driver.window_handles[1])
-        ipdb.set_trace()
         WebDriverWait(driver, 5).until(
             EC.visibility_of_element_located((By.CLASS_NAME, 'hs-menu-wrapper'))
         )

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -80,7 +80,7 @@ class TestDashboardPage:
         # and switch focus to it.
         WebDriverWait(driver, 3).until(EC.number_of_windows_to_be(2))
         driver.switch_to.window(driver.window_handles[1])
-        WebDriverWait(driver, 5).until(
+        WebDriverWait(driver, 10).until(
             EC.visibility_of_element_located((By.CLASS_NAME, 'hs-menu-wrapper'))
         )
         assert 'https://www.cos.io/products/osf-collections' in driver.current_url

--- a/tests/test_landing.py
+++ b/tests/test_landing.py
@@ -1,5 +1,7 @@
 import pytest
 from selenium.webdriver.common.keys import Keys
+from selenium.webdriver.support import expected_conditions as EC
+from selenium.webdriver.support.wait import WebDriverWait
 
 import markers
 import settings
@@ -34,6 +36,9 @@ class TestHomeLandingPage:
     @markers.core_functionality
     def test_learn_more(self, driver, landing_page):
         landing_page.learn_more_button.click()
+        WebDriverWait(driver, 5).until(
+            EC.url_matches(('https://www.cos.io/products/osf'))
+        )
         assert 'https://www.cos.io/products/osf' in driver.current_url
 
     def test_testimonials_by_buttons(self, driver, landing_page):

--- a/tests/test_login.py
+++ b/tests/test_login.py
@@ -58,10 +58,11 @@ class TestLoginPage:
         # Oauth will redirect to callback url with "error" if anything goes wrong
         assert 'error' not in driver.current_url
 
+    @pytest.mark.skipif(
+        settings.env('TEST_BUILD') == 'safari' and settings.DRIVER == 'Remote',
+        reason='Test fails on safari browser due to some oauth setting on the browser',
+    )
     def test_osf_home_link(self, driver, login_page):
-        WebDriverWait(driver, 5).until(
-            EC.element_to_be_clickable(login_page.osf_home_link)
-        )
         login_page.osf_home_link.click()
         assert LandingPage(driver, verify=True)
 
@@ -542,6 +543,10 @@ class TestInstitutionLoginPage:
 
 @markers.dont_run_on_prod
 class TestOauthAPI:
+    @pytest.mark.skipif(
+        settings.env('TEST_BUILD') == 'safari',
+        reason='Test fails on safari browser due to some oauth setting on the browser',
+    )
     def test_authorization_online(self, driver, must_be_logged_in):
         client_id = settings.DEVAPP_CLIENT_ID
         client_secret = settings.DEVAPP_CLIENT_SECRET
@@ -609,6 +614,10 @@ class TestOauthAPI:
         assert r.status_code == 401
         assert r.json()['error'] == 'expired_accessToken'
 
+    @pytest.mark.skipif(
+        settings.env('TEST_BUILD') == 'safari',
+        reason='Test fails on safari browser due to some oauth setting on the browser',
+    )
     def test_authorization_offline(self, driver, must_be_logged_in):
         client_id = settings.DEVAPP_CLIENT_ID
         client_secret = settings.DEVAPP_CLIENT_SECRET
@@ -704,6 +713,10 @@ class TestOauthAPI:
         assert r.status_code == 401
         assert r.json()['error'] == 'expired_accessToken'
 
+    @pytest.mark.skipif(
+        settings.env('TEST_BUILD') == 'safari',
+        reason='Test fails on safari browser due to some oauth setting on the browser',
+    )
     def test_authorization_single_scope(self, driver, must_be_logged_in):
         client_id = settings.DEVAPP_CLIENT_ID
         client_secret = settings.DEVAPP_CLIENT_SECRET

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -140,7 +140,9 @@ class TestFilesMetadata:
         title_input.clear()
         title_input.send_keys(new_title)
         file_metadata_page.save_metadata_button.click()
-        assert new_title == file_metadata_page.files_metadata_title.text
+        assert new_title == utils.clean_text(
+            file_metadata_page.files_metadata_title.text
+        )
         file_metadata_tab = utils.switch_to_new_tab(driver)
         utils.close_current_tab(driver, file_metadata_tab)
 
@@ -164,7 +166,9 @@ class TestFilesMetadata:
         description_input.clear()
         description_input.send_keys(new_description)
         file_metadata_page.save_metadata_button.click()
-        assert new_description == file_metadata_page.files_metadata_description.text
+        assert new_description == utils.clean_text(
+            file_metadata_page.files_metadata_description.text
+        )
         file_metadata_tab = utils.switch_to_new_tab(driver)
         utils.close_current_tab(driver, file_metadata_tab)
 
@@ -322,7 +326,9 @@ class TestProjectMetadata:
         description_input.clear()
         description_input.send_keys(new_description)
         project_metadata_page.save_description_button.click()
-        assert new_description == project_metadata_page.description.text
+        assert new_description == utils.clean_text(
+            project_metadata_page.description.text
+        )
 
     def test_edit_contributors(
         self, session, driver, project_metadata_page, default_project_with_metadata
@@ -540,7 +546,9 @@ class TestRegistrationMetadata:
         description_input.clear()
         description_input.send_keys(new_description)
         registration_metadata_page.save_metadata_description_button.click()
-        assert new_description == registration_metadata_page.metadata_description.text
+        assert new_description == utils.clean_text(
+            registration_metadata_page.metadata_description.text
+        )
 
     def test_edit_resource_information(self, driver, registration_metadata_page):
         """This test verifies that user can add/remove
@@ -579,9 +587,11 @@ class TestRegistrationMetadata:
         registration_metadata_page.select_from_dropdown_listbox('Bengali')
 
         registration_metadata_page.resource_information_save_button.click()
-        assert orig_resource_type != registration_metadata_page.resource_type.text
-        assert (
-            orig_resource_language != registration_metadata_page.resource_language.text
+        assert orig_resource_type != utils.clean_text(
+            registration_metadata_page.resource_type.text
+        )
+        assert orig_resource_language != utils.clean_text(
+            registration_metadata_page.resource_language.text
         )
 
     def test_edit_support_funding_information(

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -351,7 +351,7 @@ class TestProjectMetadata:
 
         WebDriverWait(driver, 5).until(
             EC.element_to_be_clickable(
-                (By.CSS_SELECTOR, '[data-test-edit-contributors]')
+                (By.CSS_SELECTOR, '[data-test-contributors-link]')
             )
         ).click()
 
@@ -367,6 +367,7 @@ class TestProjectMetadata:
         project_metadata_page.search_input.click()
         project_metadata_page.search_input.send_keys(new_user)
         project_metadata_page.contributor_search_button.click()
+        # project_metadata_page.contributor_search_button.click()
 
         # Get the row number for the user from the search table
         WebDriverWait(driver, 5).until(
@@ -408,7 +409,7 @@ class TestProjectMetadata:
         user = driver.find_element_by_xpath(
             contributor_table_path + '/tbody/tr[' + str(rowno) + ']/td[2]'
         )
-        assert new_user in user.text
+        assert new_user in utils.clean_text(user.text)
 
     def test_edit_resource_information(self, driver, project_metadata_page):
         """This test verifies that user can add/remove

--- a/tests/test_navbar.py
+++ b/tests/test_navbar.py
@@ -74,6 +74,9 @@ class NavbarTestLoggedOutMixin:
     def test_donate_link(self, page, driver):
         page.navbar.donate_link.click()
         donate_page = COSDonatePage(driver, verify=False)
+        WebDriverWait(driver, 10).until(
+            EC.url_matches(('https://www.cos.io/support-cos'))
+        )
         assert_donate_page(driver, donate_page)
 
     def test_sign_in_button(self, page, driver):
@@ -100,6 +103,10 @@ class NavbarTestLoggedInMixin:
         page.navbar.user_dropdown_profile.click()
         assert UserProfilePage(driver, verify=True)
 
+    # @pytest.mark.skipif(
+    #     settings.env('TEST_BUILD') == 'safari' and settings.DRIVER == 'Remote',
+    #     reason='Test fails on safari browser due to some oauth setting on the browser',
+    # )
     def test_user_profile_menu_support_link(self, driver, page):
         page.navbar.user_dropdown.click()
         page.navbar.user_dropdown_support.click()
@@ -138,6 +145,10 @@ class TestOSFHomeNavbarLoggedOut(NavbarTestLoggedOutMixin):
         page.navbar.search_link.click()
         assert SearchPage(driver, verify=True)
 
+    @pytest.mark.skipif(
+        settings.env('TEST_BUILD') == 'safari' and settings.DRIVER == 'Remote',
+        reason='Test fails on safari browser due to some oauth setting on the browser',
+    )
     def test_support_link(self, page, driver):
         page.navbar.support_link.click()
         assert SupportPage(driver, verify=True)
@@ -170,6 +181,10 @@ class TestPreprintsNavbarLoggedOut(NavbarTestLoggedOutMixin):
         page.navbar.search_link.click()
         PreprintDiscoverPage(driver, verify=True)
 
+    @pytest.mark.skipif(
+        settings.env('TEST_BUILD') == 'safari' and settings.DRIVER == 'Remote',
+        reason='Test fails on safari browser due to some oauth setting on the browser',
+    )
     def test_support_link(self, page, driver):
         page.navbar.support_link.click()
         assert SupportPage(driver, verify=True)
@@ -264,6 +279,10 @@ class TestMeetingsNavbarLoggedOut(NavbarTestLoggedOutMixin):
         page.navbar.search_link.click()
         SearchPage(driver, verify=True)
 
+    @pytest.mark.skipif(
+        settings.env('TEST_BUILD') == 'safari' and settings.DRIVER == 'Remote',
+        reason='Test fails on safari browser due to some oauth setting on the browser',
+    )
     def test_support_link(self, page, driver):
         page.navbar.support_link.click()
         assert SupportPage(driver, verify=True)
@@ -297,6 +316,10 @@ class TestInstitutionsNavbarLoggedOut(NavbarTestLoggedOutMixin):
         page.navbar.search_link.click()
         SearchPage(driver, verify=True)
 
+    @pytest.mark.skipif(
+        settings.env('TEST_BUILD') == 'safari' and settings.DRIVER == 'Remote',
+        reason='Test fails on safari browser due to some oauth setting on the browser',
+    )
     def test_support_link(self, page, driver):
         page.navbar.support_link.click()
         SupportPage(driver, verify=True)
@@ -323,7 +346,7 @@ def assert_donate_page(driver, donate_page):
     meta_tag = driver.find_element_by_xpath(
         '//meta[@property="og:title" and contains(@content, "Support COS")]'
     )
-
+    WebDriverWait(driver, 10).until(EC.url_matches(('https://www.cos.io/support-cos')))
     assert 'support-cos' in driver.current_url
     assert meta_tag.get_attribute('property') == 'og:title'
     assert meta_tag.get_attribute('content') == 'Support COS'
@@ -411,6 +434,10 @@ class TestProjectsNavbarLoggedIn:
         page.navbar.search_link.click()
         SearchPage(driver, verify=True)
 
+    @pytest.mark.skipif(
+        settings.env('TEST_BUILD') == 'safari' and settings.DRIVER == 'Remote',
+        reason='Test fails on safari browser due to some oauth setting on the browser',
+    )
     def test_support_link(self, session, driver, page):
         page.navbar.support_link.click()
         SupportPage(driver, verify=True)

--- a/tests/test_navbar.py
+++ b/tests/test_navbar.py
@@ -103,10 +103,6 @@ class NavbarTestLoggedInMixin:
         page.navbar.user_dropdown_profile.click()
         assert UserProfilePage(driver, verify=True)
 
-    # @pytest.mark.skipif(
-    #     settings.env('TEST_BUILD') == 'safari' and settings.DRIVER == 'Remote',
-    #     reason='Test fails on safari browser due to some oauth setting on the browser',
-    # )
     def test_user_profile_menu_support_link(self, driver, page):
         page.navbar.user_dropdown.click()
         page.navbar.user_dropdown_support.click()
@@ -145,10 +141,6 @@ class TestOSFHomeNavbarLoggedOut(NavbarTestLoggedOutMixin):
         page.navbar.search_link.click()
         assert SearchPage(driver, verify=True)
 
-    @pytest.mark.skipif(
-        settings.env('TEST_BUILD') == 'safari' and settings.DRIVER == 'Remote',
-        reason='Test fails on safari browser due to some oauth setting on the browser',
-    )
     def test_support_link(self, page, driver):
         page.navbar.support_link.click()
         assert SupportPage(driver, verify=True)
@@ -181,10 +173,6 @@ class TestPreprintsNavbarLoggedOut(NavbarTestLoggedOutMixin):
         page.navbar.search_link.click()
         PreprintDiscoverPage(driver, verify=True)
 
-    @pytest.mark.skipif(
-        settings.env('TEST_BUILD') == 'safari' and settings.DRIVER == 'Remote',
-        reason='Test fails on safari browser due to some oauth setting on the browser',
-    )
     def test_support_link(self, page, driver):
         page.navbar.support_link.click()
         assert SupportPage(driver, verify=True)
@@ -279,10 +267,6 @@ class TestMeetingsNavbarLoggedOut(NavbarTestLoggedOutMixin):
         page.navbar.search_link.click()
         SearchPage(driver, verify=True)
 
-    @pytest.mark.skipif(
-        settings.env('TEST_BUILD') == 'safari' and settings.DRIVER == 'Remote',
-        reason='Test fails on safari browser due to some oauth setting on the browser',
-    )
     def test_support_link(self, page, driver):
         page.navbar.support_link.click()
         assert SupportPage(driver, verify=True)
@@ -316,10 +300,6 @@ class TestInstitutionsNavbarLoggedOut(NavbarTestLoggedOutMixin):
         page.navbar.search_link.click()
         SearchPage(driver, verify=True)
 
-    @pytest.mark.skipif(
-        settings.env('TEST_BUILD') == 'safari' and settings.DRIVER == 'Remote',
-        reason='Test fails on safari browser due to some oauth setting on the browser',
-    )
     def test_support_link(self, page, driver):
         page.navbar.support_link.click()
         SupportPage(driver, verify=True)
@@ -434,10 +414,6 @@ class TestProjectsNavbarLoggedIn:
         page.navbar.search_link.click()
         SearchPage(driver, verify=True)
 
-    @pytest.mark.skipif(
-        settings.env('TEST_BUILD') == 'safari' and settings.DRIVER == 'Remote',
-        reason='Test fails on safari browser due to some oauth setting on the browser',
-    )
     def test_support_link(self, session, driver, page):
         page.navbar.support_link.click()
         SupportPage(driver, verify=True)

--- a/tests/test_navbar.py
+++ b/tests/test_navbar.py
@@ -395,6 +395,7 @@ class TestCollectionsNavbarLoggedIn:
     def test_donate_link(self, session, driver, page):
         page.donate_link.click()
         donate_page = COSDonatePage(driver, verify=False)
+        time.sleep(1)
         assert_donate_page(driver, donate_page)
 
 
@@ -424,4 +425,5 @@ class TestProjectsNavbarLoggedIn:
     def test_donate_link(self, session, driver, page):
         page.navbar.donate_link.click()
         donate_page = COSDonatePage(driver, verify=False)
+        time.sleep(1)
         assert_donate_page(driver, donate_page)

--- a/tests/test_navbar.py
+++ b/tests/test_navbar.py
@@ -1,3 +1,5 @@
+import time
+
 import pytest
 from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.support.wait import WebDriverWait
@@ -356,6 +358,7 @@ class TestCollectionsNavbarLoggedOut:
     def test_donate_link(self, session, driver, collections_discover_page):
         collections_discover_page.donate_link.click()
         donate_page = COSDonatePage(driver, verify=False)
+        time.sleep(3)
         assert_donate_page(driver, donate_page)
 
 

--- a/tests/test_preprints.py
+++ b/tests/test_preprints.py
@@ -133,7 +133,10 @@ class TestPreprintWorkflow:
             WebDriverWait(driver, 5).until(
                 EC.visibility_of(submit_page.first_selected_subject)
             )
-            assert submit_page.first_selected_subject.text == 'Engineering'
+            assert (
+                utils.clean_text(submit_page.first_selected_subject.text)
+                == 'Engineering'
+            )
 
             # Need to scroll down since the Keyword/tags section is obscured by the Dev
             # mode warning in the test environments
@@ -199,7 +202,9 @@ class TestPreprintWorkflow:
             submit_page.create_preprint_button.click()
             preprint_detail = PreprintDetailPage(driver, verify=True)
             WebDriverWait(driver, 10).until(EC.visibility_of(preprint_detail.title))
-            assert preprint_detail.title.text == 'Selenium Test Preprint'
+            assert (
+                utils.clean_text(preprint_detail.title.text) == 'Selenium Test Preprint'
+            )
             # Capture guid of supplemental materials project created during workflow
             supplemental_url = preprint_detail.view_page.get_attribute('href')
             supplemental_guid = utils.get_guid_from_url(supplemental_url, 3)
@@ -309,6 +314,7 @@ class TestPreprintWorkflow:
         WebDriverWait(driver, 5).until(
             EC.element_to_be_clickable((By.CSS_SELECTOR, '[data-test-submit-button]'))
         )
+
         edit_page.submit_preprint_button.click()
         detail_page = PreprintDetailPage(driver, verify=True)
         # Verify Title and Abstract

--- a/tests/test_preprints.py
+++ b/tests/test_preprints.py
@@ -282,7 +282,6 @@ class TestPreprintWorkflow:
         WebDriverWait(driver, 5).until(
             EC.visibility_of_element_located((By.CSS_SELECTOR, '[data-test-title]'))
         )
-        edit_page.next_button.click()
 
         # Next add another subject in the Discipline section
         WebDriverWait(driver, 5).until(
@@ -319,7 +318,10 @@ class TestPreprintWorkflow:
         detail_page = PreprintDetailPage(driver, verify=True)
         # Verify Title and Abstract
         assert detail_page.title.text == 'Selenium Preprint Edit'
-        assert detail_page.abstract.text == 'Testing Selenium Abstract edit'
+        assert (
+            utils.clean_text(detail_page.abstract.text)
+            == 'Testing Selenium Abstract edit'
+        )
         # Verify new Subject appears on the page
         subjects = detail_page.subjects
         subject_found = False

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -1,4 +1,5 @@
 import re
+import time
 from urllib.parse import urljoin
 
 import pytest
@@ -248,6 +249,7 @@ class TestProjectComponents:
             # the Overview page of a new node
             project_page.component_created_modal.go_to_new_component_link.click()
             component_page = ProjectPage(driver, verify=True)
+            time.sleep(1)
             assert component_page.title.text == 'Selenium Component'
             assert (
                 utils.clean_text(component_page.description.text)
@@ -278,6 +280,7 @@ class TestProjectComponents:
             # back to the original parent Project Overview page.
             component_page.scroll_into_view(component_page.parent_project_link.element)
             component_page.parent_project_link.click()
+            time.sleep(2)
             assert project_page
 
             # Verify that the Components section of the parent Project now lists the

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -8,6 +8,7 @@ from selenium.webdriver.support.ui import WebDriverWait
 
 import markers
 import settings
+import utils
 from api import osf_api
 from pages.login import (
     LoginPage,
@@ -249,7 +250,7 @@ class TestProjectComponents:
             component_page = ProjectPage(driver, verify=True)
             assert component_page.title.text == 'Selenium Component'
             assert (
-                component_page.description.text
+                utils.clean_text(component_page.description.text)
                 == 'This component was added by an automated selenium test.'
             )
 
@@ -376,7 +377,7 @@ class TestProjectComponents:
                 EC.visibility_of(project_page.alert_message.element)
             )
             assert (
-                project_page.alert_message.text
+                utils.clean_text(project_page.alert_message.text)
                 == 'Component has been successfully deleted.'
             )
             assert len(project_page.components) == 0
@@ -482,13 +483,13 @@ class TestProjectVOLs:
 
         # Verify VOL message at the top of the page
         assert (
-            project_page.alert_info_message.text
+            utils.clean_text(project_page.alert_info_message.text)
             == 'This project is being viewed through a private, view-only link. Anyone with the link can view this project. Keep the link safe.'
         )
 
         # Verify Contributor is visible
         user = osf_api.current_user()
-        assert project_page.contributors_list.text == user.full_name
+        assert utils.clean_text(project_page.contributors_list.text) == user.full_name
 
         # Verify File Widget loads
         assert project_page.file_widget.first_file
@@ -526,7 +527,7 @@ class TestProjectVOLs:
 
         # Verify VOL message at the top of the page
         assert (
-            project_page.alert_info_message.text
+            utils.clean_text(project_page.alert_info_message.text)
             == 'This project is being viewed through a private, view-only link. Anyone with the link can view this project. Keep the link safe.'
         )
 

--- a/tests/test_project_analytics.py
+++ b/tests/test_project_analytics.py
@@ -135,6 +135,10 @@ def public_project_node(session, driver):
 
 @markers.smoke_test
 @pytest.mark.usefixtures('hide_footer_slide_in')
+@pytest.mark.skipif(
+    settings.env('TEST_BUILD') == 'safari',
+    reason='Test fails on safari browser due to some oauth setting on the browser',
+)
 class TestNodeAnalytics:
     def test_unique_visits_graph(self, session, driver, public_project_node):
         """Test the Unique Visits Graph on the Project Analytics page. First retrieve

--- a/tests/test_project_files.py
+++ b/tests/test_project_files.py
@@ -10,6 +10,7 @@ from selenium.webdriver.support.ui import WebDriverWait
 
 import markers
 import settings
+import utils
 from api import osf_api
 from pages.landing import LandingPage
 from pages.project import (
@@ -659,7 +660,7 @@ class TestProjectVOLs:
 
         # Verify VOL message at the top of the page
         assert (
-            files_page.alert_info_message.text
+            utils.clean_text(files_page.alert_info_message.text)
             == 'You are viewing OSF through a view-only link, which may limit the data you have permission to see.'
         )
 
@@ -670,11 +671,16 @@ class TestProjectVOLs:
         row = find_row_by_name(files_page, file_name)
 
         # Get initial Download Count for the file (should be 0)
-        initial_download_count = int(
-            row.find_element_by_css_selector(
-                '[data-test-file-list-download-count]'
-            ).text[:2]
+        # initial_download_count = int(
+        #     row.find_element_by_css_selector(
+        #         '[data-test-file-list-download-count]'
+        #     ).text[:2]
+        # )
+        element = row.find_element_by_css_selector(
+            '[data-test-file-list-download-count]'
         )
+        download_count_text = element.get_attribute('textContent').strip()[:2]
+        initial_download_count = int(download_count_text)
         assert initial_download_count == 0
 
         # Verify File Download Functionality
@@ -682,11 +688,16 @@ class TestProjectVOLs:
 
         # Verify Download Count has incremented by 1
         row = find_row_by_name(files_page, file_name)
-        new_download_count = int(
-            row.find_element_by_css_selector(
-                '[data-test-file-list-download-count]'
-            ).text[:2]
+        # new_download_count = int(
+        #     row.find_element_by_css_selector(
+        #         '[data-test-file-list-download-count]'
+        #     ).text[:2]
+        # )
+        element = row.find_element_by_css_selector(
+            '[data-test-file-list-download-count]'
         )
+        download_count_text = element.get_attribute('textContent').strip()[:2]
+        new_download_count = int(download_count_text)
         assert new_download_count == initial_download_count + 1
 
         # Click the Leave this View button and verify we are navigated to OSF Home page

--- a/tests/test_project_registrations.py
+++ b/tests/test_project_registrations.py
@@ -1,6 +1,7 @@
 import pytest
 
 import markers
+import utils
 from api import osf_api
 from pages.project import RegistrationsPage
 from pages.registries import (
@@ -65,15 +66,15 @@ class TestProjectRegistrationsPage:
         )
         assert registrations_page.registration_card.absent()
         assert (
-            registrations_page.no_registrations_message_1.text
+            utils.clean_text(registrations_page.no_registrations_message_1.text)
             == 'There have been no completed registrations of this project.'
         )
         assert (
-            registrations_page.no_registrations_message_2.text
+            utils.clean_text(registrations_page.no_registrations_message_2.text)
             == 'Start a new registration by clicking the “New registration” button. Once created, registrations cannot be edited or deleted.'
         )
         assert (
-            registrations_page.no_registrations_message_3.text
+            utils.clean_text(registrations_page.no_registrations_message_3.text)
             == 'Learn more about registrations here.'
         )
         # Click 'here' link and verify redirection to support page
@@ -96,15 +97,15 @@ class TestProjectRegistrationsPage:
         )
         assert registrations_page.draft_registration_card.absent()
         assert (
-            registrations_page.no_draft_registrations_message_1.text
+            utils.clean_text(registrations_page.no_draft_registrations_message_1.text)
             == 'There are no draft registrations of this project.'
         )
         assert (
-            registrations_page.no_draft_registrations_message_2.text
+            utils.clean_text(registrations_page.no_draft_registrations_message_2.text)
             == 'Start a new registration by clicking the “New registration” button. Once created, registrations cannot be edited or deleted.'
         )
         assert (
-            registrations_page.no_draft_registrations_message_3.text
+            utils.clean_text(registrations_page.no_draft_registrations_message_3.text)
             == 'Learn more about registrations here.'
         )
         # Click 'here' link and verify redirection to support page
@@ -124,7 +125,7 @@ class TestProjectRegistrationsPage:
         # Get list of allowed schema names for OSF Registries from the api and verify
         # the list on the modal matches the api list
         api_schemas = osf_api.get_registration_schemas_for_provider(provider_id='osf')
-        api_schema_list = [schema[0] for schema in api_schemas]
+        api_schema_list = [utils.clean_text(schema[0]) for schema in api_schemas]
         api_schema_list.sort()
         modal_schema_list = create_registration_modal.get_schema_names_list()
         modal_schema_list.sort()
@@ -161,15 +162,21 @@ class TestProjectRegistrationsPage:
         """
         assert registrations_page_with_draft.draft_registration_card.present()
         assert (
-            registrations_page_with_draft.draft_registration_title.text
+            utils.clean_text(
+                registrations_page_with_draft.draft_registration_title.text
+            )
             == 'OSF Test Project'
         )
         assert (
-            registrations_page_with_draft.draft_registration_schema_name.text
+            utils.clean_text(
+                registrations_page_with_draft.draft_registration_schema_name.text
+            )
             == 'Open-Ended Registration'
         )
         assert (
-            registrations_page_with_draft.draft_registration_provider.text
+            utils.clean_text(
+                registrations_page_with_draft.draft_registration_provider.text
+            )
             == 'OSF Registries'
         )
         registrations_page_with_draft.review_draft_button.click()
@@ -186,7 +193,9 @@ class TestProjectRegistrationsPage:
         """
         assert registrations_page_with_draft.draft_registration_card.present()
         assert (
-            registrations_page_with_draft.draft_registration_title.text
+            utils.clean_text(
+                registrations_page_with_draft.draft_registration_title.text
+            )
             == 'OSF Test Project'
         )
         registrations_page_with_draft.edit_draft_button.click()
@@ -203,7 +212,9 @@ class TestProjectRegistrationsPage:
         """
         assert registrations_page_with_draft.draft_registration_card.present()
         assert (
-            registrations_page_with_draft.draft_registration_title.text
+            utils.clean_text(
+                registrations_page_with_draft.draft_registration_title.text
+            )
             == 'OSF Test Project'
         )
         # Click the Delete button for the Draft Registration card and then click the
@@ -220,6 +231,8 @@ class TestProjectRegistrationsPage:
         registrations_page_with_draft.delete_draft_registration_modal.delete_button.click()
         assert registrations_page_with_draft.draft_registration_card.absent()
         assert (
-            registrations_page_with_draft.no_draft_registrations_message_1.text
+            utils.clean_text(
+                registrations_page_with_draft.no_draft_registrations_message_1.text
+            )
             == 'There are no draft registrations of this project.'
         )

--- a/tests/test_registration_sidebar.py
+++ b/tests/test_registration_sidebar.py
@@ -4,6 +4,7 @@ from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.support.ui import WebDriverWait
 
 import markers
+import utils
 from api import osf_api
 from pages.registries import (
     RegistrationAnalyticsPage,
@@ -141,10 +142,10 @@ class TestRegistrationOutputs:
         )
         # Verify and delete the resource if already exists
         resource_id = osf_api.get_registration_resource_id(
-            registration_id=registration_guid
+            registration_id=registration_guid, resource_type=resource_type
         )
         if resource_id is not None:
-            osf_api.delete_registration_resource(registration_guid)
+            osf_api.delete_registration_resource(registration_guid, resource_type)
             registration_details_page.reload()
             WebDriverWait(driver, 10).until(
                 EC.invisibility_of_element_located(
@@ -161,7 +162,7 @@ class TestRegistrationOutputs:
             )
         )
         assert data_resource is not None
-        osf_api.delete_registration_resource(registration_guid)
+        osf_api.delete_registration_resource(registration_guid, resource_type)
 
     @pytest.mark.parametrize('resource_type', resource_types)
     def test_edit_resource(
@@ -184,10 +185,12 @@ class TestRegistrationOutputs:
         )
         registration_details_page_with_resource.save_button.click()
         assert (
-            registration_details_page_with_resource.resource_card_description.text
+            utils.clean_text(
+                registration_details_page_with_resource.resource_card_description.text
+            )
             == resource_description
         )
-        osf_api.delete_registration_resource(registration_guid)
+        osf_api.delete_registration_resource(registration_guid, resource_type)
 
     @pytest.mark.parametrize('resource_type', resource_types)
     def test_delete_resource(
@@ -201,7 +204,6 @@ class TestRegistrationOutputs:
         """This test verifies delete functionality of data output resource for a registration"""
 
         registration_details_page_with_resource.open_practice_resource_data.click()
-
         registration_details_page_with_resource.resource_type_delete_button.click()
         registration_details_page_with_resource.resource_type_delete_confirm.click()
 
@@ -213,6 +215,6 @@ class TestRegistrationOutputs:
         )
 
         assert (
-            registration_details_page_with_resource.resource_list.text
+            utils.clean_text(registration_details_page_with_resource.resource_list.text)
             == 'This registration has no resources.'
         )

--- a/tests/test_registration_sidebar.py
+++ b/tests/test_registration_sidebar.py
@@ -145,7 +145,7 @@ class TestRegistrationOutputs:
             registration_id=registration_guid, resource_type=resource_type
         )
         if resource_id is not None:
-            osf_api.delete_registration_resource(registration_guid, resource_type)
+            osf_api.delete_registration_resources(registration_guid)
             registration_details_page.reload()
             WebDriverWait(driver, 10).until(
                 EC.invisibility_of_element_located(
@@ -162,7 +162,7 @@ class TestRegistrationOutputs:
             )
         )
         assert data_resource is not None
-        osf_api.delete_registration_resource(registration_guid, resource_type)
+        osf_api.delete_registration_resources(registration_guid)
 
     @pytest.mark.parametrize('resource_type', resource_types)
     def test_edit_resource(

--- a/tests/test_registration_sidebar.py
+++ b/tests/test_registration_sidebar.py
@@ -162,7 +162,7 @@ class TestRegistrationOutputs:
             )
         )
         assert data_resource is not None
-        osf_api.delete_registration_resources(registration_guid)
+        osf_api.delete_registration_resource(registration_guid, resource_type)
 
     @pytest.mark.parametrize('resource_type', resource_types)
     def test_edit_resource(

--- a/tests/test_registration_sidebar.py
+++ b/tests/test_registration_sidebar.py
@@ -212,8 +212,8 @@ class TestRegistrationOutputs:
                 (By.CSS_SELECTOR, '[data-test-add-resource-section]')
             )
         )
-
-        assert (
-            utils.clean_text(registration_details_page_with_resource.resource_list.text)
-            == 'This registration has no resources.'
+        resource_id = osf_api.get_registration_resource_id(
+            registration_id=registration_guid, resource_type=resource_type
         )
+        assert resource_id is None
+        osf_api.delete_registration_resources(registration_guid)

--- a/tests/test_registration_sidebar.py
+++ b/tests/test_registration_sidebar.py
@@ -190,7 +190,7 @@ class TestRegistrationOutputs:
             )
             == resource_description
         )
-        osf_api.delete_registration_resource(registration_guid, resource_type)
+        osf_api.delete_registration_resources(registration_guid)
 
     @pytest.mark.parametrize('resource_type', resource_types)
     def test_delete_resource(
@@ -202,7 +202,6 @@ class TestRegistrationOutputs:
         fake,
     ):
         """This test verifies delete functionality of data output resource for a registration"""
-
         registration_details_page_with_resource.open_practice_resource_data.click()
         registration_details_page_with_resource.resource_type_delete_button.click()
         registration_details_page_with_resource.resource_type_delete_confirm.click()

--- a/tests/test_registries.py
+++ b/tests/test_registries.py
@@ -1,6 +1,7 @@
 import datetime
 import os
 import re
+import time
 import tkinter
 
 import pytest
@@ -787,10 +788,6 @@ class TestRegistrationFilesPages:
             file_mod_date = datetime.datetime.fromtimestamp(file_mtime)
             assert file_mod_date.date() == current_date.date()
 
-    @pytest.mark.skipif(
-        settings.env('TEST_BUILD') == 'safari',
-        reason='Test fails on safari browser due to some oauth setting on the browser',
-    )
     def test_files_list_page(self, driver, files_list_page):
         """Test the functionality available on the Files List page of a registration
         with a file.
@@ -803,17 +800,17 @@ class TestRegistrationFilesPages:
             self.verify_embed_links(files_list_page)
 
         # Get file name of first file listed
-        file_name = files_list_page.first_file_name.text
+        file_name = utils.clean_text(files_list_page.first_file_name.text)
 
         # Verify file download
         self.verify_download_link(
             driver, files_list_page, file_name, '[data-test-file-list-item]'
         )
 
-    @pytest.mark.skipif(
-        settings.env('TEST_BUILD') == 'safari',
-        reason='Test fails on safari browser due to some oauth setting on the browser',
-    )
+    # @pytest.mark.skipif(
+    #     settings.env('TEST_BUILD') == 'safari',
+    #     reason='Test fails on safari browser due to some oauth setting on the browser',
+    # )
     def test_file_detail_page(self, driver, files_list_page):
         """Test the functionality available on the Registration File Detail page"""
 
@@ -825,7 +822,12 @@ class TestRegistrationFilesPages:
             WebDriverWait(driver, 5).until(EC.number_of_windows_to_be(2))
 
             # Switch focus to the new tab
-            driver.switch_to.window(driver.window_handles[1])
+            if settings.env('TEST_BUILD') == 'safari':
+                driver.switch_to.window(driver.window_handles[0])
+                driver.execute_script('window.focus();')
+                time.sleep(5)
+            else:
+                driver.switch_to.window(driver.window_handles[1])
             file_detail_page = RegistrationFileDetailPage(driver, verify=True)
 
             # Wait for File Renderer to load
@@ -839,7 +841,7 @@ class TestRegistrationFilesPages:
             if settings.DRIVER != 'Remote':  # Can't access clipboard on remote machine
                 self.verify_embed_links(file_detail_page)
 
-            file_name = file_detail_page.file_name.text
+            file_name = utils.clean_text(file_detail_page.file_name.text)
 
             # Verify file download
             self.verify_download_link(driver, file_detail_page, file_name, 'iframe')

--- a/tests/test_registries.py
+++ b/tests/test_registries.py
@@ -807,10 +807,6 @@ class TestRegistrationFilesPages:
             driver, files_list_page, file_name, '[data-test-file-list-item]'
         )
 
-    # @pytest.mark.skipif(
-    #     settings.env('TEST_BUILD') == 'safari',
-    #     reason='Test fails on safari browser due to some oauth setting on the browser',
-    # )
     def test_file_detail_page(self, driver, files_list_page):
         """Test the functionality available on the Registration File Detail page"""
 

--- a/tests/test_registries.py
+++ b/tests/test_registries.py
@@ -1,7 +1,6 @@
 import datetime
 import os
 import re
-import time
 import tkinter
 
 import pytest
@@ -13,6 +12,7 @@ from selenium.webdriver.support.ui import WebDriverWait
 
 import markers
 import settings
+import utils
 from api import osf_api
 from pages.login import safe_login
 from pages.registrations import MyRegistrationsPage
@@ -63,7 +63,10 @@ class TestRegistriesSearch:
         )
         assert search_page.search_input.get_attribute('value') == 'QA Test'
         assert len(search_page.search_results) > 0
-        assert search_page.first_card_object_type_label.text[:12] == 'REGISTRATION'
+        assert (
+            utils.clean_text(search_page.first_card_object_type_label.text.upper())
+            == 'REGISTRATION'
+        )
 
     @markers.smoke_test
     @markers.core_functionality
@@ -318,17 +321,17 @@ class TestRegistrationSubmission:
             'This is a test registration created from a project using Selenium.'
         )
 
-        metadata_page.scroll_into_view(metadata_page.category_listbox_trigger.element)
-        metadata_page.category_listbox_trigger.click()
-        WebDriverWait(driver, 5).until(
-            EC.visibility_of_element_located(
-                (
-                    By.CSS_SELECTOR,
-                    '#ember-basic-dropdown-wormhole > div > ul >li.ember-power-select-option',
-                )
-            )
-        )
-        metadata_page.select_from_dropdown_listbox('Software')
+        # metadata_page.scroll_into_view(metadata_page.category_listbox_trigger.element)
+        # metadata_page.category_listbox_trigger.click()
+        # WebDriverWait(driver, 5).until(
+        #     EC.visibility_of_element_located(
+        #         (
+        #             By.CSS_SELECTOR,
+        #             '#ember-basic-dropdown-wormhole > div > ul >li.ember-power-select-option',
+        #         )
+        #     )
+        # )
+        # metadata_page.select_from_dropdown_listbox('Software')
         metadata_page.scroll_into_view(metadata_page.license_listbox_trigger.element)
         metadata_page.license_listbox_trigger.click()
         WebDriverWait(driver, 5).until(
@@ -346,7 +349,9 @@ class TestRegistrationSubmission:
         WebDriverWait(driver, 5).until(
             EC.visibility_of(metadata_page.first_selected_subject)
         )
-        assert metadata_page.first_selected_subject.text == 'Engineering'
+        assert (
+            utils.clean_text(metadata_page.first_selected_subject.text) == 'Engineering'
+        )
 
         metadata_page.tags_input_box.click()
         metadata_page.tags_input_box.send_keys('selenium\r')
@@ -359,7 +364,7 @@ class TestRegistrationSubmission:
 
         # Study Information Page
         study_page = DraftRegistrationStudyInfoPage(driver, verify=True)
-        assert study_page.page_heading.text == 'Study Information'
+        assert utils.clean_text(study_page.page_heading.text) == 'Study Information'
 
         study_page.hypothesis_textbox.click()
         study_page.hypothesis_textbox.send_keys_deliberately(
@@ -370,7 +375,7 @@ class TestRegistrationSubmission:
 
         # Design Plan Page
         design_page = DraftRegistrationDesignPlanPage(driver, verify=True)
-        assert design_page.page_heading.text == 'Design Plan'
+        assert utils.clean_text(design_page.page_heading.text) == 'Design Plan'
 
         design_page.other_radio_button.click()
         design_page.scroll_into_view(
@@ -386,7 +391,7 @@ class TestRegistrationSubmission:
         # Verify file is attached
         design_page.scroll_into_view(design_page.first_file_name.element)
         assert (
-            design_page.first_file_name.text
+            utils.clean_text(design_page.first_file_name.text)
             == 'osf selenium test file for registration.txt'
         )
 
@@ -395,7 +400,7 @@ class TestRegistrationSubmission:
 
         # Sampling Plan Page
         sampling_page = DraftRegistrationSamplingPlanPage(driver, verify=True)
-        assert sampling_page.page_heading.text == 'Sampling Plan'
+        assert utils.clean_text(sampling_page.page_heading.text) == 'Sampling Plan'
 
         sampling_page.reg_following_radio_button.click()
         sampling_page.scroll_into_view(sampling_page.data_procedures_textbox.element)
@@ -405,7 +410,7 @@ class TestRegistrationSubmission:
         )
         sampling_page.scroll_into_view(sampling_page.first_file_name.element)
         assert (
-            sampling_page.first_file_name.text
+            utils.clean_text(sampling_page.first_file_name.text)
             == 'osf selenium test file for registration.txt'
         )
 
@@ -416,7 +421,7 @@ class TestRegistrationSubmission:
 
         # Variables Page
         variables_page = DraftRegistrationVariablesPage(driver, verify=True)
-        assert variables_page.page_heading.text == 'Variables'
+        assert utils.clean_text(variables_page.page_heading.text) == 'Variables'
 
         # Verify that the Required Data Missing Indicator now displays in the left
         # sidebar since we left a required textbox empty on the previous page.
@@ -425,7 +430,7 @@ class TestRegistrationSubmission:
         # Verify file is attached
         variables_page.scroll_into_view(variables_page.first_file_name.element)
         assert (
-            variables_page.first_file_name.text
+            utils.clean_text(variables_page.first_file_name.text)
             == 'osf selenium test file for registration.txt'
         )
 
@@ -440,7 +445,7 @@ class TestRegistrationSubmission:
 
         # Analysis Plan Page
         analysis_page = DraftRegistrationAnalysisPlanPage(driver, verify=True)
-        assert analysis_page.page_heading.text == 'Analysis Plan'
+        assert utils.clean_text(analysis_page.page_heading.text) == 'Analysis Plan'
 
         analysis_page.stat_models_textbox.click()
         analysis_page.stat_models_textbox.send_keys_deliberately(
@@ -450,7 +455,7 @@ class TestRegistrationSubmission:
         # Verify file is attached
         analysis_page.scroll_into_view(analysis_page.first_file_name.element)
         assert (
-            analysis_page.first_file_name.text
+            utils.clean_text(analysis_page.first_file_name.text)
             == 'osf selenium test file for registration.txt'
         )
 
@@ -459,7 +464,7 @@ class TestRegistrationSubmission:
 
         # Other Page
         other_page = DraftRegistrationOtherPage(driver, verify=True)
-        assert other_page.page_heading.text == 'Other'
+        assert utils.clean_text(other_page.page_heading.text) == 'Other'
 
         other_page.other_textbox.click()
         other_page.other_textbox.send_keys_deliberately(
@@ -471,27 +476,31 @@ class TestRegistrationSubmission:
         # Review Page
         review_page = DraftRegistrationReviewPage(driver, verify=True)
 
-        assert review_page.title.text == 'Selenium Test Project With File Registration'
         assert (
-            review_page.description.text
+            utils.clean_text(review_page.title.text)
+            == 'Selenium Test Project With File Registration'
+        )
+        assert (
+            utils.clean_text(review_page.description.text)
             == 'This is a test registration created from a project using Selenium.'
         )
-        assert review_page.category.text == 'Software'
-        assert review_page.license.text == 'CC0 1.0 Universal'
-        assert review_page.subject.text == 'Engineering'
+        assert utils.clean_text(review_page.category.text) == 'Project'
+        assert utils.clean_text(review_page.license.text) == 'CC0 1.0 Universal'
+        assert utils.clean_text(review_page.subject.text) == 'Engineering'
         assert (
-            review_page.tags.text
+            utils.clean_text(review_page.tags.text)
             == 'qatest selenium tests/test_registries.py::TestRegistrationSubmission::()::test_submit_registration_from_project (setup)'
         )
 
         # Verify the validation error since we intentionally left the required Sample
         # Size textbox empty
         assert (
-            review_page.invalid_responses_text.text
+            utils.clean_text(review_page.invalid_responses_text.text)
             == 'Please address invalid or missing entries to complete registration.'
         )
         assert (
-            review_page.sample_size_question_error.text == "This field can't be blank."
+            utils.clean_text(review_page.sample_size_question_error.text)
+            == "This field can't be blank."
         )
         # Verify Register button is disabled
         assert driver.find_element(
@@ -501,7 +510,7 @@ class TestRegistrationSubmission:
         # Go back to Sampling Plan page and enter data in Sample Size textbox
         review_page.sampling_plan_page_link.click()
         sampling_page = DraftRegistrationSamplingPlanPage(driver, verify=True)
-        assert sampling_page.page_heading.text == 'Sampling Plan'
+        assert utils.clean_text(sampling_page.page_heading.text) == 'Sampling Plan'
         sampling_page.scroll_into_view(sampling_page.sample_size_textbox.element)
         sampling_page.sample_size_textbox.click()
         sampling_page.sample_size_textbox.send_keys_deliberately(
@@ -520,7 +529,7 @@ class TestRegistrationSubmission:
         assert review_page.invalid_responses_text.absent()
         assert review_page.sample_size_question_error.absent()
         assert (
-            review_page.sample_size_response.text
+            utils.clean_text(review_page.sample_size_response.text)
             == 'Sample Size textbox - regression testing using selenium.'
         )
 
@@ -534,7 +543,7 @@ class TestRegistrationSubmission:
         # Admin Approval status
         tombstone_page = RegistrationTombstonePage(driver, verify=True)
         assert (
-            tombstone_page.tombstone_title.text
+            utils.clean_text(tombstone_page.tombstone_title.text)
             == 'This registration is currently archiving, and no changes can be made at this time.'
         )
 
@@ -588,18 +597,18 @@ class TestRegistrationSubmission:
         metadata_page.description_textarea.send_keys_deliberately(
             'This is a test registration created using Selenium.'
         )
-        time.sleep(2)
-        metadata_page.scroll_into_view(metadata_page.category_listbox_trigger.element)
-        metadata_page.category_listbox_trigger.click()
-        WebDriverWait(driver, 5).until(
-            EC.visibility_of_element_located(
-                (
-                    By.CSS_SELECTOR,
-                    '#ember-basic-dropdown-wormhole > div > ul >li.ember-power-select-option',
-                )
-            )
-        )
-        metadata_page.select_from_dropdown_listbox('Software')
+
+        # metadata_page.scroll_into_view(metadata_page.category_listbox_trigger.element)
+        # metadata_page.category_listbox_trigger.click()
+        # WebDriverWait(driver, 5).until(
+        #     EC.visibility_of_element_located(
+        #         (
+        #             By.CSS_SELECTOR,
+        #             '#ember-basic-dropdown-wormhole > div > ul >li.ember-power-select-option',
+        #         )
+        #     )
+        # )
+        # metadata_page.select_from_dropdown_listbox('Software')
 
         metadata_page.scroll_into_view(metadata_page.license_listbox_trigger.element)
         metadata_page.license_listbox_trigger.click()
@@ -618,7 +627,9 @@ class TestRegistrationSubmission:
         WebDriverWait(driver, 5).until(
             EC.visibility_of(metadata_page.first_selected_subject)
         )
-        assert metadata_page.first_selected_subject.text == 'Engineering'
+        assert (
+            utils.clean_text(metadata_page.first_selected_subject.text) == 'Engineering'
+        )
 
         metadata_page.tags_input_box.click()
         metadata_page.tags_input_box.send_keys('selenium\r')
@@ -628,7 +639,7 @@ class TestRegistrationSubmission:
         metadata_page.next_page_button.click()
 
         summary_page = DraftRegistrationSummaryPage(driver, verify=True)
-        assert summary_page.page_heading.text == 'Summary'
+        assert utils.clean_text(summary_page.page_heading.text) == 'Summary'
 
         summary_page.summary_textbox.click()
         summary_page.summary_textbox.send_keys_deliberately(
@@ -642,15 +653,18 @@ class TestRegistrationSubmission:
         review_page = DraftRegistrationReviewPage(driver, verify=True)
         review_page.loading_indicator.here_then_gone()
 
-        assert review_page.title.text == 'Selenium Test No Project Registration'
         assert (
-            review_page.description.text
+            utils.clean_text(review_page.title.text)
+            == 'Selenium Test No Project Registration'
+        )
+        assert (
+            utils.clean_text(review_page.description.text)
             == 'This is a test registration created using Selenium.'
         )
-        assert review_page.category.text == 'Software'
-        assert review_page.license.text == 'CC0 1.0 Universal'
-        assert review_page.subject.text == 'Engineering'
-        assert review_page.tags.text == 'selenium'
+        # assert utils.clean_text(review_page.category.text) == 'Software'
+        assert utils.clean_text(review_page.license.text) == 'CC0 1.0 Universal'
+        assert utils.clean_text(review_page.subject.text) == 'Engineering'
+        assert utils.clean_text(review_page.tags.text) == 'selenium'
 
         review_page.register_button.click()
 
@@ -793,6 +807,10 @@ class TestRegistrationFilesPages:
             file_mod_date = datetime.datetime.fromtimestamp(file_mtime)
             assert file_mod_date.date() == current_date.date()
 
+    @pytest.mark.skipif(
+        settings.env('TEST_BUILD') == 'safari',
+        reason='Test fails on safari browser due to some oauth setting on the browser',
+    )
     def test_files_list_page(self, driver, files_list_page):
         """Test the functionality available on the Files List page of a registration
         with a file.
@@ -812,6 +830,10 @@ class TestRegistrationFilesPages:
             driver, files_list_page, file_name, '[data-test-file-list-item]'
         )
 
+    @pytest.mark.skipif(
+        settings.env('TEST_BUILD') == 'safari',
+        reason='Test fails on safari browser due to some oauth setting on the browser',
+    )
     def test_file_detail_page(self, driver, files_list_page):
         """Test the functionality available on the Registration File Detail page"""
 

--- a/tests/test_registries.py
+++ b/tests/test_registries.py
@@ -817,16 +817,7 @@ class TestRegistrationFilesPages:
             WebDriverWait(driver, 5).until(EC.number_of_windows_to_be(2))
 
             # Switch focus to the new tab
-            if settings.env('TEST_BUILD') == 'safari':
-                driver.switch_to.window(driver.window_handles[0])
-                driver.execute_script('window.focus();')
-                WebDriverWait(driver, 10).until(
-                    EC.visibility_of_element_located(
-                        (By.CSS_SELECTOR, '[data-test-file-renderer]')
-                    )
-                )
-            else:
-                driver.switch_to.window(driver.window_handles[1])
+            utils.switch_to_new_tab(driver)
             file_detail_page = RegistrationFileDetailPage(driver, verify=True)
 
             # Wait for File Renderer to load

--- a/tests/test_registries.py
+++ b/tests/test_registries.py
@@ -1,7 +1,6 @@
 import datetime
 import os
 import re
-import time
 import tkinter
 
 import pytest
@@ -821,7 +820,11 @@ class TestRegistrationFilesPages:
             if settings.env('TEST_BUILD') == 'safari':
                 driver.switch_to.window(driver.window_handles[0])
                 driver.execute_script('window.focus();')
-                time.sleep(5)
+                WebDriverWait(driver, 10).until(
+                    EC.visibility_of_element_located(
+                        (By.CSS_SELECTOR, '[data-test-file-renderer]')
+                    )
+                )
             else:
                 driver.switch_to.window(driver.window_handles[1])
             file_detail_page = RegistrationFileDetailPage(driver, verify=True)

--- a/tests/test_registries.py
+++ b/tests/test_registries.py
@@ -123,6 +123,8 @@ class TestRegistriesSearch:
             # Wait for the new tab to open - window count should then = 2
             WebDriverWait(driver, 5).until(EC.number_of_windows_to_be(2))
             # Switch focus to the new tab
+            if settings.env('TEST_BUILD') == 'safari':
+                driver.switch_to.window(driver.window_handles[-1])
             driver.switch_to.window(driver.window_handles[1])
             detail_page = RegistrationDetailPage(driver, verify=True)
             assert detail_page.title.text in target_registration_title

--- a/tests/test_registries.py
+++ b/tests/test_registries.py
@@ -323,17 +323,6 @@ class TestRegistrationSubmission:
             'This is a test registration created from a project using Selenium.'
         )
 
-        # metadata_page.scroll_into_view(metadata_page.category_listbox_trigger.element)
-        # metadata_page.category_listbox_trigger.click()
-        # WebDriverWait(driver, 5).until(
-        #     EC.visibility_of_element_located(
-        #         (
-        #             By.CSS_SELECTOR,
-        #             '#ember-basic-dropdown-wormhole > div > ul >li.ember-power-select-option',
-        #         )
-        #     )
-        # )
-        # metadata_page.select_from_dropdown_listbox('Software')
         metadata_page.scroll_into_view(metadata_page.license_listbox_trigger.element)
         metadata_page.license_listbox_trigger.click()
         WebDriverWait(driver, 5).until(
@@ -600,18 +589,6 @@ class TestRegistrationSubmission:
             'This is a test registration created using Selenium.'
         )
 
-        # metadata_page.scroll_into_view(metadata_page.category_listbox_trigger.element)
-        # metadata_page.category_listbox_trigger.click()
-        # WebDriverWait(driver, 5).until(
-        #     EC.visibility_of_element_located(
-        #         (
-        #             By.CSS_SELECTOR,
-        #             '#ember-basic-dropdown-wormhole > div > ul >li.ember-power-select-option',
-        #         )
-        #     )
-        # )
-        # metadata_page.select_from_dropdown_listbox('Software')
-
         metadata_page.scroll_into_view(metadata_page.license_listbox_trigger.element)
         metadata_page.license_listbox_trigger.click()
         WebDriverWait(driver, 5).until(
@@ -791,6 +768,7 @@ class TestRegistrationFilesPages:
                 'browserstack_executor: {"action": "fileExists", "arguments": {"fileName": "%s"}}'
                 % (file_name)
             )
+
             # Next get the file properties and then verify that the file creation date
             # is today
             file_props = driver.execute_script(

--- a/tests/test_registries.py
+++ b/tests/test_registries.py
@@ -1,6 +1,7 @@
 import datetime
 import os
 import re
+import time
 import tkinter
 
 import pytest
@@ -587,7 +588,7 @@ class TestRegistrationSubmission:
         metadata_page.description_textarea.send_keys_deliberately(
             'This is a test registration created using Selenium.'
         )
-
+        time.sleep(2)
         metadata_page.scroll_into_view(metadata_page.category_listbox_trigger.element)
         metadata_page.category_listbox_trigger.click()
         WebDriverWait(driver, 5).until(

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -5,6 +5,7 @@ from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.support.ui import WebDriverWait
 
 import markers
+import utils
 from pages.search import SearchPage
 
 
@@ -43,7 +44,11 @@ class TestSearchPage:
         )
         assert len(search_page.search_results) > 0
         # Verify that first search result is of Project type
-        assert search_page.first_card_object_type_label.text[:7] == 'PROJECT'
+        # assert search_page.first_card_object_type_label.text[:7] == 'PROJECT'
+        assert (
+            'PROJECT'
+            in utils.clean_text(search_page.first_card_object_type_label.text).upper()
+        )
 
     def test_search_results_exist_registrations_tab(self, driver, search_page):
         search_page.search_input.send_keys('test')
@@ -59,7 +64,10 @@ class TestSearchPage:
         )
         assert len(search_page.search_results) > 0
         # Verify that first search result is of Registration type
-        assert search_page.first_card_object_type_label.text[:12] == 'REGISTRATION'
+        assert (
+            utils.clean_text(search_page.first_card_object_type_label.text.upper())
+            == 'REGISTRATION'
+        )
 
     def test_search_results_exist_preprints_tab(self, driver, search_page):
         search_page.search_input.send_keys('test')
@@ -75,7 +83,10 @@ class TestSearchPage:
         )
         assert len(search_page.search_results) > 0
         # Verify that first search result is of Preprint type
-        assert search_page.first_card_object_type_label.text == 'PREPRINT'
+        assert (
+            utils.clean_text(search_page.first_card_object_type_label.text.upper())
+            == 'PREPRINT'
+        )
 
     def test_search_results_exist_files_tab(self, driver, search_page):
         search_page.search_input.send_keys('test')
@@ -91,7 +102,10 @@ class TestSearchPage:
         )
         assert len(search_page.search_results) > 0
         # Verify that first search result is of File type
-        assert search_page.first_card_object_type_label.text == 'FILE'
+        assert (
+            utils.clean_text(search_page.first_card_object_type_label.text.upper())
+            == 'FILE'
+        )
 
     def test_search_results_exist_users_tab(self, driver, search_page):
         search_page.loading_indicator.here_then_gone()
@@ -105,4 +119,7 @@ class TestSearchPage:
         )
         assert len(search_page.search_results) > 0
         # Verify that first search result is of User type
-        assert search_page.first_card_object_type_label.text == 'USER'
+        assert (
+            utils.clean_text(search_page.first_card_object_type_label.text.upper())
+            == 'USER'
+        )

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -11,6 +11,7 @@ from selenium.webdriver.support.ui import WebDriverWait
 import components.email_access as EmailAccess
 import markers
 import settings
+import utils
 from api import osf_api
 from pages import user
 
@@ -210,7 +211,9 @@ class TestUserAccountSettings:
         # matches the storage location region that is displayed as selected in the
         # listbox
         user_region = osf_api.get_user_region_name(session)
-        assert settings_page.storage_location_listbox.text == user_region
+        assert (
+            utils.clean_text(settings_page.storage_location_listbox.text) == user_region
+        )
 
         # Click the listbox to display all of the storage locations and get a list
         # of the displayed regions
@@ -219,7 +222,9 @@ class TestUserAccountSettings:
             By.CSS_SELECTOR,
             'div.ember-basic-dropdown-content-wormhole-origin > div > ul > li',
         )
-        listbox_regions = sorted([region.text for region in listbox_items])
+        listbox_regions = sorted(
+            [utils.clean_text(region.text) for region in listbox_items]
+        )
 
         # Get available regions using the api and verify that the lists match
         regions_data = osf_api.get_regions_data(session)
@@ -236,9 +241,7 @@ class TestUserAccountSettings:
         settings_page = user.AccountSettingsPage(driver)
         settings_page.goto()
         assert user.AccountSettingsPage(driver, verify=True)
-        settings_page.scroll_into_view(
-            settings_page.first_affiliated_institution.element
-        )
+        settings_page.scroll_into_view(settings_page.affiliation_help_text.element)
 
         # Click the Delete button to the far right of the first affiliated institution.
         # On the Delete modal, first click the Cancel button and verify that the
@@ -254,7 +257,10 @@ class TestUserAccountSettings:
         settings_page.delete_aff_inst_modal.delete_button.click()
         settings_page.loading_indicator.here_then_gone()
         settings_page.first_affiliated_institution.absent()
-        assert settings_page.no_affiliations_message.text == 'You have no affiliations.'
+        assert (
+            utils.clean_text(settings_page.no_affiliations_message.text)
+            == 'You have no affiliations.'
+        )
 
     def test_user_account_settings_update_password(self, driver, session):
         """Test the Change password section on the User Account Settings page in OSF.
@@ -271,17 +277,17 @@ class TestUserAccountSettings:
 
         assert settings_page.old_password_error_message.present()
         assert (
-            settings_page.old_password_error_message.text
+            utils.clean_text(settings_page.old_password_error_message.text)
             == "This field can't be blank."
         )
         assert settings_page.new_password_error_message.present()
         assert (
-            settings_page.new_password_error_message.text
+            utils.clean_text(settings_page.new_password_error_message.text)
             == "This field can't be blank."
         )
         assert settings_page.confirm_password_error_message.present()
         assert (
-            settings_page.confirm_password_error_message.text
+            utils.clean_text(settings_page.confirm_password_error_message.text)
             == "This field can't be blank."
         )
 
@@ -297,7 +303,7 @@ class TestUserAccountSettings:
 
         # Scroll down to the Security settings section near the bottom of the page and
         # click the Configure button
-        settings_page.scroll_into_view(settings_page.configure_2fa_button.element)
+        settings_page.scroll_into_view(settings_page.two_factor_help.element)
         settings_page.configure_2fa_button.click()
 
         # On the Configure 2FA Modal, first click the Cancel button and verify that the
@@ -343,7 +349,7 @@ class TestUserAccountSettings:
         # Verify that the account pending deactivation message is now displayed
         assert settings_page.pending_deactivation_message.present()
         assert (
-            settings_page.pending_deactivation_message.text
+            utils.clean_text(settings_page.pending_deactivation_message.text)
             == 'Your account is currently pending deactivation.'
         )
 
@@ -354,7 +360,7 @@ class TestUserAccountSettings:
         settings_page.undo_deactivation_modal.cancel_button.click()
         assert settings_page.pending_deactivation_message.present()
         assert (
-            settings_page.pending_deactivation_message.text
+            utils.clean_text(settings_page.pending_deactivation_message.text)
             == 'Your account is currently pending deactivation.'
         )
 
@@ -452,7 +458,10 @@ class TestUserDeveloperApps:
             # Click the Show client secret button to unveil the client secret and verify
             # the text on the button has changed to 'Hide client secret'
             edit_page.show_client_secret_button.click()
-            assert edit_page.show_client_secret_button.text == 'Hide client secret'
+            assert (
+                utils.clean_text(edit_page.show_client_secret_button.text)
+                == 'Hide client secret'
+            )
             assert edit_page.client_secret_input.get_attribute('value') == client_secret
             edit_page.scroll_into_view(edit_page.app_name_input.element)
             assert edit_page.app_name_input.get_attribute('value') == app_name
@@ -689,7 +698,10 @@ class TestUserDeveloperApps:
             # Click the Show client secret button to unveil the client secret and verify
             # the text on the button has changed to 'Hide client secret'
             edit_page.show_client_secret_button.click()
-            assert edit_page.show_client_secret_button.text == 'Hide client secret'
+            assert (
+                utils.clean_text(edit_page.show_client_secret_button.text)
+                == 'Hide client secret'
+            )
             assert edit_page.client_secret_input.get_attribute('value') == client_secret
             edit_page.scroll_into_view(edit_page.app_name_input.element)
             assert edit_page.app_name_input.get_attribute('value') == new_app_name

--- a/utils.py
+++ b/utils.py
@@ -203,3 +203,10 @@ def read_data_from_table(driver, table_path, check_match, item_match=None):
                     return i, datalist
 
     return rlen, datalist
+
+
+def clean_text(stringvalue):
+    clean_text = stringvalue.strip()
+    clean_text = clean_text.replace('\n', ' ')
+    clean_text = ' '.join(clean_text.split())
+    return clean_text

--- a/utils.py
+++ b/utils.py
@@ -95,7 +95,6 @@ def launch_driver(driver_name=settings.DRIVER, desired_capabilities=None):
         driver = driver_cls(options=ffo)
     elif driver_name == 'Edge' and not settings.HEADLESS:
         driver = webdriver.Edge()
-
     else:
         driver = driver_cls()
 


### PR DESCRIPTION
<!-- Before you submit your Pull Request, please confirm that:

     - Any test that will create public data either has the `QAtest` tag or the `dont_run_on_production` marker
     - `core_functionality` is marked as such
     - Your tests will be able to run on *all* servers (all stagings, test)
 -->


## Purpose
Updated the selenium test suite to support safari browser local and remote.
Fixed following tests to be executed without error on safari browser:

- test_collections.py
- test_dashboard.py
- test_institutions.py
- test_landing.py
- test_login.py
- test_meetings.py
- test_metadata.py
- test_my_projects.py
- test_my_registrations.py
- test_navbar.py
- test_popular_pages.py
- test_preprints.py
- test_registration_sidebar.py
- test_registries.py

## Summary of Changes

1. Updated settings.py to include desired capabilities for safari remote browser
2. Updated utils.py with a method to clean string objects 
3. Update tests to fix assertion errors and added delays to fix timeout errors

Fixed following tests.

test_landing.py
tests/test_landing.py::TestHomeLandingPage::test_learn_more PASSED
tests/test_landing.py::TestHomeLandingPage::test_testimonials_by_buttons PASSED

test_login.py

In test_login.py fixed following tests:

tests/test_login.py::Test2FAPage::test_need_help_link PASSED
tests/test_login.py::TestToSPage::test_continue_button_disabled PASSED
tests/test_login.py::TestToSPage::test_terms_of_use_link PASSED
tests/test_login.py::TestToSPage::test_privacy_policy_link tests/test_login.py::Test2FAPage::test_cancel_2fa_login PASSED
tests/test_login.py::Test2FAPage::test_need_help_link PASSED
tests/test_login.py::TestToSPage::test_terms_of_use_link PASSED
tests/test_login.py::TestToSPage::test_privacy_policy_link PASSED
tests/test_login.py::TestLoginErrors::test_missing_email PASSED
tests/test_login.py::TestLoginErrors::test_missing_password PASSED

Following tests are still failing due to OAUTH is blocked on safari. 

tests/test_login.py::TestOauthAPI::test_authorization_online FAILED tests/test_login.py::TestOauthAPI::test_authorization_offline FAILED
tests/test_login.py::TestOauthAPI::test_authorization_single_scope FAILED


## Reviewer's Actions
`git fetch <remote> pull/276/head:feature/integrating-safari-browser`

Run this test using 
`pytest tests/test_collections.py -s -v`
`pytest tests/test_dashboard.py -s -v`
`pytest tests/test_institutions.py -s -v`
`pytest tests/test_landing.py -s -v`
`pytest tests/test_login.py -s -v`
`pytest tests/test_meetings.py -s -v`
`pytest tests/test_metadata.py -s -v`
`pytest tests/test_my_projects.py -s -v`
`pytest tests/test_my_registrations.py -s -v`
`pytest tests/test_navbar.py -s -v`
`pytest tests/test_popular_pages.py -s -v`
`pytest tests/test_preprints.py -s -v`
`pytest tests/test_registration_sidebar.py -s -v`
`pytest tests/test_registries.py -s -v`


Change .env file to run tests on safari browser

## Testing Changes Moving Forward



## Ticket

https://openscience.atlassian.net/browse/ENG-6143
https://openscience.atlassian.net/browse/ENG-6144
https://openscience.atlassian.net/browse/ENG-6145
https://openscience.atlassian.net/browse/ENG-6146
https://openscience.atlassian.net/browse/ENG-7091
https://openscience.atlassian.net/browse/ENG-7717
