### PR TITLE
[ENG-7680] Feature/Project Contributors Metadata

### DIFF
--- a/pages/project.py
+++ b/pages/project.py
@@ -597,9 +597,10 @@ class ProjectMetadataPage(GuidBasePage):
     resource_information_save_button = Locator(
         By.CSS_SELECTOR, '[data-test-save-resource-metadata-button]'
     )
-
+    # Get the rows of search results matching the locator
     rows = GroupLocator(By.CSS_SELECTOR, '[data-test-user-card-main]')
 
+    # Select the correct user from the table of search results
     def select_from_table_of_rows(self, selection):
         for row in self.rows:
             cell = row.find_element(
@@ -615,11 +616,11 @@ class ProjectMetadataPage(GuidBasePage):
         By.CSS_SELECTOR, '[data-analytics-name="Contributor name"]'
     )
 
+    # Select new_user from contributors list on metadata page
     def select_from_list(self, selection):
         for contributor in self.contributors_list:
             if selection in contributor.text.strip():
                 return contributor
-                break
 
     search_cancel_button = Locator(
         By.CSS_SELECTOR, '[data-test-user-search-cancel-button]'

--- a/pages/project.py
+++ b/pages/project.py
@@ -563,11 +563,13 @@ class ProjectMetadataPage(GuidBasePage):
     add_contributor_button = Locator(
         By.CSS_SELECTOR, 'a.btn.btn-success.btn-sm.m-l-md[href="#addContributors"]'
     )
-    contributor_search_button = Locator(By.XPATH, '//input[@class="btn btn-default"]')
+    contributor_search_button = Locator(
+        By.CSS_SELECTOR, '[data-test-user-search-button]'
+    )
     add_displayed_contributor_button = Locator(
         By.CSS_SELECTOR, '[a.btn.btn-success.contrib-button.btn-mini]'
     )
-    search_input = Locator(By.XPATH, '//input[@class="form-control"]')
+    search_input = Locator(By.CSS_SELECTOR, '[data-test-user-search-input]')
     resource_type = Locator(
         By.CSS_SELECTOR, '[data-test-display-resource-type-general]'
     )
@@ -594,6 +596,36 @@ class ProjectMetadataPage(GuidBasePage):
 
     resource_information_save_button = Locator(
         By.CSS_SELECTOR, '[data-test-save-resource-metadata-button]'
+    )
+
+    rows = GroupLocator(By.CSS_SELECTOR, '[data-test-user-card-main]')
+
+    def select_from_table_of_rows(self, selection):
+        for row in self.rows:
+            cell = row.find_element(
+                By.CSS_SELECTOR, '[data-analytics-name="View user"]'
+            )
+            if selection in cell.text.strip():
+                row.find_element(
+                    By.CSS_SELECTOR, '[data-test-add-contributor-button]'
+                ).click()
+                break
+
+    contributors_list = GroupLocator(
+        By.CSS_SELECTOR, '[data-analytics-name="Contributor name"]'
+    )
+
+    def select_from_list(self, selection):
+        for contributor in self.contributors_list:
+            if selection in contributor.text.strip():
+                return contributor
+                break
+
+    search_cancel_button = Locator(
+        By.CSS_SELECTOR, '[data-test-user-search-cancel-button]'
+    )
+    add_contributor_finish_button = Locator(
+        By.CSS_SELECTOR, '[data-test-finish-node-contributor-editing-button]'
     )
 
     funder_name = Locator(By.XPATH, '//span[@class="ember-power-select-status-icon"]')

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -352,7 +352,7 @@ class TestProjectMetadata:
         project_metadata_page.search_input.send_keys(new_user)
         project_metadata_page.contributor_search_button.click()
 
-        # Get the row number for the user from the search table
+        # Select the new_user from the search results and add the user to the project
         WebDriverWait(driver, 5).until(
             EC.visibility_of_element_located(
                 (
@@ -371,6 +371,7 @@ class TestProjectMetadata:
                 (By.CSS_SELECTOR, '[data-test-contributors-list]')
             )
         )
+        # Retrieve the new_user from contributors list
         user = project_metadata_page.select_from_list(new_user)
         assert new_user in user.text.strip()
 

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -345,19 +345,9 @@ class TestProjectMetadata:
 
         WebDriverWait(driver, 5).until(
             EC.element_to_be_clickable(
-                (By.CSS_SELECTOR, '[data-test-edit-contributors]')
+                (By.CSS_SELECTOR, '[data-test-edit-node-contributors-button]')
             )
         ).click()
-
-        WebDriverWait(driver, 5).until(
-            EC.element_to_be_clickable(
-                (
-                    By.CSS_SELECTOR,
-                    'a.btn.btn-success.btn-sm.m-l-md[href="#addContributors"]',
-                )
-            )
-        ).click()
-
         project_metadata_page.search_input.click()
         project_metadata_page.search_input.send_keys(new_user)
         project_metadata_page.contributor_search_button.click()
@@ -366,43 +356,23 @@ class TestProjectMetadata:
         WebDriverWait(driver, 5).until(
             EC.visibility_of_element_located(
                 (
-                    By.XPATH,
-                    '//div[@class="row"]/div[@class="col-md-4"]/table[@class="table-condensed table-hover"]',
+                    By.CSS_SELECTOR,
+                    '[data-test-user-card]',
                 )
             )
         )
-        search_table_path = '//table[@class="table-condensed table-hover"]'
-        rno, search_table_data = utils.read_data_from_table(
-            driver, search_table_path, check_match=True, item_match=new_user
-        )
-        # Click on the Add button of the row number for the user from the search table to add the new contributor user
-        WebDriverWait(driver, 5).until(
-            EC.element_to_be_clickable(
-                (By.XPATH, search_table_path + '/tbody/tr[' + str(rno) + ']/td[1]')
-            )
-        ).click()
 
-        WebDriverWait(driver, 5).until(
-            EC.element_to_be_clickable((By.XPATH, '//a[@class="btn btn-success"]'))
-        ).click()
+        project_metadata_page.select_from_table_of_rows(new_user)
+        project_metadata_page.search_cancel_button.click()
+        project_metadata_page.add_contributor_finish_button.click()
 
-        project_metadata_page.reload()
         WebDriverWait(driver, 5).until(
             EC.visibility_of_element_located(
-                (By.XPATH, '//table[@id="manageContributorsTable"]')
+                (By.CSS_SELECTOR, '[data-test-contributors-list]')
             )
         )
-        contributor_table_path = '//table[@id="manageContributorsTable"]'
-        # Get the total number of rows in contributors table
-        rowno, contributor_table_data = utils.read_data_from_table(
-            driver, contributor_table_path, check_match=False
-        )
-
-        # Get the user name from the last row which is added recently
-        user = driver.find_element_by_xpath(
-            contributor_table_path + '/tbody/tr[' + str(rowno) + ']/td[2]'
-        )
-        assert new_user in user.text
+        user = project_metadata_page.select_from_list(new_user)
+        assert new_user in user.text.strip()
 
     def test_edit_resource_information(self, driver, project_metadata_page):
         """This test verifies that user can add/remove


### PR DESCRIPTION
<!-- Before you submit your Pull Request, please confirm that:

     - Any test that will create public data either has the `QAtest` tag or the `dont_run_on_production` marker
     - `core_functionality` is marked as such
     - Your tests will be able to run on *all* servers (all stagings, test)
 -->


## Purpose
Fix test_metadata.py::TestProjectMetadata::test_edit_contributors to accommodate new workflow changes to the contributors modal


## Summary of Changes

1.  Updated test_metadata.py to fix the new contributors modal workflow
2.  Updated project.py page to include new methods for selecting item from table and selecting item from  a list


## Reviewer's Actions
`git fetch <remote> pull/278/head:feature/project_edit_contributors_metadata_fix`

Run this test using
`tests/test_metadata.py::TestProjectMetadata::test_edit_contributors -s -v`

## Testing Changes Moving Forward



## Ticket

https://openscience.atlassian.net/browse/ENG-7680
