### PR TITLE
Update test_withdraw_preprint

### DIFF
--- a/api/osf_api.py
+++ b/api/osf_api.py
@@ -46,7 +46,7 @@ def create_child_node(
     node_id=None,
     title='osf selenium child node',
     tags=None,
-    **kwargs
+    **kwargs,
 ):
     """Create a child node (a.k.a. component) of a given project node."""
     if tags is None:
@@ -853,6 +853,43 @@ def accept_moderated_preprint(session=None, preprint_node=None):
             },
             'relationships': {
                 'target': {'data': {'id': preprint_node, 'type': 'preprints'}}
+            },
+        }
+    }
+    session.post(
+        url=review_url,
+        item_type='review-actions',
+        raw_body=json.dumps(review_payload),
+    )
+
+
+def get_preprint_id(session=None, preprint_node=None):
+    """Get priprint's id"""
+    if not session:
+        session = get_default_session()
+    request_url = f'/v2/preprints/{preprint_node}/requests/'
+
+    response = session.get(url=request_url)
+    preprint_id = ''
+    for item in response.get('data', []):
+        preprint_id = item.get('id')
+    return preprint_id
+
+
+def accept_withdraw_preprint(session=None, preprint_id=None):
+    """Accept a withdrawal request for a given preprint request ID."""
+    if not session:
+        session = get_default_session()
+    review_url = '/v2/actions/requests/preprints/'
+    review_payload = {
+        'data': {
+            'type': 'preprint-request-actions',
+            'attributes': {
+                'trigger': 'accept',
+                'comment': 'Preprint Withdraw Approval via OSF api',
+            },
+            'relationships': {
+                'target': {'data': {'id': preprint_id, 'type': 'preprint-requests'}}
             },
         }
     }

--- a/pages/preprints.py
+++ b/pages/preprints.py
@@ -225,7 +225,10 @@ class PreprintWithdrawPage(GuidBasePage, BasePreprintPage):
         By.CSS_SELECTOR, '[data-test-comment-input] textarea'
     )
     request_withdrawal_button = Locator(
-        By.XPATH, '//div[@class="_Footer_gyio2l"]/button[text()="Withdraw"]'
+        By.CSS_SELECTOR, '[data-test-confirm-withdraw-button]'
+    )
+    withdrawn_banner = Locator(
+        By.XPATH, "//span[normalize-space(text())='This preprint has been withdrawn.']"
     )
 
 
@@ -280,6 +283,7 @@ class PreprintDetailPage(GuidBasePage, BasePreprintPage):
     downloads_count = Locator(By.CSS_SELECTOR, '[data-test-download-count]')
     download_button = Locator(By.CSS_SELECTOR, '[data-test-download-button]')
     edit_preprint_button = Locator(By.CSS_SELECTOR, '[data-test-edit-preprint-button]')
+    withdraw_preprint_button = Locator(By.CSS_SELECTOR, '[data-test-withdrawal-button]')
     default_citation = Locator(By.CSS_SELECTOR, '[data-test-default-citation="apa"]')
 
     # Locators for the reviews app preprint detail page
@@ -303,13 +307,15 @@ class PreprintDetailPage(GuidBasePage, BasePreprintPage):
 class PendingPreprintDetailPage(PreprintDetailPage):
     # This class is for preprints that are pending moderation
     identity = Locator(
-        By.ID,
-        'preprintTitle',
+        By.CSS_SELECTOR,
+        '[data-test-preprint-title]',
         settings.LONG_TIMEOUT,
     )
     # This locator needs a data-test-selector from software devs
-    # title = Locator(By.CSS_SELECTOR, '[data-test-preprint-title]', settings.LONG_TIMEOUT)
-    title = Locator(By.ID, 'preprintTitle', settings.LONG_TIMEOUT)
+    title = Locator(
+        By.CSS_SELECTOR, '[data-test-preprint-title]', settings.LONG_TIMEOUT
+    )
+    # title = Locator(By.ID, 'preprintTitle', settings.LONG_TIMEOUT)
 
 
 class ReviewsDashboardPage(OSFBasePage):

--- a/pages/preprints.py
+++ b/pages/preprints.py
@@ -307,8 +307,8 @@ class PreprintDetailPage(GuidBasePage, BasePreprintPage):
 class PendingPreprintDetailPage(PreprintDetailPage):
     # This class is for preprints that are pending moderation
     identity = Locator(
-        By.CSS_SELECTOR,
-        '[data-test-preprint-title]',
+        By.ID,
+        'preprintTitle',
         settings.LONG_TIMEOUT,
     )
     # This locator needs a data-test-selector from software devs

--- a/tests/test_preprints.py
+++ b/tests/test_preprints.py
@@ -369,11 +369,9 @@ class TestPreprintWorkflow:
         preprint_detail_page.goto()
         WebDriverWait(driver, 5).until(EC.visibility_of(withdraw_page.withdrawn_banner))
         # Should be redirected back to Preprint Detail page
-        assert PendingPreprintDetailPage(driver, verify=True)
+        assert PreprintDetailPage(driver, verify=True)
         # Verify that "This preprint has been withdrawn." banner is displayed on Preprint Detail page.
-        assert (
-            withdraw_page.withdrawn_banner.text == 'This preprint has been withdrawn.'
-        )
+        assert withdraw_page.withdrawn_banner.is_displayed()
         # Verify via the api that the Withdrawal Request record was created
         requests = osf_api.get_preprint_requests_records(
             node_id=preprint_detail_page.guid

--- a/tests/test_preprints.py
+++ b/tests/test_preprints.py
@@ -328,7 +328,7 @@ class TestPreprintWorkflow:
         assert tag_found
 
     @markers.dont_run_on_prod
-    @pytest.mark.xfail(reason='https://openscience.atlassian.net/browse/ENG-6065')
+    # @pytest.mark.xfail(reason='https://openscience.atlassian.net/browse/ENG-6065')
     def test_withdraw_preprint(self, session, driver, preprint_detail_page):
         """Test the Withdraw Preprint functionality. Using the preprint_detail_page
         fixture we start on the Preprint Detail page for an api created preprint. Then
@@ -341,7 +341,6 @@ class TestPreprintWorkflow:
         that the withdrawal request record is created.
         """
         assert PreprintDetailPage(driver, verify=True)
-        preprint_detail_page.edit_preprint_button.click()
         edit_page = PreprintEditPage(driver)
         WebDriverWait(driver, 5).until(
             EC.element_to_be_clickable(
@@ -363,8 +362,13 @@ class TestPreprintWorkflow:
         )
         assert withdraw_page.request_withdrawal_button.is_enabled()
         withdraw_page.request_withdrawal_button.click()
+        WebDriverWait(driver, 5).until(EC.visibility_of(withdraw_page.withdrawn_banner))
         # Should be redirected back to Preprint Detail page
         assert PendingPreprintDetailPage(driver, verify=True)
+        # Verify that "This preprint has been withdrawn." banner is displayed on Preprint Detail page.
+        assert (
+            withdraw_page.withdrawn_banner.text == 'This preprint has been withdrawn.'
+        )
         # Verify via the api that the Withdrawal Request record was created
         requests = osf_api.get_preprint_requests_records(
             node_id=preprint_detail_page.guid
@@ -374,7 +378,7 @@ class TestPreprintWorkflow:
             record_found = False
             for request in requests:
                 if request['attributes']['request_type'] == 'withdrawal':
-                    assert request['attributes']['machine_state'] == 'pending'
+                    assert request['attributes']['machine_state'] == 'accepted'
                     record_found = True
                     break
             if not record_found:

--- a/tests/test_preprints.py
+++ b/tests/test_preprints.py
@@ -328,7 +328,6 @@ class TestPreprintWorkflow:
         assert tag_found
 
     @markers.dont_run_on_prod
-    # @pytest.mark.xfail(reason='https://openscience.atlassian.net/browse/ENG-6065')
     def test_withdraw_preprint(self, session, driver, preprint_detail_page):
         """Test the Withdraw Preprint functionality. Using the preprint_detail_page
         fixture we start on the Preprint Detail page for an api created preprint. Then
@@ -340,8 +339,11 @@ class TestPreprintWorkflow:
         user in the OSF admin app. The best we can do here is to verify through the api
         that the withdrawal request record is created.
         """
-        assert PreprintDetailPage(driver, verify=True)
         edit_page = PreprintEditPage(driver)
+        assert PreprintDetailPage(driver, verify=True)
+        preprint_node = preprint_detail_page.url[len(settings.OSF_HOME) + 1 :]
+        osf_api.accept_moderated_preprint(session=None, preprint_node=preprint_node)
+        preprint_detail_page.goto()
         WebDriverWait(driver, 5).until(
             EC.element_to_be_clickable(
                 (By.CSS_SELECTOR, '[data-test-withdrawal-button]')
@@ -362,6 +364,9 @@ class TestPreprintWorkflow:
         )
         assert withdraw_page.request_withdrawal_button.is_enabled()
         withdraw_page.request_withdrawal_button.click()
+        preprint_id = osf_api.get_preprint_id(session=None, preprint_node=preprint_node)
+        osf_api.accept_withdraw_preprint(session=None, preprint_id=preprint_id)
+        preprint_detail_page.goto()
         WebDriverWait(driver, 5).until(EC.visibility_of(withdraw_page.withdrawn_banner))
         # Should be redirected back to Preprint Detail page
         assert PendingPreprintDetailPage(driver, verify=True)


### PR DESCRIPTION
<!-- Before you submit your Pull Request, please confirm that:

     - Any test that will create public data either has the `QAtest` tag or the `dont_run_on_production` marker
     - `core_functionality` is marked as such
     - Your tests will be able to run on *all* servers (all stagings, test)
 -->


## Purpose
Update test_withdraw_preprint

## Summary of Changes
 - Added new assertion of banner on on Preprint Detail page in test_withdraw_preprint().
 - Updated test steps in test_withdraw_preprint(), 
 - Added new objects in the PreprintWithdrawPage class

## Reviewer's Actions
git fetch origin pull/283/head:pshtohryn/ENG-6724/update/test_withdraw_preprint

Run this test using
`pytest tests/test_preprints.py::TestPreprintWorkflow::test_withdraw_preprint -sv`

## Ticket

https://openscience.atlassian.net/browse/ENG-6724
