### PR TITLE
Add assertions for OSFI affiliations on preprint rewiev and detail pages

### DIFF
--- a/pages/preprints.py
+++ b/pages/preprints.py
@@ -100,6 +100,10 @@ class PreprintSubmitPage(BasePreprintPage):
         By.CSS_SELECTOR,
         '#ember-basic-dropdown-wormhole > div > ul >li.ember-power-select-option',
     )
+    affiliated_institutions = GroupLocator(By.CSS_SELECTOR, '[data-test-institution]')
+
+    def get_affiliated_institutions(self) -> list:
+        return [el.text for el in self.affiliated_institutions]
 
     def select_from_dropdown_listbox(self, selection):
         for option in self.dropdown_options:
@@ -180,12 +184,27 @@ class PreprintSubmitPage(BasePreprintPage):
         By.CSS_SELECTOR, '[data-test-create-project-submit]'
     )
 
+    # Review Page
+    preprint_institution_list_review = GroupLocator(
+        By.CSS_SELECTOR, 'img[data-test-preprint-institution-list]'
+    )
     create_preprint_button = Locator(By.CSS_SELECTOR, '[data-test-submit-button]')
     modal_create_preprint_button = Locator(
         By.CSS_SELECTOR,
         '.modal-footer button.btn-success:nth-child(2)',
         settings.LONG_TIMEOUT,
     )
+
+    def get_preprint_institution_list_review(self) -> list:
+        return [el.get_attribute('alt') for el in self.preprint_institution_list_review]
+
+    # Preprint Detail Page
+    preprint_institution_list_detail = GroupLocator(
+        By.CSS_SELECTOR, 'img[data-test-preprint-institution-list]'
+    )
+
+    def get_preprint_institution_list_detail(self) -> list:
+        return [el.get_attribute('alt') for el in self.preprint_institution_list_detail]
 
 
 class PreprintEditPage(PreprintSubmitPage):

--- a/pages/preprints.py
+++ b/pages/preprints.py
@@ -1,6 +1,7 @@
 from urllib.parse import urljoin
 
 import pytest
+import selenium.webdriver.support.expected_conditions as EC
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support.wait import WebDriverWait
 
@@ -101,9 +102,22 @@ class PreprintSubmitPage(BasePreprintPage):
         '#ember-basic-dropdown-wormhole > div > ul >li.ember-power-select-option',
     )
     affiliated_institutions = GroupLocator(By.CSS_SELECTOR, '[data-test-institution]')
+    affiliated_institutions_input_lst = GroupLocator(
+        By.CSS_SELECTOR, '[data-test-institution-input]'
+    )
 
     def get_affiliated_institutions(self) -> list:
         return [el.text for el in self.affiliated_institutions]
+
+    def select_all_affiliated_institutions(self):
+        wait = WebDriverWait(self.driver, 5)
+        wait.until(
+            EC.element_to_be_clickable(
+                (By.CSS_SELECTOR, '[data-test-institution-input]')
+            )
+        )
+        for subject in self.affiliated_institutions_input_lst:
+            subject.click()
 
     def select_from_dropdown_listbox(self, selection):
         for option in self.dropdown_options:

--- a/pages/preprints.py
+++ b/pages/preprints.py
@@ -212,6 +212,13 @@ class PreprintSubmitPage(BasePreprintPage):
     def get_preprint_institution_list_review(self) -> list:
         return [el.get_attribute('alt') for el in self.preprint_institution_list_review]
 
+    def assert_affiliated_institutions_equal(self, expected, actual, page_name):
+        assert expected == actual, (
+            f'Affiliated institutions on the {page_name} do not match expected values.\n'
+            f'Expected: {expected}\n'
+            f'Actual: {actual}'
+        )
+
     # Preprint Detail Page
     preprint_institution_list_detail = GroupLocator(
         By.CSS_SELECTOR, 'img[data-test-preprint-institution-list]'

--- a/tests/test_preprints.py
+++ b/tests/test_preprints.py
@@ -312,6 +312,9 @@ class TestPreprintWorkflow:
         WebDriverWait(driver, 5).until(
             EC.visibility_of_element_located((By.CSS_SELECTOR, '[data-test-title]'))
         )
+        affiliated_institutions_names_metadata_page = (
+            edit_page.get_affiliated_institutions()
+        )
         edit_page.select_top_level_subject('Business')
         # Add another Tag and click the Save and continue button
         edit_page.basics_tags_input.send_keys(os.environ['PYTEST_CURRENT_TEST'])
@@ -345,6 +348,17 @@ class TestPreprintWorkflow:
         # Verify Title and Abstract
         assert detail_page.title.text == 'Selenium Preprint Edit'
         assert detail_page.abstract.text == 'Testing Selenium Abstract edit'
+        affiliated_institutions_names_detail_page = (
+            edit_page.get_preprint_institution_list_detail()
+        )
+        assert (
+            affiliated_institutions_names_metadata_page
+            == affiliated_institutions_names_detail_page
+        ), (
+            f'Affiliated institutions on the Preprint Detail Page do not match expected values.\n'
+            f'Expected: {affiliated_institutions_names_metadata_page}\n'
+            f'Actual: {affiliated_institutions_names_detail_page}'
+        )
         # Verify new Subject appears on the page
         subjects = detail_page.subjects
         subject_found = False

--- a/tests/test_preprints.py
+++ b/tests/test_preprints.py
@@ -211,13 +211,10 @@ class TestPreprintWorkflow:
             affiliated_institutions_names_review_page = (
                 submit_page.get_preprint_institution_list_review()
             )
-            assert (
-                affiliated_institutions_names_metadata_page
-                == affiliated_institutions_names_review_page
-            ), (
-                f'Affiliated institutions on the Review Page do not match expected values.\n'
-                f'Expected: {affiliated_institutions_names_metadata_page }\n'
-                f'Actual: {affiliated_institutions_names_review_page}'
+            submit_page.assert_affiliated_institutions_equal(
+                affiliated_institutions_names_metadata_page,
+                affiliated_institutions_names_review_page,
+                'Preprint Review Page',
             )
             submit_page.info_toast.here_then_gone()
             submit_page.create_preprint_button.click()
@@ -227,13 +224,10 @@ class TestPreprintWorkflow:
             affiliated_institutions_names_detail_page = (
                 submit_page.get_preprint_institution_list_detail()
             )
-            assert (
-                affiliated_institutions_names_metadata_page
-                == affiliated_institutions_names_detail_page
-            ), (
-                f'Affiliated institutions on the Preprint Detail Page do not match expected values.\n'
-                f'Expected: {affiliated_institutions_names_metadata_page }\n'
-                f'Actual: {affiliated_institutions_names_detail_page}'
+            submit_page.assert_affiliated_institutions_equal(
+                affiliated_institutions_names_metadata_page,
+                affiliated_institutions_names_detail_page,
+                'Preprint Detail Page',
             )
             # Capture guid of supplemental materials project created during workflow
             supplemental_url = preprint_detail.view_page.get_attribute('href')

--- a/tests/test_preprints.py
+++ b/tests/test_preprints.py
@@ -312,6 +312,7 @@ class TestPreprintWorkflow:
         WebDriverWait(driver, 5).until(
             EC.visibility_of_element_located((By.CSS_SELECTOR, '[data-test-title]'))
         )
+        edit_page.select_all_affiliated_institutions()
         affiliated_institutions_names_metadata_page = (
             edit_page.get_affiliated_institutions()
         )

--- a/tests/test_preprints.py
+++ b/tests/test_preprints.py
@@ -346,13 +346,10 @@ class TestPreprintWorkflow:
         affiliated_institutions_names_detail_page = (
             edit_page.get_preprint_institution_list_detail()
         )
-        assert (
-            affiliated_institutions_names_metadata_page
-            == affiliated_institutions_names_detail_page
-        ), (
-            f'Affiliated institutions on the Preprint Detail Page do not match expected values.\n'
-            f'Expected: {affiliated_institutions_names_metadata_page}\n'
-            f'Actual: {affiliated_institutions_names_detail_page}'
+        edit_page.assert_affiliated_institutions_equal(
+            affiliated_institutions_names_metadata_page,
+            affiliated_institutions_names_detail_page,
+            'Preprint Detail Page',
         )
         # Verify new Subject appears on the page
         subjects = detail_page.subjects

--- a/tests/test_preprints.py
+++ b/tests/test_preprints.py
@@ -100,6 +100,14 @@ class TestPreprintWorkflow:
 
             # Metadata page
             WebDriverWait(driver, 5).until(
+                EC.visibility_of_element_located(
+                    (By.CSS_SELECTOR, '[data-test-institution]')
+                )
+            )
+            affiliated_institutions_names_metadata_page = (
+                submit_page.get_affiliated_institutions()
+            )
+            WebDriverWait(driver, 5).until(
                 EC.element_to_be_clickable(
                     (By.CSS_SELECTOR, '[data-test-power-select-dropdown]')
                 )
@@ -195,11 +203,38 @@ class TestPreprintWorkflow:
             submit_page.supplemental_project_create_button.click()
             submit_page.info_toast.here_then_gone()
             submit_page.next_button.click()
+            WebDriverWait(driver, 5).until(
+                EC.visibility_of_element_located(
+                    (By.CSS_SELECTOR, 'img[data-test-preprint-institution-list]')
+                )
+            )
+            affiliated_institutions_names_review_page = (
+                submit_page.get_preprint_institution_list_review()
+            )
+            assert (
+                affiliated_institutions_names_metadata_page
+                == affiliated_institutions_names_review_page
+            ), (
+                f'Affiliated institutions on the Review Page do not match expected values.\n'
+                f'Expected: {affiliated_institutions_names_metadata_page }\n'
+                f'Actual: {affiliated_institutions_names_review_page}'
+            )
             submit_page.info_toast.here_then_gone()
             submit_page.create_preprint_button.click()
             preprint_detail = PreprintDetailPage(driver, verify=True)
             WebDriverWait(driver, 10).until(EC.visibility_of(preprint_detail.title))
             assert preprint_detail.title.text == 'Selenium Test Preprint'
+            affiliated_institutions_names_detail_page = (
+                submit_page.get_preprint_institution_list_detail()
+            )
+            assert (
+                affiliated_institutions_names_metadata_page
+                == affiliated_institutions_names_detail_page
+            ), (
+                f'Affiliated institutions on the Preprint Detail Page do not match expected values.\n'
+                f'Expected: {affiliated_institutions_names_metadata_page }\n'
+                f'Actual: {affiliated_institutions_names_detail_page}'
+            )
             # Capture guid of supplemental materials project created during workflow
             supplemental_url = preprint_detail.view_page.get_attribute('href')
             supplemental_guid = utils.get_guid_from_url(supplemental_url, 3)


### PR DESCRIPTION
<!-- Before you submit your Pull Request, please confirm that:

     - Any test that will create public data either has the `QAtest` tag or the `dont_run_on_production` marker
     - `core_functionality` is marked as such
     - Your tests will be able to run on *all* servers (all stagings, test)
 -->


## Purpose

Add assertions for OSFI affiliations to the following pages:

Preprint Review Page

Preprint Detail Page

## Summary of Changes

Updated :
- test_create_preprint_from_landing.py and test_edit_preprint with new assertions
- added new locators and methods in preprint.py

## Reviewer's Actions
`git fetch origin pull/284/head:pshtohryn/ENG-6198/feature/osfi-affiliations-assertions`

Run this test using
`pytest tests/test_preprints.py::TestPreprintWorkflow::test_create_preprint_from_landing -sv`
`pytest tests/test_preprints.py::TestPreprintWorkflow::test_edit_preprint -sv`

## Testing Changes Moving Forward



## Ticket

https://openscience.atlassian.net/browse/ENG-6198
https://openscience.atlassian.net/browse/ENG-6723