### PR TITLE
ENG-8267 fix test_change_title

### DIFF
--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -51,7 +51,22 @@ class TestProjectDetailPage:
         # to provide a little extra time.  We can do this by waiting on the log widget to load.
         project_page.log_widget.loading_indicator.here_then_gone()
         project_page.title.click()
+        WebDriverWait(driver, 10).until(
+            EC.presence_of_element_located(
+                (By.CSS_SELECTOR, '.overflow.editable.editable-click')
+            )
+        )
+        # overflow editable editable-click
+        project_page.title_editable.click()
+        WebDriverWait(driver, 10).until(
+            EC.presence_of_element_located((By.CSS_SELECTOR, '.form-inline input'))
+        )
         project_page.title_input.clear()
+        WebDriverWait(driver, 10).until(
+            EC.text_to_be_present_in_element(
+                (By.CSS_SELECTOR, '.form-inline input'), ''
+            )
+        )
         project_page.title_input.send_keys(new_title)
         project_page.title_edit_submit_button.click()
         project_page.verify()  # Wait for the page to reload


### PR DESCRIPTION
<!-- Before you submit your Pull Request, please confirm that:

     - Any test that will create public data either has the `QAtest` tag or the `dont_run_on_production` marker
     - `core_functionality` is marked as such
     - Your tests will be able to run on *all* servers (all stagings, test)
 -->


## Purpose
Update flaky test - Project title


## Summary of Changes
Stabilized  `test_change_title` by adding explicit wait and an additional click to trigger the overflow editable element on the Project page.


## Reviewer's Actions
`git fetch <remote> pull/288/head:pshtohryn/ENG-8267/fix/test_change_title`

Run this test using
`pytest tests/test_project.py::TestProjectDetailPage::test_change_title -sv `

## Testing Changes Moving Forward



## Ticket

https://openscience.atlassian.net/browse/ENG-8267
