### PR TITLE
Added edit title and edit contributors tests

### DIFF
--- a/api/osf_api.py
+++ b/api/osf_api.py
@@ -1279,3 +1279,45 @@ def create_registration_resource(registration_guid, resource_type):
         item_id=resource_id,
         item_type='resources',
     )['data']
+
+
+def update_registration_title(registration_guid, title):
+    """This method updates the title of the given
+    registration."""
+    session = client.Session(
+        api_base_url=settings.API_DOMAIN,
+        auth=(settings.REGISTRATIONS_USER, settings.REGISTRATIONS_USER_PASSWORD),
+    )
+    url = '/v2/registrations/{}/'.format(registration_guid)
+    payload = {
+        'data': {
+            'id': registration_guid,
+            'type': 'registrations',
+            'attributes': {'title': title},
+        }
+    }
+    session.patch(
+        url=url,
+        raw_body=json.dumps(payload),
+        item_id=registration_guid,
+        item_type='registrations',
+    )['data']
+
+
+def delete_registration_contributor(registration_guid, user_name):
+    """This method deletes the given user from the given registration"""
+    session = client.Session(
+        api_base_url=settings.API_DOMAIN,
+        auth=(settings.REGISTRATIONS_USER, settings.REGISTRATIONS_USER_PASSWORD),
+    )
+    url = '/v2/registrations/{}/contributors/'.format(registration_guid)
+    data = session.get(url)['data']
+
+    for i in range(0, len(data)):
+        if user_name in data[i]['embeds']['users']['data']['attributes']['full_name']:
+            user_id = data[i]['embeds']['users']['data']['id']
+            delete_url = '/v2/registrations/{}/contributors/{}/'.format(
+                registration_guid, user_id
+            )
+            session.delete(delete_url, item_type='users')
+            break

--- a/pages/registries.py
+++ b/pages/registries.py
@@ -143,22 +143,27 @@ class RegistrationDetailPage(BaseSubmittedRegistrationPage):
 class RegistrationMetadataPage(BaseSubmittedRegistrationPage):
     url_addition = 'metadata'
     identity = Locator(By.CSS_SELECTOR, '[data-test-display-resource-type-general]')
-
+    metadata_title = Locator(By.CSS_SELECTOR, '[data-test-display-node-title]')
     metadata_description = Locator(
         By.CSS_SELECTOR, '[data-test-display-node-description]'
     )
     edit_metadata_description_button = Locator(
         By.CSS_SELECTOR, '[data-test-edit-node-description-button]'
     )
+    save_metadata_title_button = Locator(
+        By.CSS_SELECTOR, '[data-test-save-node-title-button]'
+    )
     save_metadata_description_button = Locator(
         By.CSS_SELECTOR, '[data-test-save-node-description-button]'
     )
     contributors_list = Locator(By.CSS_SELECTOR, '[data-test-contributors-list]')
-    contributor_search_button = Locator(By.XPATH, '//input[@class="btn btn-default"]')
+    contributor_search_button = Locator(
+        By.CSS_SELECTOR, '[data-test-user-search-button]'
+    )
     add_displayed_contributor_button = Locator(
         By.CSS_SELECTOR, '[a.btn.btn-success.contrib-button.btn-mini]'
     )
-    search_input = Locator(By.XPATH, '//input[@class="form-control"]')
+    search_input = Locator(By.CSS_SELECTOR, '[data-test-user-search-input]')
     resource_type = Locator(
         By.CSS_SELECTOR, '[data-test-display-resource-type-general]'
     )
@@ -182,6 +187,35 @@ class RegistrationMetadataPage(BaseSubmittedRegistrationPage):
             if option.text == selection:
                 option.click()
                 break
+
+    rows = GroupLocator(By.CSS_SELECTOR, '[data-test-user-card-main]')
+
+    def select_from_table_of_rows(self, selection):
+        for row in self.rows:
+            cell = row.find_element(
+                By.CSS_SELECTOR, '[data-analytics-name="View user"]'
+            )
+            if selection in cell.text.strip():
+                row.find_element(
+                    By.CSS_SELECTOR, '[data-test-add-contributor-button]'
+                ).click()
+                break
+
+    contributors_list = GroupLocator(
+        By.CSS_SELECTOR, '[data-analytics-name="Contributor name"]'
+    )
+
+    def select_from_list(self, selection):
+        for contributor in self.contributors_list:
+            if selection in contributor.text.strip():
+                return contributor
+
+    search_cancel_button = Locator(
+        By.CSS_SELECTOR, '[data-test-user-search-cancel-button]'
+    )
+    add_contributor_finish_button = Locator(
+        By.CSS_SELECTOR, '[data-test-finish-node-contributor-editing-button]'
+    )
 
     resource_information_save_button = Locator(
         By.CSS_SELECTOR, '[data-test-save-resource-metadata-button]'

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -482,10 +482,13 @@ class TestProjectMetadata:
 @markers.core_functionality
 class TestRegistrationMetadata:
     @pytest.fixture()
-    def registration_metadata_page(self, driver):
-        registration_guid = osf_api.get_registration_by_title(
-            'Selenium Registration for Metadata tests'
-        )
+    def title(self):
+        TITLE = 'Selenium Registration for Metadata tests'
+        return TITLE
+
+    @pytest.fixture()
+    def registration_metadata_page(self, driver, title):
+        registration_guid = osf_api.get_registration_by_title(title)
         osf_api.update_registration_metadata_with_custom_data(registration_guid)
         registration_metadata_page = RegistrationMetadataPage(
             driver, guid=registration_guid
@@ -494,21 +497,19 @@ class TestRegistrationMetadata:
         return registration_metadata_page
 
     @pytest.fixture()
-    def registration_guid(self):
-        registration_guid = osf_api.get_registration_by_title(
-            'Selenium Registration for Metadata tests'
-        )
+    def registration_guid(self, title):
+        registration_guid = osf_api.get_registration_by_title(title)
         return registration_guid
 
     def test_edit_metadata_title_and_description(
-        self, driver, registration_metadata_page, fake, registration_guid
+        self, driver, registration_metadata_page, fake, registration_guid, title
     ):
         """This test verifies that the registration metadata title
         and description fields are editable and changes are saved."""
 
         new_title = fake.sentence(nb_words=2)
         new_description = fake.sentence(nb_words=4)
-        original_title = 'Selenium Registration for Metadata tests'
+        # original_title = 'Selenium Registration for Metadata tests'
 
         WebDriverWait(driver, 5).until(
             EC.element_to_be_clickable(
@@ -540,8 +541,11 @@ class TestRegistrationMetadata:
         assert new_description == utils.clean_text(
             registration_metadata_page.metadata_description.text
         )
+        assert new_title == utils.clean_text(
+            registration_metadata_page.metadata_title.text
+        )
         osf_api.update_registration_title(
-            registration_guid=registration_guid, title=original_title
+            registration_guid=registration_guid, title=title
         )
 
     def test_edit_contributors(

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -493,11 +493,37 @@ class TestRegistrationMetadata:
         registration_metadata_page.goto()
         return registration_metadata_page
 
-    def test_edit_metadata_description(self, driver, registration_metadata_page, fake):
-        """This test verifies that the registration metadata field
-        description is editable and changes are saved."""
+    @pytest.fixture()
+    def registration_guid(self):
+        registration_guid = osf_api.get_registration_by_title(
+            'Selenium Registration for Metadata tests'
+        )
+        return registration_guid
 
+    def test_edit_metadata_title_and_description(
+        self, driver, registration_metadata_page, fake, registration_guid
+    ):
+        """This test verifies that the registration metadata title
+        and description fields are editable and changes are saved."""
+
+        new_title = fake.sentence(nb_words=2)
         new_description = fake.sentence(nb_words=4)
+        original_title = 'Selenium Registration for Metadata tests'
+
+        WebDriverWait(driver, 5).until(
+            EC.element_to_be_clickable(
+                (By.CSS_SELECTOR, '[data-test-edit-node-title-button]')
+            )
+        ).click()
+        title_input = driver.find_element_by_css_selector(
+            '[data-test-title-field] textarea'
+        )
+        title_input.clear()
+        title_input.send_keys(new_title)
+        registration_metadata_page.save_metadata_title_button.click()
+        assert new_title == utils.clean_text(
+            registration_metadata_page.metadata_title.text
+        )
 
         WebDriverWait(driver, 5).until(
             EC.element_to_be_clickable(
@@ -511,7 +537,64 @@ class TestRegistrationMetadata:
         description_input.clear()
         description_input.send_keys(new_description)
         registration_metadata_page.save_metadata_description_button.click()
-        assert new_description == registration_metadata_page.metadata_description.text
+        assert new_description == utils.clean_text(
+            registration_metadata_page.metadata_description.text
+        )
+        osf_api.update_registration_title(
+            registration_guid=registration_guid, title=original_title
+        )
+
+    def test_edit_contributors(
+        self, session, driver, registration_metadata_page, registration_guid
+    ):
+        """This test verifies that user can add/remove
+        contributors to registration metadata."""
+
+        if settings.DOMAIN == 'test':
+            new_user = 'Selenium Test User (Do Not Use)'
+        elif settings.DOMAIN == 'prod':
+            new_user = 'OSF Tester1'
+        else:
+            new_user = 'Selenium Staging'
+
+        # Delete the user if its already exists
+        osf_api.delete_registration_contributor(
+            registration_guid=registration_guid, user_name=new_user
+        )
+        registration_metadata_page.goto_with_reload()
+
+        WebDriverWait(driver, 5).until(
+            EC.element_to_be_clickable(
+                (By.CSS_SELECTOR, '[data-test-edit-node-contributors-button]')
+            )
+        ).click()
+
+        registration_metadata_page.search_input.click()
+        registration_metadata_page.search_input.send_keys(new_user)
+        registration_metadata_page.contributor_search_button.click()
+
+        # Get the row number for the user from the search table
+        WebDriverWait(driver, 5).until(
+            EC.visibility_of_element_located(
+                (
+                    By.CSS_SELECTOR,
+                    '[data-test-user-card]',
+                )
+            )
+        )
+
+        registration_metadata_page.select_from_table_of_rows(new_user)
+        registration_metadata_page.search_cancel_button.click()
+        registration_metadata_page.add_contributor_finish_button.click()
+
+        WebDriverWait(driver, 5).until(
+            EC.visibility_of_element_located(
+                (By.CSS_SELECTOR, '[data-test-contributors-list]')
+            )
+        )
+
+        user = registration_metadata_page.select_from_list(new_user)
+        assert new_user in user.text.strip()
 
     def test_edit_resource_information(self, driver, registration_metadata_page):
         """This test verifies that user can add/remove

--- a/utils.py
+++ b/utils.py
@@ -261,3 +261,10 @@ def read_data_from_table(driver, table_path, check_match, item_match=None):
                     return i, datalist
 
     return rlen, datalist
+
+
+def clean_text(stringvalue):
+    clean_text = stringvalue.strip()
+    clean_text = clean_text.replace('\n', ' ')
+    clean_text = ' '.join(clean_text.split())
+    return clean_text


### PR DESCRIPTION
<!-- Before you submit your Pull Request, please confirm that:

     - Any test that will create public data either has the `QAtest` tag or the `dont_run_on_production` marker
     - `core_functionality` is marked as such
     - Your tests will be able to run on *all* servers (all stagings, test)
 -->


## Purpose
Updated the selenium test suite to add new tests to registration metadata tests to include edit title and edit contributors tests.


## Summary of Changes
Updated test_metadata.py to add edit title and edit contributors tests to RegistrationMetadata.
Updated registries.py page to include new methods for selecting item from table and selecting item from a list
Updated osf_api.py to include 2 new methods to update registration title and delete registration contributor
Updated utils.py to include new method to clean text


## Reviewer's Actions
`git fetch <remote> pull/282/head:feature/registration_metadata_fix`

Run this test using
`pytest tests/metadata.py::TestRegistrationMetadata -s -v`

## Testing Changes Moving Forward



## Ticket

https://openscience.atlassian.net/browse/ENG-7681
https://openscience.atlassian.net/browse/ENG-7682
